### PR TITLE
Polish destructive confirmation UX and keyboard-first message interactions

### DIFF
--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -53,12 +53,13 @@ export function MessageItem({
       await onDelete()
       toast({ title: "Message deleted", description: "The message was removed for everyone in this channel." })
       setShowDeleteDialog(false)
-    } catch {
+    } catch (error) {
       toast({
         title: "Could not delete message",
         description: "Please try again. If this keeps happening, refresh and retry.",
         variant: "destructive",
       })
+      throw error
     } finally {
       setIsDeleting(false)
     }

--- a/apps/web/components/modals/confirm-action-dialog.tsx
+++ b/apps/web/components/modals/confirm-action-dialog.tsx
@@ -47,8 +47,12 @@ export function ConfirmActionDialog({
 
   async function handleConfirm() {
     if (!canConfirm) return
-    await onConfirm()
-    onOpenChange(false)
+    try {
+      await onConfirm()
+      onOpenChange(false)
+    } catch {
+      // Keep dialog open so users can retry when the action fails.
+    }
   }
 
   return (
@@ -70,8 +74,12 @@ export function ConfirmActionDialog({
           </div>
 
           {acknowledgeRiskLabel && (
-            <label className="mt-4 flex items-start gap-2 rounded-md border border-white/10 bg-black/20 p-3 text-sm text-[#dcddde]">
+            <label
+              htmlFor="confirm-action-risk-ack"
+              className="mt-4 flex items-start gap-2 rounded-md border border-white/10 bg-black/20 p-3 text-sm text-[#dcddde]"
+            >
               <input
+                id="confirm-action-risk-ack"
                 type="checkbox"
                 className="mt-1 h-4 w-4 accent-red-500"
                 checked={riskAcknowledged}


### PR DESCRIPTION
### Motivation
- Replace browser-native `window.confirm` with an accessible, product-integrated confirmation flow that has proper destructive semantics and consistent styling. 
- Improve keyboard-first and assistive workflows for message rows so actions are discoverable and operable without a mouse. 
- Make deletion resilient by surfacing failures and preventing silent errors during destructive operations.

### Description
- Added `ConfirmActionDialog` at `apps/web/components/modals/confirm-action-dialog.tsx` implemented with `@radix-ui/react-alert-dialog`, supporting `title`, `description`, `entitySummary`, optional risk-acknowledgement via `acknowledgeRiskLabel`, `isLoading`, and configurable `loadingLabel` props. 
- Replaced `window.confirm` in `apps/web/components/chat/message-item.tsx` with the new `ConfirmActionDialog`, wired `showDeleteDialog` and `isDeleting` state, and set the delete button/context-menu to open the modal. 
- Hardened the delete flow to await `onDelete()`, close the dialog on success, and show a destructive toast with recovery guidance on failure. 
- Improved keyboard and accessibility behaviors in `MessageItem` by importing `KeyboardEvent`, adding `onKeyDown`/keyboard shortcuts (`R`, `E`, `Delete`), `tabIndex`, `role`, `aria-label`, focus/blur handlers to show actions, and small action toolbar polish (animations and `aria-label`s).

### Testing
- Ran type checking with `npm run -w apps/web type-check`, which completed successfully. 
- Ran linter with `npm run -w apps/web lint`, which completed successfully. 
- Ran unit tests `npm run -w apps/web test -- voice-audio-settings.test.ts`, which passed (`1 file, 6 tests`). 
- Launched the dev server with `npm run -w apps/web dev -- --port 3000` for a manual smoke run and captured a Playwright screenshot; the server started but runtime rendering in this environment reported missing Supabase environment variables and Google Fonts fetch issues (dev server still started).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699be5b9cc648325bfe640d20760ae2e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcuts for message actions: R (Reply), E (Edit), Delete opens deletion flow
  * Confirmation modal for destructive actions with optional risk acknowledgment and loading state

* **Accessibility**
  * Improved keyboard navigation, focus handling, ARIA labels, and tabbable action controls

* **Style**
  * Smooth transitions and enhanced focus/visual feedback for action panels and buttons
<!-- end of auto-generated comment: release notes by coderabbit.ai -->