### PR TITLE
fix: update middleware to use @supabase/ssr v0.8.0 cookie API

### DIFF
--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -1,11 +1,9 @@
-import { createServerClient, type CookieOptions } from "@supabase/ssr"
+import { createServerClient } from "@supabase/ssr"
 import { type NextRequest, NextResponse } from "next/server"
 
 export async function updateSession(request: NextRequest) {
-  let response = NextResponse.next({
-    request: {
-      headers: request.headers,
-    },
+  let supabaseResponse = NextResponse.next({
+    request,
   })
 
   const supabase = createServerClient(
@@ -13,28 +11,27 @@ export async function updateSession(request: NextRequest) {
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get(name: string) {
-          return request.cookies.get(name)?.value
+        getAll() {
+          return request.cookies.getAll()
         },
-        set(name: string, value: string, options: CookieOptions) {
-          request.cookies.set({ name, value, ...options })
-          response = NextResponse.next({
-            request: { headers: request.headers },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value)
+          )
+          supabaseResponse = NextResponse.next({
+            request,
           })
-          response.cookies.set({ name, value, ...options })
-        },
-        remove(name: string, options: CookieOptions) {
-          request.cookies.set({ name, value: "", ...options })
-          response = NextResponse.next({
-            request: { headers: request.headers },
-          })
-          response.cookies.set({ name, value: "", ...options })
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          )
         },
       },
     }
   )
 
-  await supabase.auth.getUser()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
 
-  return response
+  return { response: supabaseResponse, user }
 }

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,37 +1,21 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { updateSession } from "@/lib/supabase/middleware"
-import { createServerClient } from "@supabase/ssr"
 
 const PUBLIC_ROUTES = ["/login", "/register", "/api/auth"]
 
 export async function middleware(request: NextRequest) {
-  // Update session (refresh token if needed)
-  const response = await updateSession(request)
   const pathname = request.nextUrl.pathname
 
   // Allow public routes
   if (PUBLIC_ROUTES.some((route) => pathname.startsWith(route))) {
+    const { response } = await updateSession(request)
     return response
   }
 
-  // Check auth for protected routes
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) {
-          return request.cookies.get(name)?.value
-        },
-        set() {},
-        remove() {},
-      },
-    }
-  )
+  // Update session and get user in a single call
+  const { response, user } = await updateSession(request)
 
-  const { data: { user } } = await supabase.auth.getUser()
-
-  if (!user && pathname !== "/login" && pathname !== "/register") {
+  if (!user) {
     const loginUrl = new URL("/login", request.url)
     loginUrl.searchParams.set("redirect", pathname)
     return NextResponse.redirect(loginUrl)


### PR DESCRIPTION
Replace deprecated get/set/remove cookie methods with getAll/setAll as required by @supabase/ssr 0.5.0+. Also eliminates the redundant second Supabase client and double getUser() call in middleware.ts by returning the user directly from updateSession().

Resolves MIDDLEWARE_INVOCATION_FAILED 500 error on Vercel.

https://claude.ai/code/session_01SwT3xwK5Rvsw3w3SyAEW9V