### PR TITLE
Unified moderation timeline: API, UI, audit-log extensions, and tests

### DIFF
--- a/apps/web/__tests__/moderation-timeline.test.ts
+++ b/apps/web/__tests__/moderation-timeline.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest"
+import {
+  applyTimelineFilters,
+  mapActionType,
+  paginateTimeline,
+  sortTimelineEvents,
+  type TimelineEvent,
+} from "@/lib/moderation-timeline"
+
+function makeEvent(index: number, overrides: Partial<TimelineEvent> = {}): TimelineEvent {
+  const createdAt = new Date(Date.UTC(2025, 0, 1, 12, 0, 0) + index * 1000).toISOString()
+  return {
+    id: `event-${index}`,
+    action: "member_ban",
+    action_type: mapActionType("member_ban"),
+    created_at: createdAt,
+    actor_id: index % 2 === 0 ? "actor-a" : "actor-b",
+    target_id: index % 3 === 0 ? "target-a" : "target-b",
+    target_type: "user",
+    reason: null,
+    metadata: null,
+    actor: null,
+    target: null,
+    incident_key: `incident-${Math.floor(index / 10)}`,
+    ...overrides,
+  }
+}
+
+describe("moderation timeline helpers", () => {
+  it("orders timeline events by created_at desc and id tie-break desc", () => {
+    const sameTime = new Date().toISOString()
+    const events = [
+      makeEvent(2, { created_at: sameTime, id: "a" }),
+      makeEvent(1, { created_at: sameTime, id: "z" }),
+      makeEvent(5, { created_at: "2025-01-01T00:00:00.000Z", id: "m" }),
+    ]
+
+    const sorted = sortTimelineEvents(events)
+    expect(sorted.map((e) => e.id)).toEqual(["z", "a", "m"])
+  })
+
+  it("applies actor/target/action/date range filters correctly", () => {
+    const events = [
+      makeEvent(1, { action: "member_ban", action_type: mapActionType("member_ban"), actor_id: "actor-1", target_id: "target-1", created_at: "2025-01-02T00:00:00.000Z" }),
+      makeEvent(2, { action: "member_kick", action_type: mapActionType("member_kick"), actor_id: "actor-2", target_id: "target-1", created_at: "2025-01-03T00:00:00.000Z" }),
+      makeEvent(3, { action: "automod_action", action_type: mapActionType("automod_action"), actor_id: "actor-1", target_id: "target-2", created_at: "2025-01-04T00:00:00.000Z" }),
+    ]
+
+    const filtered = applyTimelineFilters(events, {
+      actorId: "actor-1",
+      targetId: "target-2",
+      actionTypes: ["automod"],
+      from: "2025-01-04T00:00:00.000Z",
+      to: "2025-01-04T23:59:59.999Z",
+    })
+
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.id).toBe("event-3")
+  })
+
+  it("supports high-volume cursor pagination without duplicates", () => {
+    const events = Array.from({ length: 1200 }, (_, i) => makeEvent(i))
+
+    const seen = new Set<string>()
+    let cursor: { created_at: string; id: string } | null = null
+    let pageCount = 0
+
+    while (true) {
+      const { data, nextCursor } = paginateTimeline(events, 125, cursor)
+      for (const event of data) {
+        expect(seen.has(event.id)).toBe(false)
+        seen.add(event.id)
+      }
+
+      pageCount += 1
+      cursor = nextCursor
+      if (!nextCursor) break
+    }
+
+    expect(seen.size).toBe(1200)
+    expect(pageCount).toBeGreaterThan(5)
+  })
+})

--- a/apps/web/app/api/servers/[serverId]/members/[userId]/roles/route.ts
+++ b/apps/web/app/api/servers/[serverId]/members/[userId]/roles/route.ts
@@ -53,6 +53,13 @@ export async function POST(
     }
   }
 
