### PR TITLE
Add server template import/export APIs, DB RPCs, and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,21 @@ STREAM            = 1 << 11  // 2048
 
 Administrator overrides all other permissions. No paywall — all features free.
 
+
+## Server Templates
+
+Vortex supports reusable **server templates** for import/export:
+
+- Template schema includes `metadata`, `roles`, `categories`, `channels`, and channel-level permission overrides.
+- Metadata supports `source`, `version`, and `created_by`.
+- Built-in starter templates are available in the UI: **Gaming**, **Study**, **Startup**, and **Creator**.
+- Import flow validates JSON, shows a diff preview, and applies transactionally (via `create_server_from_template`/`apply_server_template`).
+- Unsupported permission names/fields are normalized or ignored with warnings so imports degrade gracefully.
+- Export flow serializes the current server into a reusable template JSON document.
+
+API entrypoint: `POST /api/server-templates` with modes:
+`validate`, `preview`, `apply`, `create-server`, and `export`.
+
 ## License
 
 MIT

--- a/apps/web/app/api/server-templates/route.ts
+++ b/apps/web/app/api/server-templates/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { STARTER_TEMPLATES, validateAndNormalizeTemplate, type ServerTemplate } from "@/lib/server-templates"
+
+function diffSummary(current: { roleCount: number; categoryCount: number; channelCount: number }, template: ServerTemplate) {
+  return {
+    roles: { current: current.roleCount, incoming: template.roles.length, delta: template.roles.length - current.roleCount },
+    categories: { current: current.categoryCount, incoming: template.categories.length, delta: template.categories.length - current.categoryCount },
+    channels: { current: current.channelCount, incoming: template.channels.length, delta: template.channels.length - current.channelCount },
+  }
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const mode = url.searchParams.get("mode")
+  if (mode === "starter") {
+    return NextResponse.json({ templates: STARTER_TEMPLATES })
+  }
+  return NextResponse.json({ error: "Invalid mode" }, { status: 400 })
+}
+
+export async function POST(request: Request) {
+  const supabase = await createServerSupabaseClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  let body: any
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const mode = body?.mode as string | undefined
+  const result = validateAndNormalizeTemplate(body?.template)
+  if (mode !== "export" && result.errors.length > 0) {
+    return NextResponse.json({ errors: result.errors, warnings: result.warnings }, { status: 400 })
+  }
+
+  if (mode === "validate") {
+    return NextResponse.json({ template: result.template, warnings: result.warnings })
+  }
+
+  if (mode === "preview") {
+    const serverId = String(body?.serverId ?? "")
+    if (!serverId) return NextResponse.json({ error: "serverId is required" }, { status: 400 })
+    const [{ count: roleCount }, { count: channelCount }, { count: categoryCount }] = await Promise.all([
+      supabase.from("roles").select("id", { count: "exact", head: true }).eq("server_id", serverId),
+      supabase.from("channels").select("id", { count: "exact", head: true }).eq("server_id", serverId).neq("type", "category"),
+      supabase.from("channels").select("id", { count: "exact", head: true }).eq("server_id", serverId).eq("type", "category"),
+    ])
+
+    return NextResponse.json({
+      warnings: result.warnings,
+      diff: diffSummary(
+        { roleCount: roleCount ?? 0, categoryCount: categoryCount ?? 0, channelCount: channelCount ?? 0 },
+        result.template!,
+      ),
+    })
+  }
+
+  if (mode === "apply") {
+    const serverId = String(body?.serverId ?? "")
+    if (!serverId) return NextResponse.json({ error: "serverId is required" }, { status: 400 })
+
+    const { data, error } = await supabase.rpc("apply_server_template", {
+      p_server_id: serverId,
+      p_template: result.template as unknown as never,
+    })
+    if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+    return NextResponse.json({ ok: true, result: data, warnings: result.warnings })
+  }
+
+  if (mode === "create-server") {
+    const name = String(body?.name ?? "").trim()
+    if (!name) return NextResponse.json({ error: "name is required" }, { status: 400 })
+
+    const { data, error } = await supabase.rpc("create_server_from_template", {
+      p_name: name,
+      p_description: String(body?.description ?? ""),
+      p_icon_url: String(body?.iconUrl ?? ""),
+      p_template: result.template as unknown as never,
+    })
+    if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+    return NextResponse.json({ server: data, warnings: result.warnings }, { status: 201 })
+  }
+
+  if (mode === "export") {
+    const serverId = String(body?.serverId ?? "")
+    if (!serverId) return NextResponse.json({ error: "serverId is required" }, { status: 400 })
+
+    const { data, error } = await supabase.rpc("export_server_template", { p_server_id: serverId })
+    if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+    return NextResponse.json({ template: data })
+  }
+
+  return NextResponse.json({ error: "Invalid mode" }, { status: 400 })
+}

--- a/apps/web/components/modals/create-server-modal.tsx
+++ b/apps/web/components/modals/create-server-modal.tsx
@@ -11,6 +11,7 @@ import { useToast } from "@/components/ui/use-toast"
 import { createClientSupabaseClient } from "@/lib/supabase/client"
 import { useAppStore } from "@/lib/stores/app-store"
 import type { ServerRow } from "@/types/database"
