### PR TITLE
fix: prevent middleware 500 and add missing auth callback route

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server"
+import type { User } from "@supabase/supabase-js"
 import { updateSession } from "@/lib/supabase/middleware"
 
 const PUBLIC_ROUTES = ["/login", "/register", "/api/auth", "/auth/callback"]
@@ -18,7 +19,7 @@ export async function middleware(request: NextRequest) {
 
   // Update session and get user in a single call
   let response: NextResponse
-  let user: Awaited<ReturnType<typeof updateSession>>["user"]
+  let user: User | null = null
 
   try {
     const result = await updateSession(request)
@@ -27,6 +28,8 @@ export async function middleware(request: NextRequest) {
   } catch {
     // If Supabase is unreachable or misconfigured, fail open to login
     const loginUrl = new URL("/login", request.url)
+    const dest = request.nextUrl.searchParams.get("redirect") || request.nextUrl.pathname
+    loginUrl.searchParams.set("redirect", dest)
     return NextResponse.redirect(loginUrl)
   }
 


### PR DESCRIPTION
- Wrap middleware Supabase calls in try-catch so a misconfigured or unreachable Supabase instance redirects to /login instead of returning a 500 on every route
- Add /auth/callback to PUBLIC_ROUTES so the route can run before a session exists (required for code-exchange flow)
- Create app/auth/callback/route.ts to handle the Supabase PKCE code exchange; without this route magic-link and OAuth logins silently fail

https://claude.ai/code/session_01SwT3xwK5Rvsw3w3SyAEW9V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication callback handling to support the authorization flow.
  * Enhanced error handling for authentication failures with improved fallback behavior to login page.
  * Refined session management with more robust protection for authenticated routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->