### PR TITLE
Refactor message destructive flows for native confirmations and keyboard usability

### DIFF
--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -53,6 +53,12 @@ export function MessageItem({
       await onDelete()
       toast({ title: "Message deleted", description: "The message was removed for everyone in this channel." })
       setShowDeleteDialog(false)
+    } catch (error: any) {
+      toast({
+        variant: "destructive",
+        title: "Could not delete message",
+        description: error?.message ?? "Please try again.",
+      })
     } finally {
       setIsDeleting(false)
     }
@@ -83,6 +89,8 @@ export function MessageItem({
   }
 
   function handleMessageKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return
+
     if ((event.target as HTMLElement).closest("button, textarea, input, a")) {
       return
     }
@@ -224,6 +232,7 @@ export function MessageItem({
           tabIndex={0}
           role="group"
           aria-label={`Message from ${displayName}. Press R to reply${isOwn ? ", E to edit, and Delete to delete" : ""}.`}
+          aria-keyshortcuts={isOwn ? "R, E, Delete" : "R"}
         >
           {/* Reply reference */}
           {message.reply_to_id && message.reply_to && (
@@ -522,10 +531,12 @@ export function MessageItem({
       onOpenChange={setShowDeleteDialog}
       title="Delete this message?"
       description="This removes the message from the channel for everyone. Attachments and replies linked to it may become harder to follow."
-      confirmLabel="Delete message"
-      emphasizeRiskLabel="I understand this action cannot be undone."
+      confirmLabel="Delete for everyone"
+      cancelLabel="Keep message"
+      emphasizeRiskLabel="I understand this can’t be undone."
       entitySummary={message.content ?? "(No text content)"}
       isLoading={isDeleting}
+      loadingLabel="Deleting message…"
       onConfirm={confirmDelete}
     />
     </>

--- a/apps/web/components/modals/confirm-action-dialog.tsx
+++ b/apps/web/components/modals/confirm-action-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { AlertTriangle } from "lucide-react"
 import {
   Dialog,
@@ -22,6 +22,7 @@ interface ConfirmActionDialogProps {
   emphasizeRiskLabel?: string
   entitySummary?: string
   isLoading?: boolean
+  loadingLabel?: string
   onConfirm: () => Promise<void> | void
 }
 
@@ -35,6 +36,7 @@ export function ConfirmActionDialog({
   emphasizeRiskLabel,
   entitySummary,
   isLoading = false,
+  loadingLabel = "Deleting…",
   onConfirm,
 }: ConfirmActionDialogProps) {
   const [riskConfirmed, setRiskConfirmed] = useState(false)
@@ -45,20 +47,29 @@ export function ConfirmActionDialog({
     }
   }, [open])
 
-  const canConfirm = useMemo(
-    () => !isLoading && (emphasizeRiskLabel ? riskConfirmed : true),
-    [emphasizeRiskLabel, isLoading, riskConfirmed]
-  )
+  const canConfirm = !isLoading && (emphasizeRiskLabel ? riskConfirmed : true)
+  const cancelRef = useRef<HTMLButtonElement | null>(null)
 
   async function handleConfirm() {
     if (!canConfirm) return
     await onConfirm()
-    onOpenChange(false)
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md border border-red-500/20 bg-[#1e1f22] text-[#f2f3f5] shadow-2xl shadow-black/40 data-[state=open]:duration-300 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-top-[46%]">
+    <Dialog open={open} onOpenChange={(nextOpen) => { if (!isLoading) onOpenChange(nextOpen) }}>
+      <DialogContent
+        className="max-w-md border border-red-500/20 bg-[#1e1f22] text-[#f2f3f5] shadow-2xl shadow-black/40 data-[state=open]:duration-300 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-top-[46%]"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          cancelRef.current?.focus()
+        }}
+        onEscapeKeyDown={(event) => {
+          if (isLoading) event.preventDefault()
+        }}
+        onPointerDownOutside={(event) => {
+          if (isLoading) event.preventDefault()
+        }}
+      >
         <DialogHeader className="gap-2">
           <div className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-red-500/15 text-red-300">
             <AlertTriangle className="h-5 w-5" />
@@ -91,6 +102,7 @@ export function ConfirmActionDialog({
             className="text-[#b5bac1] hover:bg-white/10 hover:text-white"
             onClick={() => onOpenChange(false)}
             disabled={isLoading}
+            ref={cancelRef}
           >
             {cancelLabel}
           </Button>
@@ -100,7 +112,7 @@ export function ConfirmActionDialog({
             onClick={handleConfirm}
             disabled={!canConfirm}
           >
-            {isLoading ? "Deleting…" : confirmLabel}
+            {isLoading ? loadingLabel : confirmLabel}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
### Motivation
- Remove browser-native `window.confirm` usage and replace it with an in-app, product-integrated confirmation flow to keep destructive UX consistent with the app styling and interaction model. 
- Close accessibility and keyboard-first workflow gaps by making message rows focusable and discoverable by assistive tech. 
- Reduce accidental deletions with clearer copy and explicit acknowledgement of destructive actions.

### Description
- Added a reusable `ConfirmActionDialog` component at `apps/web/components/modals/confirm-action-dialog.tsx` that supports title/description, `entitySummary`, an optional risk-acknowledgement checkbox, loading state and disabled confirm behavior. 
- Replaced `window.confirm(...)` in `apps/web/components/chat/message-item.tsx` with the new `ConfirmActionDialog` and improved deletion copy to: `"Delete this message?"` and `"This removes the message from the channel for everyone. Attachments and replies linked to it may become harder to follow."`. 
- Introduced keyboard-first interactions and accessibility improvements in `MessageItem`: message rows are `tabIndex={0}`, use `role="group"`, provide an `aria-label`, show action controls on `focus` (not only hover), and added shortcuts `R` = reply, `E` = edit (own messages) and `Delete` = open delete confirmation. 
- Added interaction polish such as action toolbar entrance animation classes, explicit `aria-label`s on action buttons, contextual message preview in the dialog, and a toast confirmation on successful delete.

### Testing
- Ran type checking with `npm run -w apps/web type-check`, which completed successfully. 
- Attempted targeted unit test `npm run -w apps/web test -- message-item` which exited with "No test files found" for that filter and therefore did not run tests for the component. 
- Ran an existing test file via `npm run -w apps/web test -- voice-audio-settings.test.ts` which passed (`1 file, 6 tests`). 
- Launched the local dev server via `npm run -w apps/web dev` for visual validation and produced a Playwright screenshot, noting runtime warnings about missing Supabase environment variables and Google Fonts fetch fallbacks during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699be5b9cc648325bfe640d20760ae2e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confirmation dialog for message deletion (optional risk acknowledgment) with loading state and success/error feedback
  * Keyboard shortcuts for message actions (R reply, E edit own messages, Delete to open delete confirmation)

* **Accessibility**
  * Improved ARIA labels, focus/blur handling, and visible focus-ring styling on message controls

* **UX**
  * Inline deletion flow, toast notifications, and enhanced animations/transitions for the action panel
<!-- end of auto-generated comment: release notes by coderabbit.ai -->