+import { TemplateManager } from "@/components/modals/template-manager"
 
 interface Props {
   open: boolean
@@ -26,7 +27,7 @@ export function CreateServerModal({ open, onClose }: Props) {
   const [iconFile, setIconFile] = useState<File | null>(null)
   const [iconPreview, setIconPreview] = useState<string | null>(null)
   const [joinCode, setJoinCode] = useState("")
-  const [mode, setMode] = useState<"create" | "join">("create")
+  const [mode, setMode] = useState<"create" | "join" | "template">("create")
   const fileRef = useRef<HTMLInputElement>(null)
   const supabase = createClientSupabaseClient()
 
@@ -171,6 +172,13 @@ export function CreateServerModal({ open, onClose }: Props) {
           >
             Join Existing
           </button>
+          <button
+            onClick={() => setMode("template")}
+            className={`flex-1 py-2 rounded text-sm font-medium transition-colors ${mode === "template" ? "text-white" : "text-gray-400 hover:text-gray-200"}`}
+            style={{ background: mode === "template" ? '#5865f2' : '#2b2d31' }}
+          >
+            Import Template
+          </button>
         </div>
 
         {mode === "create" ? (
@@ -217,7 +225,7 @@ export function CreateServerModal({ open, onClose }: Props) {
               Create Server
             </Button>
           </div>
-        ) : (
+        ) : mode === "join" ? (
           <div className="space-y-4">
             <div className="space-y-2">
               <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
@@ -241,6 +249,29 @@ export function CreateServerModal({ open, onClose }: Props) {
               {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Join Server
             </Button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+                Server Name <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Template Powered Server"
+                style={{ background: '#1e1f22', borderColor: '#1e1f22', color: '#f2f3f5' }}
+              />
+            </div>
+            <TemplateManager
+              createName={name}
+              createDescription={""}
+              onServerCreated={(server) => {
+                addServer(server)
+                onClose()
+                router.push(`/channels/${server.id}`)
+              }}
+            />
           </div>
         )}
       </DialogContent>

--- a/apps/web/components/modals/server-settings-modal.tsx
+++ b/apps/web/components/modals/server-settings-modal.tsx
@@ -12,6 +12,7 @@ import { createClientSupabaseClient } from "@/lib/supabase/client"
 import { useAppStore } from "@/lib/stores/app-store"
 import type { ServerRow, AutoModRuleRow, AutoModAction, ScreeningConfigRow } from "@/types/database"
 import { RoleManager } from "@/components/roles/role-manager"
+import { TemplateManager } from "@/components/modals/template-manager"
 
 interface Channel {
   id: string
@@ -128,6 +129,9 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
                     <Zap className="w-3.5 h-3.5 mr-1.5" />
                     AutoMod
                   </TabsTrigger>
+                  <TabsTrigger value="templates" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: '#b5bac1' }}>
+                    Templates
+                  </TabsTrigger>
                 </>
               )}
             </TabsList>
@@ -229,6 +233,10 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
 
             <TabsContent value="automod" className="mt-0">
               <AutoModTab serverId={server.id} channels={channels} open={open} />
+            </TabsContent>
+
+            <TabsContent value="templates" className="mt-0">
+              {isOwner ? <TemplateManager serverId={server.id} /> : <p style={{ color: "#b5bac1" }}>Only the owner can import/export templates.</p>}
             </TabsContent>
           </div>
         </Tabs>

--- a/apps/web/components/modals/template-manager.tsx
+++ b/apps/web/components/modals/template-manager.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { useToast } from "@/components/ui/use-toast"
+import type { ServerRow } from "@/types/database"
+
+interface Props {
+  serverId?: string
+  createName?: string
+  createDescription?: string
+  iconUrl?: string
+  onServerCreated?: (server: ServerRow) => void
+}
+
+export function TemplateManager({ serverId, createName, createDescription, iconUrl, onServerCreated }: Props) {
+  const { toast } = useToast()
+  const [starterTemplates, setStarterTemplates] = useState<Record<string, unknown>>({})
+  const [starterKey, setStarterKey] = useState("")
+  const [rawTemplate, setRawTemplate] = useState("")
+  const [warnings, setWarnings] = useState<string[]>([])
+  const [diff, setDiff] = useState<any>(null)
+  const [loading, setLoading] = useState(false)
+  const [exportValue, setExportValue] = useState("")
+
+  useEffect(() => {
+    fetch("/api/server-templates?mode=starter")
+      .then((r) => r.json())
+      .then((d) => setStarterTemplates(d.templates ?? {}))
+      .catch(() => setStarterTemplates({}))
+  }, [])
+
+  const parsedTemplate = useMemo(() => {
+    if (starterKey && starterTemplates[starterKey]) return starterTemplates[starterKey]
+    if (!rawTemplate.trim()) return null
+    try {
+      return JSON.parse(rawTemplate)
+    } catch {
+      return null
+    }
+  }, [rawTemplate, starterKey, starterTemplates])
+
+  async function request(mode: string) {
+    if (!parsedTemplate && mode !== "export") {
+      toast({ variant: "destructive", title: "Provide a valid template JSON or starter template" })
+      return
+    }
+    setLoading(true)
+    try {
+      const res = await fetch("/api/server-templates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mode,
+          serverId,
+          name: createName,
+          description: createDescription,
+          iconUrl,
+          template: parsedTemplate,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? data.errors?.join(", ") ?? "Request failed")
+      setWarnings(data.warnings ?? [])
+      if (mode === "preview") setDiff(data.diff)
+      if (mode === "apply") toast({ title: "Template imported successfully" })
+      if (mode === "create-server") {
+        toast({ title: "Server created from template" })
+        onServerCreated?.(data.server)
+      }
+      if (mode === "export") {
+        setExportValue(JSON.stringify(data.template, null, 2))
+        toast({ title: "Template exported" })
+      }
+    } catch (error: any) {
+      toast({ variant: "destructive", title: "Template request failed", description: error.message })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <Label className="text-xs uppercase" style={{ color: '#b5bac1' }}>Starter template</Label>
+        <select
+          value={starterKey}
+          onChange={(e) => setStarterKey(e.target.value)}
+          className="w-full rounded px-3 py-2 text-sm"
+          style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #1e1f22' }}
+        >
+          <option value="">Custom JSON</option>
+          {Object.keys(starterTemplates).map((key) => (
+            <option key={key} value={key}>{key}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="space-y-1">
+        <Label className="text-xs uppercase" style={{ color: '#b5bac1' }}>Template JSON</Label>
+        <textarea
+          value={rawTemplate}
+          onChange={(e) => { setRawTemplate(e.target.value); setStarterKey("") }}
+          rows={8}
+          placeholder='{"metadata":{"source":"custom","version":"1.0.0","created_by":"you"},"roles":[],"categories":[],"channels":[]}'
+          className="w-full rounded px-3 py-2 text-xs font-mono resize-y"
+          style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #1e1f22' }}
+        />
+      </div>
+
+      <div className="flex gap-2">
+        {serverId && <Button variant="outline" onClick={() => request("preview")} disabled={loading}>Preview Diff</Button>}
+        {serverId && <Button onClick={() => request("apply")} disabled={loading} style={{ background: '#5865f2' }}>Import Template</Button>}
+        {!serverId && <Button onClick={() => request("create-server")} disabled={loading || !createName?.trim()} style={{ background: '#5865f2' }}>Create from Template</Button>}
+        {serverId && <Button variant="outline" onClick={() => request("export")} disabled={loading}>Export</Button>}
+      </div>
+
+      {diff && (
+        <div className="text-xs rounded p-2" style={{ background: '#1e1f22', color: '#b5bac1' }}>
+          <div>Roles: {diff.roles.current} → {diff.roles.incoming}</div>
+          <div>Categories: {diff.categories.current} → {diff.categories.incoming}</div>
+          <div>Channels: {diff.channels.current} → {diff.channels.incoming}</div>
+        </div>
+      )}
+
+      {warnings.length > 0 && (
+        <div className="text-xs rounded p-2" style={{ background: '#3f2e00', color: '#f1c40f' }}>
+          {warnings.slice(0, 6).map((warning) => <div key={warning}>• {warning}</div>)}
+        </div>
+      )}
+
+      {exportValue && (
+        <div className="space-y-1">
+          <Label className="text-xs uppercase" style={{ color: '#b5bac1' }}>Exported template</Label>
+          <textarea readOnly value={exportValue} rows={8} className="w-full rounded px-3 py-2 text-xs font-mono" style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #1e1f22' }} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/lib/server-templates.test.ts
+++ b/apps/web/lib/server-templates.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { validateAndNormalizeTemplate } from "@/lib/server-templates"
+
+const baseTemplate = {
+  metadata: { source: "test", version: "1", created_by: "qa" },
+  roles: [{ name: "@everyone", permissions: ["VIEW_CHANNELS", "SEND_MESSAGES"], is_default: true }],
+  categories: [{ name: "General" }],
+  channels: [{ name: "chat", category: "General", type: "text" }],
+}
+
+describe("validateAndNormalizeTemplate", () => {
+  it("rejects malformed template", () => {
+    const result = validateAndNormalizeTemplate({ nope: true })
+    expect(result.template).toBeNull()
+    expect(result.errors.length).toBeGreaterThan(0)
+  })
+
+  it("handles large templates", () => {
+    const large = {
+      ...baseTemplate,
+      channels: Array.from({ length: 300 }, (_, i) => ({ name: `ch-${i}`, type: "text" })),
+    }
+    const result = validateAndNormalizeTemplate(large)
+    expect(result.errors).toEqual([])
+    expect(result.template?.channels).toHaveLength(300)
+  })
+
+  it("is idempotent for normalized output", () => {
+    const first = validateAndNormalizeTemplate(baseTemplate)
+    const second = validateAndNormalizeTemplate(first.template)
+    expect(second.errors).toEqual([])
+    expect(second.template).toEqual(first.template)
+  })
+})

--- a/apps/web/lib/server-templates.ts
+++ b/apps/web/lib/server-templates.ts
@@ -1,0 +1,264 @@
+import { PERMISSIONS } from "@vortex/shared"
+
+export type TemplatePermissionInput = number | string[]
+
+export interface TemplateMetadata {
+  source: string
+  version: string
+  created_by: string
+}
+
+export interface TemplateRole {
+  name: string
+  color?: string
+  position?: number
+  permissions: TemplatePermissionInput
+  is_hoisted?: boolean
+  mentionable?: boolean
+  is_default?: boolean
+}
+
+export interface TemplateChannelPermission {
+  role: string
+  allow?: TemplatePermissionInput
+  deny?: TemplatePermissionInput
+}
+
+export interface TemplateChannel {
+  name: string
+  type?: "text" | "voice" | "forum" | "stage" | "announcement" | "media"
+  category?: string
+  position?: number
+  topic?: string
+  slowmode_delay?: number
+  nsfw?: boolean
+  forum_guidelines?: string
+  permissions?: TemplateChannelPermission[]
+}
+
+export interface TemplateCategory {
+  name: string
+  position?: number
+}
+
+export interface ServerTemplate {
+  name?: string
+  description?: string
+  metadata: TemplateMetadata
+  roles: TemplateRole[]
+  categories: TemplateCategory[]
+  channels: TemplateChannel[]
+}
+
+const PERMISSION_ALIASES: Record<string, keyof typeof PERMISSIONS> = {
+  VIEW_CHANNEL: "VIEW_CHANNELS",
+  SEND_MESSAGE: "SEND_MESSAGES",
+  MANAGE_MESSAGE: "MANAGE_MESSAGES",
+  CONNECT: "CONNECT_VOICE",
+  SPEAK_VOICE: "SPEAK",
+}
+
+const PERMISSION_KEYS = new Set(Object.keys(PERMISSIONS))
+
+export function normalizePermissionInput(input: TemplatePermissionInput | undefined): { value: number; warnings: string[] } {
+  if (typeof input === "number") {
+    if (!Number.isFinite(input) || input < 0) return { value: 0, warnings: ["Permission number was invalid and reset to 0"] }
+    return { value: Math.floor(input), warnings: [] }
+  }
+
+  if (!Array.isArray(input)) return { value: 0, warnings: [] }
+
+  let bitmask = 0
+  const warnings: string[] = []
+  for (const raw of input) {
+    const key = String(raw).trim().toUpperCase()
+    const canonical = PERMISSION_KEYS.has(key) ? key as keyof typeof PERMISSIONS : PERMISSION_ALIASES[key]
+    if (!canonical) {
+      warnings.push(`Unsupported permission \"${raw}\" was ignored`)
+      continue
+    }
+    bitmask |= PERMISSIONS[canonical]
+  }
+  return { value: bitmask, warnings }
+}
+
+export function validateAndNormalizeTemplate(payload: unknown): { template: ServerTemplate | null; errors: string[]; warnings: string[] } {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  if (!payload || typeof payload !== "object") return { template: null, errors: ["Template payload must be a JSON object"], warnings }
+
+  const raw = payload as Record<string, unknown>
+  const metadata = raw.metadata as Record<string, unknown> | undefined
+  if (!metadata || typeof metadata !== "object") {
+    errors.push("metadata is required")
+  }
+
+  const rolesRaw = Array.isArray(raw.roles) ? raw.roles : []
+  if (rolesRaw.length === 0) errors.push("At least one role is required")
+  const roles: TemplateRole[] = rolesRaw.flatMap((role, index) => {
+    if (!role || typeof role !== "object") {
+      errors.push(`roles[${index}] must be an object`)
+      return []
+    }
+    const r = role as Record<string, unknown>
+    const name = String(r.name ?? "").trim()
+    if (!name) errors.push(`roles[${index}].name is required`)
+    const normalizedPerms = normalizePermissionInput(r.permissions as TemplatePermissionInput)
+    warnings.push(...normalizedPerms.warnings.map((w) => `roles[${index}]: ${w}`))
+    return [{
+      name,
+      color: typeof r.color === "string" ? r.color : "#99AAB5",
+      position: typeof r.position === "number" ? r.position : index,
+      permissions: normalizedPerms.value,
+      is_hoisted: !!r.is_hoisted,
+      mentionable: !!r.mentionable,
+      is_default: !!r.is_default,
+    }]
+  })
+
+  const categoriesRaw = Array.isArray(raw.categories) ? raw.categories : []
+  const categories: TemplateCategory[] = categoriesRaw.flatMap((cat, index) => {
+    if (!cat || typeof cat !== "object") {
+      errors.push(`categories[${index}] must be an object`)
+      return []
+    }
+    const c = cat as Record<string, unknown>
+    const name = String(c.name ?? "").trim()
+    if (!name) errors.push(`categories[${index}].name is required`)
+    return [{ name, position: typeof c.position === "number" ? c.position : index }]
+  })
+
+  const channelsRaw = Array.isArray(raw.channels) ? raw.channels : []
+  if (channelsRaw.length === 0) errors.push("At least one channel is required")
+  const validTypes = new Set(["text", "voice", "forum", "stage", "announcement", "media"])
+
+  const channels: TemplateChannel[] = channelsRaw.flatMap((chan, index) => {
+    if (!chan || typeof chan !== "object") {
+      errors.push(`channels[${index}] must be an object`)
+      return []
+    }
+    const c = chan as Record<string, unknown>
+    const name = String(c.name ?? "").trim()
+    const type = typeof c.type === "string" ? c.type : "text"
+    if (!name) errors.push(`channels[${index}].name is required`)
+    if (!validTypes.has(type)) {
+      warnings.push(`channels[${index}].type \"${type}\" unsupported, defaulted to text`)
+    }
+
+    const permissionsRaw = Array.isArray(c.permissions) ? c.permissions : []
+    const permissions: TemplateChannelPermission[] = permissionsRaw.flatMap((p, pIndex) => {
+      if (!p || typeof p !== "object") {
+        warnings.push(`channels[${index}].permissions[${pIndex}] ignored (not an object)`)
+        return []
+      }
+      const permissionObj = p as Record<string, unknown>
+      const role = String(permissionObj.role ?? "").trim()
+      if (!role) {
+        warnings.push(`channels[${index}].permissions[${pIndex}] ignored (missing role)`)
+        return []
+      }
+      const allow = normalizePermissionInput(permissionObj.allow as TemplatePermissionInput)
+      const deny = normalizePermissionInput(permissionObj.deny as TemplatePermissionInput)
+      warnings.push(...allow.warnings.map((w) => `channels[${index}](${role}) allow: ${w}`))
+      warnings.push(...deny.warnings.map((w) => `channels[${index}](${role}) deny: ${w}`))
+      return [{ role, allow: allow.value, deny: deny.value }]
+    })
+
+    return [{
+      name,
+      type: validTypes.has(type) ? type as TemplateChannel["type"] : "text",
+      category: typeof c.category === "string" ? c.category : undefined,
+      position: typeof c.position === "number" ? c.position : index,
+      topic: typeof c.topic === "string" ? c.topic : undefined,
+      slowmode_delay: typeof c.slowmode_delay === "number" ? c.slowmode_delay : 0,
+      nsfw: !!c.nsfw,
+      forum_guidelines: typeof c.forum_guidelines === "string" ? c.forum_guidelines : undefined,
+      permissions,
+    }]
+  })
+
+  const roleNames = new Set(roles.map((r) => r.name.toLowerCase()))
+  for (const [index, channel] of channels.entries()) {
+    if (channel.category && !categories.some((cat) => cat.name.toLowerCase() === channel.category!.toLowerCase())) {
+      warnings.push(`channels[${index}] references missing category \"${channel.category}\" and will be placed at root`)
+      delete channel.category
+    }
+    for (const perm of channel.permissions ?? []) {
+      if (!roleNames.has(perm.role.toLowerCase())) {
+        warnings.push(`channels[${index}] permission for unknown role \"${perm.role}\" ignored at apply time`)
+      }
+    }
+  }
+
+  if (errors.length > 0) return { template: null, errors, warnings }
+
+  return {
+    template: {
+      name: typeof raw.name === "string" ? raw.name : undefined,
+      description: typeof raw.description === "string" ? raw.description : undefined,
+      metadata: {
+        source: String(metadata?.source ?? "custom"),
+        version: String(metadata?.version ?? "1.0.0"),
+        created_by: String(metadata?.created_by ?? "unknown"),
+      },
+      roles,
+      categories,
+      channels,
+    },
+    errors,
+    warnings,
+  }
+}
+
+export const STARTER_TEMPLATES: Record<string, ServerTemplate> = {
+  Gaming: {
+    metadata: { source: "builtin", version: "1.0.0", created_by: "vortex" },
+    roles: [
+      { name: "@everyone", permissions: ["VIEW_CHANNELS", "SEND_MESSAGES", "CONNECT_VOICE", "SPEAK"], is_default: true },
+      { name: "Mods", color: "#FEE75C", permissions: ["MANAGE_MESSAGES", "KICK_MEMBERS", "BAN_MEMBERS"] },
+    ],
+    categories: [{ name: "Lobby" }, { name: "Games" }],
+    channels: [
+      { name: "welcome", category: "Lobby", type: "text" },
+      { name: "lfg", category: "Games", type: "text" },
+      { name: "Squad Voice", category: "Games", type: "voice" },
+    ],
+  },
+  Study: {
+    metadata: { source: "builtin", version: "1.0.0", created_by: "vortex" },
+    roles: [{ name: "@everyone", permissions: ["VIEW_CHANNELS", "SEND_MESSAGES", "CONNECT_VOICE", "SPEAK"], is_default: true }],
+    categories: [{ name: "General" }, { name: "Subjects" }],
+    channels: [
+      { name: "announcements", category: "General", type: "announcement" },
+      { name: "homework-help", category: "Subjects", type: "text" },
+      { name: "focus-room", category: "General", type: "voice" },
+    ],
+  },
+  Startup: {
+    metadata: { source: "builtin", version: "1.0.0", created_by: "vortex" },
+    roles: [
+      { name: "@everyone", permissions: ["VIEW_CHANNELS", "SEND_MESSAGES"], is_default: true },
+      { name: "Team", color: "#57F287", permissions: ["MANAGE_CHANNELS", "MANAGE_MESSAGES"] },
+    ],
+    categories: [{ name: "Company" }, { name: "Engineering" }],
+    channels: [
+      { name: "all-hands", category: "Company", type: "announcement" },
+      { name: "product", category: "Company", type: "text" },
+      { name: "dev-sync", category: "Engineering", type: "voice" },
+    ],
+  },
+  Creator: {
+    metadata: { source: "builtin", version: "1.0.0", created_by: "vortex" },
+    roles: [
+      { name: "@everyone", permissions: ["VIEW_CHANNELS", "SEND_MESSAGES"], is_default: true },
+      { name: "VIP", color: "#EB459E", permissions: ["VIEW_CHANNELS", "SEND_MESSAGES", "CONNECT_VOICE"] },
+    ],
+    categories: [{ name: "Community" }, { name: "Content" }],
+    channels: [
+      { name: "news", category: "Community", type: "announcement" },
+      { name: "fan-chat", category: "Community", type: "text" },
+      { name: "creator-lounge", category: "Content", type: "voice" },
+    ],
+  },
+}

--- a/apps/web/types/database.ts
+++ b/apps/web/types/database.ts
@@ -1174,6 +1174,18 @@ export type Database = {
         Args: Record<string, never>
         Returns: number
       }
+      apply_server_template: {
+        Args: { p_server_id: string; p_template: Json }
+        Returns: Json
+      }
+      export_server_template: {
+        Args: { p_server_id: string }
+        Returns: Json
+      }
+      create_server_from_template: {
+        Args: { p_name: string; p_description: string; p_icon_url: string; p_template: Json }
+        Returns: Database['public']['Tables']['servers']['Row']
+      }
     }
     Enums: {
       [_ in never]: never

--- a/supabase/migrations/00017_server_templates.sql
+++ b/supabase/migrations/00017_server_templates.sql
@@ -1,0 +1,297 @@
+-- Server template import/export helpers
+
+CREATE OR REPLACE FUNCTION public.apply_server_template(
+  p_server_id UUID,
+  p_template JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_owner UUID;
+  v_default_role_id UUID;
+  v_default_role_name TEXT;
+  v_default_permissions BIGINT := 3;
+  v_default_color TEXT := '#99AAB5';
+  v_role JSONB;
+  v_category JSONB;
+  v_channel JSONB;
+  v_perm JSONB;
+  v_role_id UUID;
+  v_channel_id UUID;
+  v_parent_id UUID;
+  v_deleted_channels INTEGER := 0;
+BEGIN
+  SELECT owner_id INTO v_owner FROM public.servers WHERE id = p_server_id;
+  IF v_owner IS NULL THEN
+    RAISE EXCEPTION 'Server not found';
+  END IF;
+
+  IF v_owner <> auth.uid() THEN
+    RAISE EXCEPTION 'Only server owner can import templates';
+  END IF;
+
+  IF jsonb_typeof(p_template) <> 'object' THEN
+    RAISE EXCEPTION 'Template must be an object';
+  END IF;
+
+  CREATE TEMP TABLE IF NOT EXISTS tmp_role_map(name TEXT PRIMARY KEY, role_id UUID) ON COMMIT DROP;
+  CREATE TEMP TABLE IF NOT EXISTS tmp_category_map(name TEXT PRIMARY KEY, channel_id UUID) ON COMMIT DROP;
+  CREATE TEMP TABLE IF NOT EXISTS tmp_channel_map(name TEXT PRIMARY KEY, channel_id UUID) ON COMMIT DROP;
+  TRUNCATE tmp_role_map, tmp_category_map, tmp_channel_map;
+
+  SELECT id INTO v_default_role_id
+  FROM public.roles
+  WHERE server_id = p_server_id AND is_default = TRUE
+  LIMIT 1;
+
+  SELECT COALESCE(r->>'name', '@everyone'),
+         COALESCE((r->>'permissions')::BIGINT, 3),
+         COALESCE(r->>'color', '#99AAB5')
+  INTO v_default_role_name, v_default_permissions, v_default_color
+  FROM jsonb_array_elements(COALESCE(p_template->'roles', '[]'::jsonb)) r
+  WHERE COALESCE((r->>'is_default')::BOOLEAN, FALSE) = TRUE
+  LIMIT 1;
+
+  IF v_default_role_id IS NULL THEN
+    INSERT INTO public.roles (server_id, name, color, position, permissions, is_default)
+    VALUES (p_server_id, v_default_role_name, v_default_color, 0, v_default_permissions, TRUE)
+    RETURNING id INTO v_default_role_id;
+  ELSE
+    UPDATE public.roles
+    SET name = v_default_role_name,
+        color = v_default_color,
+        permissions = v_default_permissions,
+        is_hoisted = FALSE,
+        mentionable = FALSE
+    WHERE id = v_default_role_id;
+  END IF;
+
+  INSERT INTO tmp_role_map(name, role_id)
+  VALUES (LOWER(v_default_role_name), v_default_role_id)
+  ON CONFLICT (name) DO UPDATE SET role_id = EXCLUDED.role_id;
+
+  DELETE FROM public.member_roles
+  WHERE server_id = p_server_id
+    AND role_id IN (SELECT id FROM public.roles WHERE server_id = p_server_id AND is_default = FALSE);
+
+  DELETE FROM public.roles
+  WHERE server_id = p_server_id AND is_default = FALSE;
+
+  FOR v_role IN
+    SELECT value
+    FROM jsonb_array_elements(COALESCE(p_template->'roles', '[]'::jsonb))
+  LOOP
+    IF COALESCE((v_role->>'is_default')::BOOLEAN, FALSE) = TRUE THEN
+      CONTINUE;
+    END IF;
+
+    INSERT INTO public.roles (server_id, name, color, position, permissions, is_hoisted, mentionable, is_default)
+    VALUES (
+      p_server_id,
+      COALESCE(v_role->>'name', 'new role'),
+      COALESCE(v_role->>'color', '#99AAB5'),
+      COALESCE((v_role->>'position')::INTEGER, 0),
+      COALESCE((v_role->>'permissions')::BIGINT, 0),
+      COALESCE((v_role->>'is_hoisted')::BOOLEAN, FALSE),
+      COALESCE((v_role->>'mentionable')::BOOLEAN, FALSE),
+      FALSE
+    )
+    RETURNING id INTO v_role_id;
+
+    INSERT INTO tmp_role_map(name, role_id)
+    VALUES (LOWER(COALESCE(v_role->>'name', 'new role')), v_role_id)
+    ON CONFLICT (name) DO UPDATE SET role_id = EXCLUDED.role_id;
+  END LOOP;
+
+  DELETE FROM public.channels WHERE server_id = p_server_id;
+  GET DIAGNOSTICS v_deleted_channels = ROW_COUNT;
+
+  FOR v_category IN
+    SELECT value
+    FROM jsonb_array_elements(COALESCE(p_template->'categories', '[]'::jsonb))
+  LOOP
+    INSERT INTO public.channels (server_id, name, type, position)
+    VALUES (
+      p_server_id,
+      COALESCE(v_category->>'name', 'category'),
+      'category',
+      COALESCE((v_category->>'position')::INTEGER, 0)
+    )
+    RETURNING id INTO v_channel_id;
+
+    INSERT INTO tmp_category_map(name, channel_id)
+    VALUES (LOWER(COALESCE(v_category->>'name', 'category')), v_channel_id)
+    ON CONFLICT (name) DO UPDATE SET channel_id = EXCLUDED.channel_id;
+  END LOOP;
+
+  FOR v_channel IN
+    SELECT value
+    FROM jsonb_array_elements(COALESCE(p_template->'channels', '[]'::jsonb))
+  LOOP
+    SELECT channel_id INTO v_parent_id
+    FROM tmp_category_map
+    WHERE name = LOWER(COALESCE(v_channel->>'category', ''));
+
+    INSERT INTO public.channels (
+      server_id, name, type, position, topic, parent_id, slowmode_delay, nsfw, forum_guidelines
+    )
+    VALUES (
+      p_server_id,
+      COALESCE(v_channel->>'name', 'channel'),
+      COALESCE(v_channel->>'type', 'text'),
+      COALESCE((v_channel->>'position')::INTEGER, 0),
+      NULLIF(v_channel->>'topic', ''),
+      v_parent_id,
+      COALESCE((v_channel->>'slowmode_delay')::INTEGER, 0),
+      COALESCE((v_channel->>'nsfw')::BOOLEAN, FALSE),
+      NULLIF(v_channel->>'forum_guidelines', '')
+    )
+    RETURNING id INTO v_channel_id;
+
+    INSERT INTO tmp_channel_map(name, channel_id)
+    VALUES (LOWER(COALESCE(v_channel->>'name', 'channel')), v_channel_id)
+    ON CONFLICT (name) DO UPDATE SET channel_id = EXCLUDED.channel_id;
+
+    FOR v_perm IN
+      SELECT value FROM jsonb_array_elements(COALESCE(v_channel->'permissions', '[]'::jsonb))
+    LOOP
+      SELECT role_id INTO v_role_id
+      FROM tmp_role_map
+      WHERE name = LOWER(COALESCE(v_perm->>'role', ''));
+
+      IF v_role_id IS NULL THEN
+        CONTINUE;
+      END IF;
+
+      INSERT INTO public.channel_permissions (channel_id, role_id, allow_permissions, deny_permissions)
+      VALUES (
+        v_channel_id,
+        v_role_id,
+        COALESCE((v_perm->>'allow')::BIGINT, 0),
+        COALESCE((v_perm->>'deny')::BIGINT, 0)
+      )
+      ON CONFLICT (channel_id, role_id)
+      DO UPDATE SET
+        allow_permissions = EXCLUDED.allow_permissions,
+        deny_permissions = EXCLUDED.deny_permissions;
+    END LOOP;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'deleted_channels', v_deleted_channels,
+    'roles_count', (SELECT COUNT(*) FROM public.roles WHERE server_id = p_server_id),
+    'channels_count', (SELECT COUNT(*) FROM public.channels WHERE server_id = p_server_id)
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.export_server_template(p_server_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_owner UUID;
+BEGIN
+  SELECT owner_id INTO v_owner FROM public.servers WHERE id = p_server_id;
+  IF v_owner IS NULL THEN
+    RAISE EXCEPTION 'Server not found';
+  END IF;
+
+  IF v_owner <> auth.uid() THEN
+    RAISE EXCEPTION 'Only server owner can export templates';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'name', (SELECT name FROM public.servers WHERE id = p_server_id),
+    'description', (SELECT description FROM public.servers WHERE id = p_server_id),
+    'metadata', jsonb_build_object('source', 'export', 'version', '1.0.0', 'created_by', auth.uid()::TEXT),
+    'roles', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'name', r.name,
+        'color', r.color,
+        'position', r.position,
+        'permissions', r.permissions,
+        'is_hoisted', r.is_hoisted,
+        'mentionable', r.mentionable,
+        'is_default', r.is_default
+      ) ORDER BY r.position DESC)
+      FROM public.roles r
+      WHERE r.server_id = p_server_id
+    ), '[]'::jsonb),
+    'categories', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', c.name, 'position', c.position) ORDER BY c.position ASC)
+      FROM public.channels c
+      WHERE c.server_id = p_server_id AND c.type = 'category'
+    ), '[]'::jsonb),
+    'channels', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'name', c.name,
+        'type', c.type,
+        'position', c.position,
+        'category', parent.name,
+        'topic', c.topic,
+        'slowmode_delay', c.slowmode_delay,
+        'nsfw', c.nsfw,
+        'forum_guidelines', c.forum_guidelines,
+        'permissions', COALESCE((
+          SELECT jsonb_agg(jsonb_build_object(
+            'role', r.name,
+            'allow', cp.allow_permissions,
+            'deny', cp.deny_permissions
+          ))
+          FROM public.channel_permissions cp
+          JOIN public.roles r ON r.id = cp.role_id
+          WHERE cp.channel_id = c.id
+        ), '[]'::jsonb)
+      ) ORDER BY c.position ASC)
+      FROM public.channels c
+      LEFT JOIN public.channels parent ON parent.id = c.parent_id
+      WHERE c.server_id = p_server_id AND c.type <> 'category'
+    ), '[]'::jsonb)
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.apply_server_template(UUID, JSONB) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.apply_server_template(UUID, JSONB) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.export_server_template(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.export_server_template(UUID) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.create_server_from_template(
+  p_name TEXT,
+  p_description TEXT,
+  p_icon_url TEXT,
+  p_template JSONB
+)
+RETURNS public.servers
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_server public.servers;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  INSERT INTO public.servers (name, description, icon_url, owner_id)
+  VALUES (p_name, NULLIF(p_description, ''), NULLIF(p_icon_url, ''), auth.uid())
+  RETURNING * INTO v_server;
+
+  PERFORM public.apply_server_template(v_server.id, p_template);
+
+  SELECT * INTO v_server FROM public.servers WHERE id = v_server.id;
+  RETURN v_server;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.create_server_from_template(TEXT, TEXT, TEXT, JSONB) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.create_server_from_template(TEXT, TEXT, TEXT, JSONB) TO authenticated;


### PR DESCRIPTION
### Motivation
- Provide a reusable server template system so servers can be exported/imported and new servers created from templates. 
- Ensure imports apply transactionally and can be previewed before mutating existing server state. 
- Normalize legacy/third-party permission names into the platform bitmask and surface warnings for unsupported fields to degrade gracefully.

### Description
- Added a schema/validation/normalization module at `apps/web/lib/server-templates.ts` that accepts template JSON with `metadata`, `roles`, `categories`, `channels`, and maps permission names/aliases into the internal bitmask while returning warnings for unsupported values. 
- Implemented a unified API `GET/POST /api/server-templates` at `apps/web/app/api/server-templates/route.ts` supporting `validate`, `preview` (diff summary), `apply` (apply to existing server), `create-server` (create + apply), `export`, and a `?mode=starter` list of built-in templates. 
- Added transactional DB helpers in `supabase/migrations/00017_server_templates.sql`: `apply_server_template(server_id, template)`, `export_server_template(server_id)`, and `create_server_from_template(name, description, icon, template)`, with owner checks and rollback-safe operations. 
- Integrated the import UX: new `TemplateManager` component (`apps/web/components/modals/template-manager.tsx`) plus UI hooks in server creation (`Import Template` mode in `create-server` modal) and server settings (new `Templates` tab in `server-settings`), and updated generated RPC typings in `apps/web/types/database.ts` and README documentation.

### Testing
- Ran the unit tests for the template library with `npm --prefix apps/web run test -- server-templates.test.ts` and all tests passed (3 tests). 
- Ran TypeScript checks with `npm --prefix apps/web run type-check` and the codebase type-checked successfully after adding RPC typings. 
- The template import flow is backed by DB-side RPCs to guarantee transactional apply/rollback; SQL functions were added in `supabase/migrations/00017_server_templates.sql` for that purpose.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bd0c1993883258a803dacfe05f132)