+  const { data: roleData } = await supabase
+    .from("roles")
+    .select("id, name")
+    .eq("id", roleId)
+    .eq("server_id", serverId)
+    .single()
+
   const { error } = await supabase
     .from("member_roles")
     .insert({ server_id: serverId, user_id: userId, role_id: roleId })
@@ -61,6 +68,20 @@ export async function POST(
     if (error.code === "23505") return NextResponse.json({ ok: true }) // already assigned
     return NextResponse.json({ error: error.message }, { status: 500 })
   }
+
+  await supabase.from("audit_logs").insert({
+    server_id: serverId,
+    actor_id: user.id,
+    action: "role_assigned",
+    target_id: userId,
+    target_type: "user",
+    changes: {
+      role_id: roleId,
+      role_name: roleData?.name ?? null,
+      before: { has_role: false },
+      after: { has_role: true },
+    },
+  })
 
   return NextResponse.json({ ok: true })
 }
@@ -109,5 +130,27 @@ export async function DELETE(
     .eq("role_id", roleId)
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  const { data: roleData } = await supabase
+    .from("roles")
+    .select("id, name")
+    .eq("id", roleId)
+    .eq("server_id", serverId)
+    .single()
+
+  await supabase.from("audit_logs").insert({
+    server_id: serverId,
+    actor_id: user.id,
+    action: "role_removed",
+    target_id: userId,
+    target_type: "user",
+    changes: {
+      role_id: roleId,
+      role_name: roleData?.name ?? null,
+      before: { has_role: true },
+      after: { has_role: false },
+    },
+  })
+
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/app/api/servers/[serverId]/moderation/timeline/route.ts
+++ b/apps/web/app/api/servers/[serverId]/moderation/timeline/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import {
+  applyTimelineFilters,
+  deriveIncidentKey,
+  mapActionType,
+  paginateTimeline,
+  timelineToCsv,
+  type TimelineActionType,
+  type TimelineCursor,
+  type TimelineEvent,
+} from "@/lib/moderation-timeline"
+
+function parseActionTypes(raw: string | null): TimelineActionType[] {
+  if (!raw) return []
+  return raw
+    .split(",")
+    .map((token) => token.trim())
+    .filter(Boolean)
+    .filter((token): token is TimelineActionType =>
+      ["ban", "kick", "timeout", "message_action", "automod", "appeal", "role_change", "settings", "other"].includes(token)
+    )
+}
+
+function parseCursor(raw: string | null): TimelineCursor | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8")) as TimelineCursor
+    if (!parsed?.created_at || !parsed?.id) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function encodeCursor(cursor: TimelineCursor | null): string | null {
+  if (!cursor) return null
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url")
+}
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ serverId: string }> }) {
+  const { serverId } = await params
+  const supabase = await createServerSupabaseClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { data: server } = await supabase
+    .from("servers")
+    .select("owner_id")
+    .eq("id", serverId)
+    .single()
+
+  if (server?.owner_id !== user.id) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+  const { searchParams } = new URL(req.url)
+  const limit = Math.min(Math.max(parseInt(searchParams.get("limit") ?? "50", 10), 1), 200)
+  const cursor = parseCursor(searchParams.get("cursor"))
+
+  const filters = {
+    actorId: searchParams.get("actor_id"),
+    targetId: searchParams.get("target_id"),
+    actionTypes: parseActionTypes(searchParams.get("action_types")),
+    from: searchParams.get("from"),
+    to: searchParams.get("to"),
+  }
+
+  // Reuse existing audit_logs as the primary data source.
+  const { data: logs, error } = await supabase
+    .from("audit_logs")
+    .select("id, action, actor_id, target_id, target_type, changes, created_at")
+    .eq("server_id", serverId)
+    .order("created_at", { ascending: false })
+    .order("id", { ascending: false })
+    .limit(5000)
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  const entries: TimelineEvent[] = (logs ?? []).map((log) => {
+    const metadata = (log.changes ?? null) as Record<string, unknown> | null
+    const action_type = mapActionType(log.action)
+    const base = {
+      id: log.id,
+      action: log.action,
+      action_type,
+      created_at: log.created_at,
+      actor_id: log.actor_id,
+      target_id: log.target_id,
+      target_type: log.target_type,
+      reason: (metadata?.reason as string | undefined) ?? null,
+      metadata,
+      actor: null,
+      target: null,
+    } satisfies Omit<TimelineEvent, "incident_key">
+
+    return {
+      ...base,
+      incident_key: deriveIncidentKey({
+        action_type,
+        target_id: base.target_id,
+        metadata,
+        created_at: base.created_at,
+      }),
+    }
+  })
+
+  const filtered = applyTimelineFilters(entries, filters)
+  const { data: page, nextCursor } = paginateTimeline(filtered, limit, cursor)
+
+  const userIds = new Set<string>()
+  for (const event of page) {
+    if (event.actor_id) userIds.add(event.actor_id)
+    if (event.target_id && event.target_type === "user") userIds.add(event.target_id)
+  }
+
+  let users: Array<{ id: string; username: string; display_name: string | null; avatar_url: string | null }> = []
+  if (userIds.size) {
+    const { data: fetchedUsers } = await supabase
+      .from("users")
+      .select("id, username, display_name, avatar_url")
+      .in("id", Array.from(userIds))
+    users = (fetchedUsers ?? []) as typeof users
+  }
+
+  const userMap = Object.fromEntries((users ?? []).map((row) => [row.id, row]))
+  const hydrated = page.map((event) => ({
+    ...event,
+    actor: event.actor_id ? userMap[event.actor_id] ?? null : null,
+    target: event.target_id && event.target_type === "user" ? userMap[event.target_id] ?? null : null,
+  }))
+
+  const format = (searchParams.get("format") ?? "json").toLowerCase()
+  if (format === "csv") {
+    const csv = timelineToCsv(hydrated)
+    return new NextResponse(csv, {
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="moderation-timeline-${serverId}.csv"`,
+      },
+    })
+  }
+
+  const grouped = hydrated.reduce<Record<string, TimelineEvent[]>>((acc, event) => {
+    if (!acc[event.incident_key]) acc[event.incident_key] = []
+    acc[event.incident_key].push(event)
+    return acc
+  }, {})
+
+  return NextResponse.json({
+    data: hydrated,
+    incidents: Object.entries(grouped).map(([incident_key, incidentEvents]) => ({
+      incident_key,
+      count: incidentEvents.length,
+      started_at: incidentEvents[incidentEvents.length - 1]?.created_at ?? null,
+      latest_at: incidentEvents[0]?.created_at ?? null,
+      events: incidentEvents,
+    })),
+    next_cursor: encodeCursor(nextCursor),
+  })
+}

--- a/apps/web/app/channels/[serverId]/moderation/page.tsx
+++ b/apps/web/app/channels/[serverId]/moderation/page.tsx
@@ -1,0 +1,25 @@
+import { redirect, notFound } from "next/navigation"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { ModerationTimeline } from "@/components/moderation/moderation-timeline"
+
+export default async function ModerationTimelinePage({ params: paramsPromise }: { params: Promise<{ serverId: string }> }) {
+  const { serverId } = await paramsPromise
+  const supabase = await createServerSupabaseClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect("/login")
+
+  const { data: member } = await supabase
+    .from("server_members")
+    .select("server_id")
+    .eq("server_id", serverId)
+    .eq("user_id", user.id)
+    .single()
+
+  if (!member) notFound()
+
+  return (
+    <main className="flex-1 overflow-y-auto bg-zinc-950">
+      <ModerationTimeline serverId={serverId} />
+    </main>
+  )
+}

--- a/apps/web/app/channels/[serverId]/moderation/target/[targetId]/page.tsx
+++ b/apps/web/app/channels/[serverId]/moderation/target/[targetId]/page.tsx
@@ -1,0 +1,49 @@
+import { redirect, notFound } from "next/navigation"
+import Link from "next/link"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { mapActionType } from "@/lib/moderation-timeline"
+
+export default async function TargetModerationTimelinePage({ params: paramsPromise }: { params: Promise<{ serverId: string; targetId: string }> }) {
+  const { serverId, targetId } = await paramsPromise
+  const supabase = await createServerSupabaseClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect("/login")
+
+  const { data: member } = await supabase
+    .from("server_members")
+    .select("server_id")
+    .eq("server_id", serverId)
+    .eq("user_id", user.id)
+    .single()
+
+  if (!member) notFound()
+
+  const { data: entries } = await supabase
+    .from("audit_logs")
+    .select("id, action, created_at, changes")
+    .eq("server_id", serverId)
+    .eq("target_id", targetId)
+    .order("created_at", { ascending: false })
+    .limit(100)
+
+  return (
+    <main className="flex-1 overflow-y-auto bg-zinc-950 p-6 text-zinc-100">
+      <div className="mb-4">
+        <h1 className="text-xl font-semibold">Target Timeline</h1>
+        <p className="text-sm text-zinc-400">User: {targetId}</p>
+        <Link className="text-sm text-sky-400" href={`/channels/${serverId}/moderation`}>Back to full moderation timeline</Link>
+      </div>
+      <div className="space-y-2">
+        {(entries ?? []).map((entry) => (
+          <article key={entry.id} className="rounded border border-zinc-800 bg-zinc-900/50 p-3">
+            <p className="text-sm font-medium">{entry.action} · {mapActionType(entry.action)}</p>
+            <p className="text-xs text-zinc-400">{new Date(entry.created_at).toLocaleString()}</p>
+            {((entry.changes as Record<string, unknown> | null)?.reason as string | undefined) && (
+              <p className="text-xs text-zinc-300 mt-1">Reason: {String((entry.changes as Record<string, unknown>).reason)}</p>
+            )}
+          </article>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/apps/web/components/moderation/moderation-timeline.tsx
+++ b/apps/web/components/moderation/moderation-timeline.tsx
@@ -1,0 +1,209 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { format } from "date-fns"
+import { ChevronDown, ChevronRight, Download, Filter, Loader2, ShieldAlert, User } from "lucide-react"
+import { buildDiffRows, type TimelineActionType } from "@/lib/moderation-timeline"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+type EventActor = { id: string; username: string; display_name: string | null; avatar_url: string | null }
+type TimelineEvent = {
+  id: string
+  action: string
+  action_type: TimelineActionType
+  created_at: string
+  reason: string | null
+  actor_id: string | null
+  target_id: string | null
+  target_type: string | null
+  metadata: Record<string, unknown> | null
+  actor: EventActor | null
+  target: EventActor | null
+  incident_key: string
+}
+
+type TimelinePayload = {
+  data: TimelineEvent[]
+  incidents: Array<{ incident_key: string; count: number; started_at: string | null; latest_at: string | null; events: TimelineEvent[] }>
+  next_cursor: string | null
+}
+
+const ACTION_TYPE_OPTIONS: TimelineActionType[] = ["ban", "kick", "timeout", "message_action", "automod", "appeal", "role_change", "settings", "other"]
+
+export function ModerationTimeline({ serverId }: { serverId: string }) {
+  const [events, setEvents] = useState<TimelineEvent[]>([])
+  const [incidents, setIncidents] = useState<TimelinePayload["incidents"]>([])
+  const [cursor, setCursor] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+  const [expandedIncidents, setExpandedIncidents] = useState<Record<string, boolean>>({})
+
+  const [actorId, setActorId] = useState("")
+  const [targetId, setTargetId] = useState("")
+  const [from, setFrom] = useState("")
+  const [to, setTo] = useState("")
+  const [actionTypes, setActionTypes] = useState<TimelineActionType[]>([])
+
+  const params = useMemo(() => {
+    const search = new URLSearchParams({ limit: "50" })
+    if (actorId) search.set("actor_id", actorId)
+    if (targetId) search.set("target_id", targetId)
+    if (from) search.set("from", new Date(from).toISOString())
+    if (to) search.set("to", new Date(to).toISOString())
+    if (actionTypes.length) search.set("action_types", actionTypes.join(","))
+    return search
+  }, [actionTypes, actorId, from, targetId, to])
+
+  const load = useCallback(async (append = false) => {
+    setLoading(true)
+    const search = new URLSearchParams(params)
+    if (append && cursor) search.set("cursor", cursor)
+
+    const res = await fetch(`/api/servers/${serverId}/moderation/timeline?${search.toString()}`)
+    if (!res.ok) {
+      setLoading(false)
+      return
+    }
+
+    const payload = (await res.json()) as TimelinePayload
+    setEvents((prev) => (append ? [...prev, ...payload.data] : payload.data))
+    setIncidents((prev) => (append ? [...prev, ...payload.incidents] : payload.incidents))
+    setCursor(payload.next_cursor)
+    setLoading(false)
+  }, [cursor, params, serverId])
+
+  useEffect(() => {
+    void load(false)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const onToggleActionType = (actionType: TimelineActionType) => {
+    setActionTypes((prev) => (prev.includes(actionType) ? prev.filter((item) => item !== actionType) : [...prev, actionType]))
+  }
+
+  const exportFile = async (formatType: "json" | "csv") => {
+    const search = new URLSearchParams(params)
+    search.set("limit", "200")
+    search.set("format", formatType)
+    const res = await fetch(`/api/servers/${serverId}/moderation/timeline?${search.toString()}`)
+    if (!res.ok) return
+
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = `moderation-timeline.${formatType}`
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <section className="p-6 text-zinc-100 space-y-4">
+      <header className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">Moderation Timeline</h1>
+          <p className="text-sm text-zinc-400">Unified timeline across bans, kicks, timeouts, automod, appeals, messages, and role changes.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={() => exportFile("json")}><Download className="w-4 h-4 mr-1" />Export JSON</Button>
+          <Button variant="outline" onClick={() => exportFile("csv")}><Download className="w-4 h-4 mr-1" />Export CSV</Button>
+        </div>
+      </header>
+
+      <div className="rounded-md border border-zinc-800 bg-zinc-900/40 p-4 space-y-3">
+        <div className="flex items-center gap-2 text-sm text-zinc-300"><Filter className="w-4 h-4" /> Filters</div>
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-2">
+          <Input placeholder="Actor user id" value={actorId} onChange={(e) => setActorId(e.target.value)} />
+          <Input placeholder="Target user id" value={targetId} onChange={(e) => setTargetId(e.target.value)} />
+          <Input type="datetime-local" value={from} onChange={(e) => setFrom(e.target.value)} />
+          <Input type="datetime-local" value={to} onChange={(e) => setTo(e.target.value)} />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {ACTION_TYPE_OPTIONS.map((actionType) => (
+            <Button key={actionType} size="sm" variant={actionTypes.includes(actionType) ? "default" : "outline"} onClick={() => onToggleActionType(actionType)}>
+              {actionType}
+            </Button>
+          ))}
+        </div>
+        <Button onClick={() => load(false)} disabled={loading}>{loading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Apply filters"}</Button>
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-4">
+        <div className="space-y-3">
+          <h2 className="font-semibold">Timeline Events</h2>
+          {events.map((event) => {
+            const key = `event-${event.id}`
+            const isOpen = !!expanded[key]
+            const diffRows = buildDiffRows(event.metadata)
+            const actorName = event.actor?.display_name ?? event.actor?.username ?? event.actor_id ?? "system"
+            const targetName = event.target?.display_name ?? event.target?.username ?? event.target_id ?? "n/a"
+
+            return (
+              <article key={event.id} className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+                <button className="w-full text-left flex items-start justify-between gap-2" onClick={() => setExpanded((prev) => ({ ...prev, [key]: !isOpen }))}>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium truncate">{event.action} · {event.action_type}</p>
+                    <p className="text-xs text-zinc-400 truncate">{actorName} → {targetName}</p>
+                  </div>
+                  <span className="text-xs text-zinc-500 flex items-center gap-1">{isOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}{format(new Date(event.created_at), "MMM d, HH:mm")}</span>
+                </button>
+                {isOpen && (
+                  <div className="mt-3 text-sm space-y-2">
+                    {event.reason && <p className="text-zinc-300">Reason: {event.reason}</p>}
+                    <p className="text-zinc-400">Incident: {event.incident_key}</p>
+                    {diffRows.length > 0 && (
+                      <div className="rounded bg-zinc-950 p-2 border border-zinc-800">
+                        <p className="text-xs text-zinc-400 mb-1">Before / After</p>
+                        {diffRows.map((row) => (
+                          <div key={`${event.id}-${row.field}`} className="grid grid-cols-3 gap-2 text-xs py-0.5">
+                            <span className="text-zinc-400">{row.field}</span>
+                            <span className="text-red-300 break-all">{JSON.stringify(row.before)}</span>
+                            <span className="text-green-300 break-all">{JSON.stringify(row.after)}</span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </article>
+            )
+          })}
+          <Button onClick={() => load(true)} disabled={!cursor || loading}>{loading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Load more"}</Button>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="font-semibold">Incident View</h2>
+          {incidents.map((incident) => {
+            const open = !!expandedIncidents[incident.incident_key]
+            return (
+              <article key={incident.incident_key} className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+                <button className="w-full text-left flex items-center justify-between" onClick={() => setExpandedIncidents((prev) => ({ ...prev, [incident.incident_key]: !open }))}>
+                  <div>
+                    <p className="text-sm font-medium truncate">{incident.incident_key}</p>
+                    <p className="text-xs text-zinc-400">{incident.count} events</p>
+                  </div>
+                  {open ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                </button>
+                {open && (
+                  <ul className="mt-2 space-y-2">
+                    {incident.events.map((event) => (
+                      <li key={event.id} className="text-xs text-zinc-300 flex items-center gap-2">
+                        <ShieldAlert className="w-3 h-3" />
+                        <span>{event.action}</span>
+                        <span className="text-zinc-500">{format(new Date(event.created_at), "MMM d, HH:mm")}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </article>
+            )
+          })}
+          {incidents.length === 0 && <p className="text-sm text-zinc-500 flex items-center gap-2"><User className="w-4 h-4" />No incidents loaded yet.</p>}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/lib/moderation-timeline.ts
+++ b/apps/web/lib/moderation-timeline.ts
@@ -1,0 +1,182 @@
+export type TimelineActionType =
+  | "ban"
+  | "kick"
+  | "timeout"
+  | "message_action"
+  | "automod"
+  | "appeal"
+  | "role_change"
+  | "settings"
+  | "other"
+
+export interface TimelineActor {
+  id: string
+  username: string
+  display_name: string | null
+  avatar_url: string | null
+}
+
+export interface TimelineEvent {
+  id: string
+  action: string
+  action_type: TimelineActionType
+  created_at: string
+  actor_id: string | null
+  target_id: string | null
+  target_type: string | null
+  reason: string | null
+  metadata: Record<string, unknown> | null
+  actor: TimelineActor | null
+  target: TimelineActor | null
+  incident_key: string
+}
+
+export interface TimelineCursor {
+  created_at: string
+  id: string
+}
+
+export interface TimelineFilters {
+  actorId?: string | null
+  targetId?: string | null
+  actionTypes?: TimelineActionType[]
+  from?: string | null
+  to?: string | null
+}
+
+const ACTION_TYPE_MAP: Record<string, TimelineActionType> = {
+  member_ban: "ban",
+  member_kick: "kick",
+  member_timeout: "timeout",
+  member_timeout_remove: "timeout",
+  automod_block: "automod",
+  automod_action: "automod",
+  automod_timeout: "automod",
+  automod_alert: "automod",
+  automod_rule_created: "automod",
+  automod_rule_updated: "automod",
+  automod_rule_deleted: "automod",
+  appeal_status_changed: "appeal",
+  role_assigned: "role_change",
+  role_removed: "role_change",
+  moderation_settings_updated: "settings",
+  message_pin: "message_action",
+}
+
+function getStringRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+export function mapActionType(action: string): TimelineActionType {
+  return ACTION_TYPE_MAP[action] ?? "other"
+}
+
+export function deriveIncidentKey(event: Pick<TimelineEvent, "action_type" | "target_id" | "metadata" | "created_at">): string {
+  const metadata = getStringRecord(event.metadata)
+  const metadataIncident = metadata?.incident_id
+  if (typeof metadataIncident === "string" && metadataIncident) return metadataIncident
+
+  const target = event.target_id ?? "unknown-target"
+  const timeBucket = new Date(event.created_at)
+  const bucket = Number.isNaN(timeBucket.getTime()) ? "unknown-time" : Math.floor(timeBucket.getTime() / (1000 * 60 * 15))
+
+  const reasonKey = typeof metadata?.reason === "string" ? metadata.reason.toLowerCase().slice(0, 64) : "no-reason"
+
+  return `${event.action_type}:${target}:${reasonKey}:${bucket}`
+}
+
+export function applyTimelineFilters(events: TimelineEvent[], filters: TimelineFilters): TimelineEvent[] {
+  const actionTypes = filters.actionTypes?.length ? new Set(filters.actionTypes) : null
+  const fromMs = filters.from ? Date.parse(filters.from) : Number.NaN
+  const toMs = filters.to ? Date.parse(filters.to) : Number.NaN
+
+  return events.filter((event) => {
+    if (filters.actorId && event.actor_id !== filters.actorId) return false
+    if (filters.targetId && event.target_id !== filters.targetId) return false
+    if (actionTypes && !actionTypes.has(event.action_type)) return false
+
+    const createdMs = Date.parse(event.created_at)
+    if (!Number.isNaN(fromMs) && (Number.isNaN(createdMs) || createdMs < fromMs)) return false
+    if (!Number.isNaN(toMs) && (Number.isNaN(createdMs) || createdMs > toMs)) return false
+
+    return true
+  })
+}
+
+export function sortTimelineEvents(events: TimelineEvent[]): TimelineEvent[] {
+  return [...events].sort((a, b) => {
+    const timeA = Date.parse(a.created_at)
+    const timeB = Date.parse(b.created_at)
+    if (timeA !== timeB) return timeB - timeA
+    if (a.id === b.id) return 0
+    return a.id < b.id ? 1 : -1
+  })
+}
+
+export function paginateTimeline(events: TimelineEvent[], limit: number, cursor?: TimelineCursor | null): { data: TimelineEvent[]; nextCursor: TimelineCursor | null } {
+  const sorted = sortTimelineEvents(events)
+  const startIndex = cursor
+    ? sorted.findIndex((event) => event.created_at === cursor.created_at && event.id === cursor.id) + 1
+    : 0
+
+  const safeStart = Math.max(0, startIndex)
+  const page = sorted.slice(safeStart, safeStart + limit)
+  const last = page.at(-1)
+
+  return {
+    data: page,
+    nextCursor: last && safeStart + limit < sorted.length ? { created_at: last.created_at, id: last.id } : null,
+  }
+}
+
+export function buildDiffRows(metadata: Record<string, unknown> | null): Array<{ field: string; before: unknown; after: unknown }> {
+  if (!metadata) return []
+
+  const explicitBefore = getStringRecord(metadata.before)
+  const explicitAfter = getStringRecord(metadata.after)
+
+  if (explicitBefore || explicitAfter) {
+    const keys = new Set<string>([...Object.keys(explicitBefore ?? {}), ...Object.keys(explicitAfter ?? {})])
+    return Array.from(keys).map((key) => ({
+      field: key,
+      before: explicitBefore?.[key] ?? null,
+      after: explicitAfter?.[key] ?? null,
+    }))
+  }
+
+  const oldValue = getStringRecord(metadata.old)
+  const newValue = getStringRecord(metadata.new)
+  if (oldValue || newValue) {
+    const keys = new Set<string>([...Object.keys(oldValue ?? {}), ...Object.keys(newValue ?? {})])
+    return Array.from(keys).map((key) => ({
+      field: key,
+      before: oldValue?.[key] ?? null,
+      after: newValue?.[key] ?? null,
+    }))
+  }
+
+  return []
+}
+
+export function timelineToCsv(events: TimelineEvent[]): string {
+  const headers = ["id", "created_at", "action", "action_type", "actor_id", "target_id", "target_type", "reason", "incident_key"]
+  const rows = events.map((event) => [
+    event.id,
+    event.created_at,
+    event.action,
+    event.action_type,
+    event.actor_id ?? "",
+    event.target_id ?? "",
+    event.target_type ?? "",
+    event.reason ?? "",
+    event.incident_key,
+  ])
+
+  const escapeCsv = (value: string) => {
+    if (/[",\n]/.test(value)) return `"${value.replaceAll('"', '""')}"`
+    return value
+  }
+
+  return [headers, ...rows].map((line) => line.map((cell) => escapeCsv(String(cell))).join(",")).join("\n")
+}


### PR DESCRIPTION
### Motivation

- Provide a single, unified moderation timeline that surfaces bans, kicks, timeouts/mutes, message actions, automod hits, appeals, role changes, and settings changes in a consistent view.  
- Reuse and extend the existing `audit_logs` table as the canonical data source rather than replacing existing audit instrumentation.  
- Offer operator-friendly tooling: cursor pagination, advanced filters, incident grouping, diff visualization for changed state, and CSV/JSON export for compliance and investigations.

### Description

- Add shared timeline utilities in `apps/web/lib/moderation-timeline.ts` including action normalization, incident-key derivation, sorting, filtering, cursor pagination, diff row extraction, and CSV serialization.  
- Implement a new backend API endpoint at `GET /api/servers/[serverId]/moderation/timeline` that reuses `audit_logs`, supports cursor pagination (`cursor` / `next_cursor`), advanced filters (`actor_id`, `target_id`, `action_types`, `from`, `to`), incident grouping, and `format=csv|json` exports.  
- Add a moderation UI and pages in `apps/web/components/moderation/moderation-timeline.tsx` and `apps/web/app/channels/[serverId]/moderation` with expandable event cards, incident panel, target-centric timeline (`/moderation/target/[targetId]`), filter controls, and export buttons.  
- Extend audit logging for role assignment/removal endpoints to write `role_assigned` / `role_removed` entries with `before`/`after` metadata for diff rendering, and add unit tests covering ordering, filtering, and high-volume pagination behavior in `apps/web/__tests__/moderation-timeline.test.ts`.

### Testing

- Ran unit tests with `cd apps/web && npm run test`, and the suite passed (8 files, 49 tests).  
- Ran type checking with `cd apps/web && npm run type-check`, and `tsc --noEmit` succeeded with no type errors.  
- An attempt to run `vitest` with `--runInBand` failed because that option is not supported by this `vitest` version, but the tests executed normally with `npm run test` and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c6bba46208325adc06fb51e11ce32)