### PR TITLE
Add moderation appeal workflow with triage APIs and audit logging

### DIFF
--- a/apps/web/__tests__/appeals-auth.test.ts
+++ b/apps/web/__tests__/appeals-auth.test.ts
@@ -5,6 +5,8 @@ describe("appeal anti-abuse and payload boundaries", () => {
   it("caps attachment list to 10 and removes non-strings", () => {
     const attachments = sanitizeEvidenceAttachments([
       "https://a.test",
+      "javascript:alert(1)",
+      "not-a-url",
       "",
       3,
       ...new Array(20).fill("https://evidence.test"),
@@ -12,6 +14,7 @@ describe("appeal anti-abuse and payload boundaries", () => {
 
     expect(attachments.length).toBe(10)
     expect(attachments.every((item) => typeof item === "string")).toBe(true)
+    expect(attachments.some((item) => item.startsWith("javascript:"))).toBe(false)
   })
 
   it("produces higher anti-abuse scores for suspicious appeals", () => {

--- a/apps/web/__tests__/appeals-state.test.ts
+++ b/apps/web/__tests__/appeals-state.test.ts
@@ -16,8 +16,13 @@ describe("appeal state transitions", () => {
     expect(isValidAppealTransition("reviewing", "closed")).toBe(true)
   })
 
-  it("blocks closed -> any", () => {
+  it("allows only finalization from approved/denied and blocks transitions from closed", () => {
+    expect(isValidAppealTransition("approved", "closed")).toBe(true)
+    expect(isValidAppealTransition("denied", "closed")).toBe(true)
+    expect(isValidAppealTransition("approved", "reviewing")).toBe(false)
+    expect(isValidAppealTransition("denied", "reviewing")).toBe(false)
     expect(isValidAppealTransition("closed", "reviewing")).toBe(false)
+    expect(isValidAppealTransition("closed", "closed")).toBe(false)
   })
 
   it("validates status enum", () => {

--- a/apps/web/app/api/appeals/[appealId]/route.ts
+++ b/apps/web/app/api/appeals/[appealId]/route.ts
@@ -1,14 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createServerSupabaseClient, createServiceRoleClient } from "@/lib/supabase/server"
 import { aggregateMemberPermissions } from "@/lib/server-auth"
-import { isValidAppealStatus, isValidAppealTransition } from "@/lib/appeals"
-
-const BAN_MEMBERS = 16
-const ADMINISTRATOR = 128
-
-function canModerate(permissions: number) {
-  return (permissions & BAN_MEMBERS) !== 0 || (permissions & ADMINISTRATOR) !== 0
-}
+import { isTerminalAppealStatus, isValidAppealStatus, isValidAppealTransition } from "@/lib/appeals"
+import { canModerate } from "@/lib/moderation-auth"
 
 async function getRequester() {
   const supabase = await createServerSupabaseClient()
@@ -35,20 +29,18 @@ export async function GET(
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
   if (!appeal) return NextResponse.json({ error: "Not found" }, { status: 404 })
 
-  let isModerator = false
-  if (appeal.user_id !== user.id) {
-    const { data: member } = await supabase
-      .from("server_members")
-      .select("member_roles(roles(permissions))")
-      .eq("server_id", appeal.server_id)
-      .eq("user_id", user.id)
-      .maybeSingle()
+  const { data: member } = await supabase
+    .from("server_members")
+    .select("member_roles(roles(permissions))")
+    .eq("server_id", appeal.server_id)
+    .eq("user_id", user.id)
+    .maybeSingle()
 
-    const permissions = aggregateMemberPermissions((member as any)?.member_roles)
-    isModerator = canModerate(permissions)
+  const permissions = aggregateMemberPermissions((member as any)?.member_roles)
+  const isModerator = canModerate(permissions)
+  const isOwner = appeal.user_id === user.id
 
-    if (!isModerator) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
-  }
+  if (!isOwner && !isModerator) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
 
   const serviceSupabase = await createServiceRoleClient()
   const notesPromise = isModerator
@@ -102,12 +94,26 @@ export async function PATCH(
   const permissions = aggregateMemberPermissions((member as any)?.member_roles)
   if (!canModerate(permissions)) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
 
-  const body = await req.json()
-  const nextStatus = body.status as string | undefined
-  const assignReviewerId = body.assignReviewerId as string | undefined
-  const internalNote = typeof body.internalNote === "string" ? body.internalNote.trim() : ""
-  const decisionTemplateId = typeof body.decisionTemplateId === "string" ? body.decisionTemplateId : null
-  const decisionReason = typeof body.decisionReason === "string" ? body.decisionReason : null
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Malformed JSON" }, { status: 400 })
+  }
+
+  const parsed = body as {
+    status?: unknown
+    assignReviewerId?: unknown
+    internalNote?: unknown
+    decisionTemplateId?: unknown
+    decisionReason?: unknown
+  }
+
+  const nextStatus = typeof parsed.status === "string" ? parsed.status : undefined
+  const assignReviewerId = typeof parsed.assignReviewerId === "string" ? parsed.assignReviewerId : undefined
+  const internalNote = typeof parsed.internalNote === "string" ? parsed.internalNote.trim() : ""
+  const decisionTemplateId = typeof parsed.decisionTemplateId === "string" ? parsed.decisionTemplateId : null
+  const decisionReason = typeof parsed.decisionReason === "string" ? parsed.decisionReason : null
 
   const updatePayload: Record<string, unknown> = { updated_at: new Date().toISOString() }
 
@@ -117,12 +123,15 @@ export async function PATCH(
     if (!isValidAppealStatus(nextStatus)) {
       return NextResponse.json({ error: "Invalid status" }, { status: 400 })
     }
+    if (!isValidAppealStatus(appeal.status)) {
+      return NextResponse.json({ error: "Invalid current status" }, { status: 500 })
+    }
     if (!isValidAppealTransition(appeal.status, nextStatus)) {
       return NextResponse.json({ error: "Invalid state transition" }, { status: 409 })
     }
 
     updatePayload.status = nextStatus
-    if (nextStatus === "closed") updatePayload.closed_at = new Date().toISOString()
+    if (isTerminalAppealStatus(nextStatus)) updatePayload.closed_at = new Date().toISOString()
     if (decisionTemplateId) updatePayload.decision_template_id = decisionTemplateId
     if (decisionReason) updatePayload.decision_reason = decisionReason
   }
@@ -135,16 +144,21 @@ export async function PATCH(
   if (updateError) return NextResponse.json({ error: updateError.message }, { status: 500 })
 
   if (internalNote) {
-    await (serviceSupabase as any).from("moderation_appeal_internal_notes").insert({
+    const { error: noteError } = await (serviceSupabase as any).from("moderation_appeal_internal_notes").insert({
       appeal_id: appealId,
       server_id: appeal.server_id,
       author_id: user.id,
       note: internalNote,
     })
+
+    if (noteError) {
+      console.warn("Failed appeal internal note insert", { appealId, moderatorId: user.id, action: "internal_note", error: noteError })
+      return NextResponse.json({ error: "Failed to save internal note" }, { status: 500 })
+    }
   }
 
   if (nextStatus) {
-    await (serviceSupabase as any).from("moderation_appeal_status_events").insert({
+    const { error: statusEventError } = await (serviceSupabase as any).from("moderation_appeal_status_events").insert({
       appeal_id: appealId,
       server_id: appeal.server_id,
       actor_id: user.id,
@@ -155,7 +169,12 @@ export async function PATCH(
       },
     })
 
-    await serviceSupabase.from("audit_logs").insert({
+    if (statusEventError) {
+      console.warn("Failed appeal status event insert", { appealId, moderatorId: user.id, action: "status_update", error: statusEventError })
+      return NextResponse.json({ error: "Failed to write status event" }, { status: 500 })
+    }
+
+    const { error: auditError } = await serviceSupabase.from("audit_logs").insert({
       server_id: appeal.server_id,
       actor_id: user.id,
       action: "appeal_status_changed",
@@ -164,7 +183,12 @@ export async function PATCH(
       changes: { from: appeal.status, to: nextStatus },
     })
 
-    await (serviceSupabase as any).from("notifications").insert([
+    if (auditError) {
+      console.warn("Failed appeal audit log insert", { appealId, moderatorId: user.id, action: "status_update", error: auditError })
+      return NextResponse.json({ error: "Failed to write audit log" }, { status: 500 })
+    }
+
+    const { error: notificationError } = await (serviceSupabase as any).from("notifications").insert([
       {
         user_id: appeal.user_id,
         type: "system",
@@ -180,6 +204,11 @@ export async function PATCH(
         server_id: appeal.server_id,
       },
     ])
+
+    if (notificationError) {
+      console.warn("Failed appeal notification insert", { appealId, moderatorId: user.id, action: "status_update", error: notificationError })
+      return NextResponse.json({ error: "Failed to send notifications" }, { status: 500 })
+    }
   }
 
   return NextResponse.json({ message: "Appeal updated" })

--- a/apps/web/app/api/appeals/route.ts
+++ b/apps/web/app/api/appeals/route.ts
@@ -30,32 +30,41 @@ export async function POST(req: NextRequest) {
 
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
-  const body = await req.json()
+  let payload: unknown
+  try {
+    payload = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Malformed JSON" }, { status: 400 })
+  }
+
+  const body = payload as { serverId?: unknown; statement?: unknown; evidenceAttachments?: unknown }
   const serverId = typeof body.serverId === "string" ? body.serverId : ""
   const statement = typeof body.statement === "string" ? body.statement.trim() : ""
-  const evidenceAttachments = sanitizeEvidenceAttachments(body.evidenceAttachments)
 
-  if (!serverId || statement.length < 20) {
+  if (!serverId || statement.length < 20 || statement.length > 4000) {
     return NextResponse.json({ error: "Invalid payload" }, { status: 400 })
   }
+
+  const evidenceAttachments = sanitizeEvidenceAttachments(body.evidenceAttachments)
 
   const rate = rateLimiter.check(`appeals:${user.id}:${serverId}`, { limit: 3, windowMs: 60 * 60 * 1000 })
   if (!rate.allowed) {
     return NextResponse.json({ error: "Too many submissions, please try later" }, { status: 429 })
   }
 
-  const { data: ban } = await supabase
+  const { data: ban, error: banError } = await serviceSupabase
     .from("server_bans")
     .select("server_id, user_id")
     .eq("server_id", serverId)
     .eq("user_id", user.id)
     .maybeSingle()
 
+  if (banError) return NextResponse.json({ error: banError.message }, { status: 500 })
   if (!ban) {
     return NextResponse.json({ error: "Appeal cannot be created" }, { status: 403 })
   }
 
-  const { data: duplicate } = await (serviceSupabase as any)
+  const { data: duplicate, error: duplicateError } = await (serviceSupabase as any)
     .from("moderation_appeals")
     .select("id")
     .eq("server_id", serverId)
@@ -63,15 +72,20 @@ export async function POST(req: NextRequest) {
     .in("status", ["submitted", "reviewing"])
     .maybeSingle()
 
+  if (duplicateError) return NextResponse.json({ error: duplicateError.message }, { status: 500 })
   if (duplicate) {
     return NextResponse.json({ error: "An active appeal already exists" }, { status: 409 })
   }
 
-  const { count } = await (serviceSupabase as any)
+  const thirtyDaysAgoIso = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+  const { count, error: countError } = await (serviceSupabase as any)
     .from("moderation_appeals")
     .select("id", { count: "exact", head: true })
     .eq("server_id", serverId)
     .eq("user_id", user.id)
+    .gte("submitted_at", thirtyDaysAgoIso)
+
+  if (countError) return NextResponse.json({ error: countError.message }, { status: 500 })
 
   const antiAbuseScore = computeAntiAbuseScore({
     statement,
@@ -84,8 +98,6 @@ export async function POST(req: NextRequest) {
     .insert({
       server_id: serverId,
       user_id: user.id,
-      ban_server_id: serverId,
-      ban_user_id: user.id,
       appellant_statement: statement,
       evidence_attachments: evidenceAttachments,
       anti_abuse_score: antiAbuseScore,
@@ -96,7 +108,7 @@ export async function POST(req: NextRequest) {
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
 
-  await (serviceSupabase as any).from("moderation_appeal_status_events").insert({
+  const { error: eventError } = await (serviceSupabase as any).from("moderation_appeal_status_events").insert({
     appeal_id: appeal.id,
     server_id: serverId,
     actor_id: user.id,
@@ -105,7 +117,13 @@ export async function POST(req: NextRequest) {
     metadata: { antiAbuseScore },
   })
 
-  await serviceSupabase.from("audit_logs").insert({
+  if (eventError) {
+    console.warn("Failed appeal status event insert", { appealId: appeal.id, moderatorId: user.id, action: "create", error: eventError })
+    await (serviceSupabase as any).from("moderation_appeals").delete().eq("id", appeal.id)
+    return NextResponse.json({ error: "Failed to create appeal status event" }, { status: 500 })
+  }
+
+  const { error: auditError } = await serviceSupabase.from("audit_logs").insert({
     server_id: serverId,
     actor_id: user.id,
     action: "appeal_status_changed",
@@ -114,7 +132,14 @@ export async function POST(req: NextRequest) {
     changes: { from: null, to: "submitted" },
   })
 
-  await (serviceSupabase as any).from("notifications").insert([
+  if (auditError) {
+    console.warn("Failed appeal audit log insert", { appealId: appeal.id, moderatorId: user.id, action: "create", error: auditError })
+    await (serviceSupabase as any).from("moderation_appeal_status_events").delete().eq("appeal_id", appeal.id)
+    await (serviceSupabase as any).from("moderation_appeals").delete().eq("id", appeal.id)
+    return NextResponse.json({ error: "Failed to write appeal audit log" }, { status: 500 })
+  }
+
+  const { error: notificationError } = await (serviceSupabase as any).from("notifications").insert([
     {
       user_id: user.id,
       type: "system",
@@ -123,6 +148,11 @@ export async function POST(req: NextRequest) {
       server_id: serverId,
     },
   ])
+
+  if (notificationError) {
+    console.warn("Failed appeal notification insert", { appealId: appeal.id, moderatorId: user.id, action: "create", error: notificationError })
+    return NextResponse.json({ error: "Failed to create appeal notification" }, { status: 500 })
+  }
 
   return NextResponse.json({
     message: "Appeal submitted",

--- a/apps/web/app/api/servers/[serverId]/appeal-templates/route.ts
+++ b/apps/web/app/api/servers/[serverId]/appeal-templates/route.ts
@@ -1,36 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
-import { createServerSupabaseClient, createServiceRoleClient } from "@/lib/supabase/server"
-import { aggregateMemberPermissions } from "@/lib/server-auth"
-
-const BAN_MEMBERS = 16
-const ADMINISTRATOR = 128
-
-function canModerate(permissions: number) {
-  return (permissions & BAN_MEMBERS) !== 0 || (permissions & ADMINISTRATOR) !== 0
-}
-
-async function requireModerator(serverId: string) {
-  const supabase = await createServerSupabaseClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) return { error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }), user: null, supabase }
-
-  const { data: member } = await supabase
-    .from("server_members")
-    .select("member_roles(roles(permissions))")
-    .eq("server_id", serverId)
-    .eq("user_id", user.id)
-    .maybeSingle()
-
-  const permissions = aggregateMemberPermissions((member as any)?.member_roles)
-  if (!canModerate(permissions)) {
-    return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }), user: null, supabase }
-  }
-
-  return { error: null, user, supabase }
-}
+import { createServiceRoleClient } from "@/lib/supabase/server"
+import { requireModerator } from "@/lib/moderation-auth"
 
 export async function GET(
   _req: NextRequest,
@@ -58,8 +28,28 @@ export async function POST(
   const auth = await requireModerator(serverId)
   if (auth.error || !auth.user) return auth.error!
 
-  const { title, body, decision } = await req.json()
-  if (!["approved", "denied", "closed"].includes(decision)) {
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Malformed JSON" }, { status: 400 })
+  }
+
+  const { title, body: templateBody, decision } = body as {
+    title?: unknown
+    body?: unknown
+    decision?: unknown
+  }
+
+  if (typeof title !== "string" || title.trim().length < 3 || title.trim().length > 80) {
+    return NextResponse.json({ error: "Invalid title" }, { status: 400 })
+  }
+
+  if (typeof templateBody !== "string" || templateBody.trim().length < 10 || templateBody.trim().length > 3000) {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 })
+  }
+
+  if (typeof decision !== "string" || !["approved", "denied", "closed"].includes(decision)) {
     return NextResponse.json({ error: "Invalid decision" }, { status: 400 })
   }
 
@@ -68,8 +58,8 @@ export async function POST(
     .from("moderation_decision_templates")
     .insert({
       server_id: serverId,
-      title,
-      body,
+      title: title.trim(),
+      body: templateBody.trim(),
       decision,
       created_by: auth.user.id,
     })

--- a/apps/web/app/api/servers/[serverId]/appeals/route.ts
+++ b/apps/web/app/api/servers/[serverId]/appeals/route.ts
@@ -1,48 +1,26 @@
 import { NextRequest, NextResponse } from "next/server"
-import { createServerSupabaseClient } from "@/lib/supabase/server"
-import { aggregateMemberPermissions } from "@/lib/server-auth"
+import { APPEAL_STATUSES, isValidAppealStatus } from "@/lib/appeals"
+import { requireModerator } from "@/lib/moderation-auth"
 
-const BAN_MEMBERS = 16
-const ADMINISTRATOR = 128
-
-function canModerate(permissions: number) {
-  return (permissions & BAN_MEMBERS) !== 0 || (permissions & ADMINISTRATOR) !== 0
-}
+const TRIAGE_STATUSES = APPEAL_STATUSES.filter((status) => status === "submitted" || status === "reviewing")
 
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ serverId: string }> }
 ) {
   const { serverId } = await params
-  const supabase = await createServerSupabaseClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-
-  const { data: member } = await supabase
-    .from("server_members")
-    .select("member_roles(roles(permissions))")
-    .eq("server_id", serverId)
-    .eq("user_id", user.id)
-    .maybeSingle()
-
-  const permissions = aggregateMemberPermissions((member as any)?.member_roles)
-  if (!canModerate(permissions)) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
-  }
+  const auth = await requireModerator(serverId)
+  if (auth.error) return auth.error
 
   const status = new URL(req.url).searchParams.get("status")
-  const statuses = ["submitted", "reviewing", "approved", "denied", "closed"]
-  const query = (supabase as any)
+  const query = (auth.supabase as any)
     .from("moderation_appeals")
     .select("id, user_id, status, submitted_at, assigned_reviewer_id, anti_abuse_score")
     .eq("server_id", serverId)
     .order("submitted_at", { ascending: true })
 
-  if (status && statuses.includes(status)) query.eq("status", status)
-  else query.in("status", ["submitted", "reviewing"])
+  if (status && isValidAppealStatus(status)) query.eq("status", status)
+  else query.in("status", TRIAGE_STATUSES)
 
   const { data, error } = await query
 

--- a/apps/web/app/appeals/page.tsx
+++ b/apps/web/app/appeals/page.tsx
@@ -58,14 +58,14 @@ export default function AppealsPage() {
       <p className="mt-2 text-sm text-zinc-300">Submit one active appeal per server and track review status.</p>
 
       <section className="mt-6 rounded-lg border border-zinc-700 bg-zinc-900 p-4">
-        <label className="block text-sm mb-2">Server ID</label>
-        <input className="w-full rounded bg-zinc-800 p-2 mb-3" value={serverId} onChange={(e) => setServerId(e.target.value)} />
+        <label htmlFor="serverId" className="block text-sm mb-2">Server ID</label>
+        <input id="serverId" className="w-full rounded bg-zinc-800 p-2 mb-3" value={serverId} onChange={(e) => setServerId(e.target.value)} />
 
-        <label className="block text-sm mb-2">Statement (min 20 chars)</label>
-        <textarea className="w-full rounded bg-zinc-800 p-2 mb-3 min-h-32" value={statement} onChange={(e) => setStatement(e.target.value)} />
+        <label htmlFor="statement" className="block text-sm mb-2">Statement (min 20 chars)</label>
+        <textarea id="statement" className="w-full rounded bg-zinc-800 p-2 mb-3 min-h-32" value={statement} onChange={(e) => setStatement(e.target.value)} />
 
-        <label className="block text-sm mb-2">Evidence attachments (one URL per line)</label>
-        <textarea className="w-full rounded bg-zinc-800 p-2 mb-4 min-h-24" value={evidence} onChange={(e) => setEvidence(e.target.value)} />
+        <label htmlFor="evidence" className="block text-sm mb-2">Evidence attachments (one URL per line)</label>
+        <textarea id="evidence" className="w-full rounded bg-zinc-800 p-2 mb-4 min-h-24" value={evidence} onChange={(e) => setEvidence(e.target.value)} />
 
         <button className="rounded bg-indigo-600 px-4 py-2 text-sm" onClick={submitAppeal}>Submit appeal</button>
 

--- a/apps/web/lib/appeals.ts
+++ b/apps/web/lib/appeals.ts
@@ -1,6 +1,8 @@
 export const APPEAL_STATUSES = ["submitted", "reviewing", "approved", "denied", "closed"] as const
 export type AppealStatus = (typeof APPEAL_STATUSES)[number]
 
+const TERMINAL_APPEAL_STATUSES: AppealStatus[] = ["approved", "denied", "closed"]
+
 const allowedTransitions: Record<AppealStatus, AppealStatus[]> = {
   submitted: ["reviewing", "closed"],
   reviewing: ["approved", "denied", "closed"],
@@ -13,27 +15,49 @@ export function isValidAppealStatus(status: string): status is AppealStatus {
   return APPEAL_STATUSES.includes(status as AppealStatus)
 }
 
-export function isValidAppealTransition(from: AppealStatus, to: AppealStatus) {
-  return allowedTransitions[from].includes(to)
+export function isValidAppealTransition(from: AppealStatus, to: AppealStatus): boolean {
+  return (allowedTransitions[from] ?? []).includes(to)
+}
+
+function containsBadPattern(statement: string): boolean {
+  return /(unban me now|free nitro|http:\/\/|\.ru\b|discord\.gift)/i.test(statement)
+}
+
+export function isTerminalAppealStatus(status: AppealStatus): boolean {
+  return TERMINAL_APPEAL_STATUSES.includes(status)
 }
 
 export function computeAntiAbuseScore(input: {
   statement: string
   evidenceAttachments: string[]
   recentAppealCount: number
-}) {
+  isRepeatOffender?: boolean
+  accountAgeDays?: number
+}): number {
   let score = 0
   if (input.statement.length < 80) score += 15
   if (input.statement.length > 2000) score += 10
   if (input.evidenceAttachments.length > 8) score += 25
   if (input.recentAppealCount > 2) score += 30
+  if (input.isRepeatOffender) score += 20
+  if (typeof input.accountAgeDays === "number" && input.accountAgeDays < 3) score += 10
+  if (containsBadPattern(input.statement)) score += 15
   return Math.min(100, score)
 }
 
 export function sanitizeEvidenceAttachments(raw: unknown): string[] {
   if (!Array.isArray(raw)) return []
+
   return raw
     .map((item) => (typeof item === "string" ? item.trim() : ""))
-    .filter(Boolean)
+    .filter((item) => Boolean(item) && item.length <= 2000)
+    .filter((item) => {
+      try {
+        const parsed = new URL(item)
+        return parsed.protocol === "https:" || parsed.protocol === "http:"
+      } catch {
+        return false
+      }
+    })
     .slice(0, 10)
 }

--- a/apps/web/lib/moderation-auth.ts
+++ b/apps/web/lib/moderation-auth.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { aggregateMemberPermissions } from "@/lib/server-auth"
+
+export const BAN_MEMBERS = 16
+export const ADMINISTRATOR = 128
+
+export function canModerate(permissions: number): boolean {
+  return (permissions & BAN_MEMBERS) !== 0 || (permissions & ADMINISTRATOR) !== 0
+}
+
+export async function requireModerator(serverId: string) {
+  const supabase = await createServerSupabaseClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return {
+      error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+      user: null,
+      supabase,
+      permissions: 0,
+    }
+  }
+
+  const { data: member } = await supabase
+    .from("server_members")
+    .select("member_roles(roles(permissions))")
+    .eq("server_id", serverId)
+    .eq("user_id", user.id)
+    .maybeSingle()
+
+  const permissions = aggregateMemberPermissions((member as any)?.member_roles)
+  if (!canModerate(permissions)) {
+    return {
+      error: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+      user: null,
+      supabase,
+      permissions,
+    }
+  }
+
+  return { error: null, user, supabase, permissions }
+}

--- a/supabase/migrations/00017_appeals.sql
+++ b/supabase/migrations/00017_appeals.sql
@@ -1,11 +1,19 @@
 -- Appeal workflow for moderation bans.
 
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
 CREATE TABLE IF NOT EXISTS public.moderation_appeals (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  server_id UUID NOT NULL REFERENCES public.servers(id) ON DELETE CASCADE,
-  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
-  ban_server_id UUID NOT NULL,
-  ban_user_id UUID NOT NULL,
+  server_id UUID NOT NULL,
+  user_id UUID NOT NULL,
   linked_action TEXT NOT NULL DEFAULT 'member_ban',
   appellant_statement TEXT NOT NULL CHECK (char_length(appellant_statement) BETWEEN 20 AND 4000),
   evidence_attachments JSONB NOT NULL DEFAULT '[]'::jsonb,
@@ -18,11 +26,16 @@ CREATE TABLE IF NOT EXISTS public.moderation_appeals (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   closed_at TIMESTAMPTZ,
   CONSTRAINT moderation_appeals_ban_fk
-    FOREIGN KEY (ban_server_id, ban_user_id)
+    FOREIGN KEY (server_id, user_id)
     REFERENCES public.server_bans(server_id, user_id)
-    ON DELETE CASCADE,
-  CONSTRAINT moderation_appeals_same_subject CHECK (server_id = ban_server_id AND user_id = ban_user_id)
+    ON DELETE CASCADE
 );
+
+DROP TRIGGER IF EXISTS moderation_appeals_set_updated_at ON public.moderation_appeals;
+CREATE TRIGGER moderation_appeals_set_updated_at
+  BEFORE UPDATE ON public.moderation_appeals
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at();
 
 CREATE UNIQUE INDEX IF NOT EXISTS moderation_appeals_open_unique_idx
   ON public.moderation_appeals(server_id, user_id)
@@ -94,16 +107,8 @@ CREATE POLICY "Server moderators can view appeals"
 
 -- Inserts/updates are expected via API + service-role.
 
-CREATE POLICY "Moderators can view decision templates"
-  ON public.moderation_decision_templates FOR SELECT
-  USING (public.has_permission(server_id, 16) OR public.has_permission(server_id, 128));
-
 CREATE POLICY "Moderators can manage decision templates"
   ON public.moderation_decision_templates FOR ALL
-  USING (public.has_permission(server_id, 16) OR public.has_permission(server_id, 128));
-
-CREATE POLICY "Moderators can view internal notes"
-  ON public.moderation_appeal_internal_notes FOR SELECT
   USING (public.has_permission(server_id, 16) OR public.has_permission(server_id, 128));
 
 CREATE POLICY "Moderators can manage internal notes"


### PR DESCRIPTION
### Motivation
- Introduce a structured appeal workflow so banned users can submit appeals and moderators can triage, decide, and document outcomes while preserving privacy and least-privilege access.
- Ensure every appeal status change is auditable and linked to moderation timelines to satisfy compliance and reviewer accountability requirements.
- Apply guardrails (rate limits, duplicate prevention, anti-abuse scoring, sanitized evidence) to reduce abuse and automated spam of the appeals channel.

### Description
- Add DB migration `00017_appeals.sql` creating `moderation_appeals`, `moderation_appeal_status_events`, `moderation_appeal_internal_notes`, and `moderation_decision_templates` with RLS policies and a unique index preventing concurrent open appeals per user/server.
- Add shared appeal logic in `apps/web/lib/appeals.ts` implementing the status enum/transition model, anti-abuse scoring, and evidence sanitization.
- Implement public-safe user APIs in `apps/web/app/api/appeals/route.ts` allowing banned users to submit and list their appeals with rate limiting, ban-link verification, duplicate checks, anti-abuse scoring, status-event writes, audit-log linkage, and notifications.
- Implement moderator APIs: triage listing in `apps/web/app/api/servers/[serverId]/appeals/route.ts` and decision-template management in `apps/web/app/api/servers/[serverId]/appeal-templates/route.ts`, both gated by moderator permissions.
- Implement per-appeal endpoint `apps/web/app/api/appeals/[appealId]/route.ts` supporting owner/moderator read semantics, reviewer assignment, internal notes, validated state transitions, decision metadata, status-event logging, audit-log writes, and notifications to both users and moderators.
- Add a simple public UI at `/appeals` for submission and tracking, plus unit tests covering state transitions and anti-abuse/payload boundaries.

### Testing
- Ran unit tests with `npm --workspace apps/web run test -- appeals-state appeals-auth` and observed all tests pass (`7 passed`).
- Performed TypeScript checks with `npm --workspace apps/web run type-check` and the type-check completed successfully.
- All automated test runs mentioned above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bdad519448325978bde3541bb7c06)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now submit ban appeals with statements and evidence attachments
  * Appeal tracking with status updates throughout the review process
  * Moderators can review and manage appeals with customizable decision templates
  * Built-in rate limiting and anti-abuse protections
  
* **Tests**
  * Added comprehensive test coverage for appeal validation and state transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->