### PR TITLE
Fix misleading "Welcome back!" message shown after signup

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { createClientSupabaseClient } from "@/lib/supabase/client"
 import { Button } from "@/components/ui/button"
@@ -12,6 +12,8 @@ import { Loader2, Zap } from "lucide-react"
 
 export default function LoginPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const isNewUser = searchParams.get("registered") === "true"
   const { toast } = useToast()
   const [loading, setLoading] = useState(false)
   const [magicLinkLoading, setMagicLinkLoading] = useState(false)
@@ -76,9 +78,13 @@ export default function LoginPage() {
             <Zap className="w-7 h-7 text-white" />
           </div>
         </div>
-        <h1 className="text-2xl font-bold text-white">Welcome back!</h1>
+        <h1 className="text-2xl font-bold text-white">
+          {isNewUser ? "Verify your email" : "Welcome back!"}
+        </h1>
         <p style={{ color: '#b5bac1' }} className="text-sm mt-1">
-          We&apos;re so excited to see you again!
+          {isNewUser
+            ? "Check your inbox for a verification link, then log in below."
+            : "We\u2019re so excited to see you again!"}
         </p>
       </div>
 

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -65,7 +65,7 @@ export default function RegisterPage() {
         title: "Account created!",
         description: "Check your email to verify your account, then log in.",
       })
-      router.push("/login")
+      router.push("/login?registered=true")
     } catch (error: any) {
       toast({
         variant: "destructive",


### PR DESCRIPTION
After creating an account, users were redirected to /login which displayed "Welcome back!" — a confusing greeting for a brand-new user.

Now the register page passes ?registered=true when redirecting to login. The login page detects this param and instead shows "Verify your email" with instructions to check their inbox before logging in.

https://claude.ai/code/session_01F5ouscJgHwt3o5BhpwD4fB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login page now displays tailored messages based on user status: newly registered users receive a verification prompt upon their first login, while returning users see the standard welcome message, providing clearer guidance during the onboarding experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->