### PR TITLE
Replace native destructive confirms with product dialogs

### DIFF
--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -6,6 +6,8 @@ import { Reply, Edit2, Trash2, Smile, Clipboard, Hash, MessageSquare, AlertCircl
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { UserProfilePopover } from "@/components/user-profile-popover"
 import { ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem, ContextMenuSeparator } from "@/components/ui/context-menu"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
 import { useToast } from "@/components/ui/use-toast"
 import type { MessageWithAuthor, AttachmentRow, ThreadRow } from "@/types/database"
 import { cn } from "@/lib/utils/cn"
@@ -45,13 +47,13 @@ export function MessageItem({
   const [showActions, setShowActions] = useState(false)
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const [showCreateThread, setShowCreateThread] = useState(false)
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const { toast } = useToast()
   const isOwn = message.author_id === currentUserId
 
-  function confirmDelete() {
-    if (window.confirm("Are you sure you want to delete this message? This cannot be undone.")) {
-      onDelete()
-    }
+  async function confirmDelete() {
+    await onDelete()
+    setShowDeleteDialog(false)
   }
 
   const displayName =
@@ -445,7 +447,7 @@ export function MessageItem({
 
               {isOwn && (
                 <button
-                  onClick={confirmDelete}
+                  onClick={() => setShowDeleteDialog(true)}
                   className="w-8 h-8 flex items-center justify-center hover:bg-red-500/20 transition-colors"
                   style={{ color: "#f23f43" }}
                   title="Delete"
@@ -490,7 +492,7 @@ export function MessageItem({
         {isOwn && (
           <>
             <ContextMenuSeparator />
-            <ContextMenuItem variant="destructive" onClick={confirmDelete}>
+            <ContextMenuItem variant="destructive" onClick={() => setShowDeleteDialog(true)}>
               <Trash2 className="w-4 h-4 mr-2" /> Delete Message
             </ContextMenuItem>
           </>
@@ -509,6 +511,25 @@ export function MessageItem({
         }}
       />
     )}
+
+    <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+      <DialogContent style={{ background: "#313338", borderColor: "#1e1f22", color: "#f2f3f5" }}>
+        <DialogHeader>
+          <DialogTitle>Delete message?</DialogTitle>
+          <DialogDescription style={{ color: "#b5bac1" }}>
+            This action is irreversible. This message will be permanently removed for everyone in this channel.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="secondary" onClick={() => setShowDeleteDialog(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={confirmDelete}>
+            Delete message
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
     </>
   )
 }

--- a/apps/web/components/modals/server-settings-modal.tsx
+++ b/apps/web/components/modals/server-settings-modal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from "react"
 import { Loader2, Copy, RefreshCw, Trash2, Webhook, Smile, Plus, Check, Shield, ShieldCheck, Zap } from "lucide-react"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -947,6 +947,7 @@ function AutoModTab({ serverId, channels, open }: { serverId: string; channels: 
   const [form, setForm] = useState<AutoModRuleForm>(DEFAULT_FORM)
   const [sampleMessage, setSampleMessage] = useState("")
   const [saving, setSaving] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<AutoModRuleRow | null>(null)
 
   useEffect(() => {
     if (!open) return
@@ -1010,6 +1011,7 @@ function AutoModTab({ serverId, channels, open }: { serverId: string; channels: 
       setRules((prev) => prev.filter((r) => r.id !== ruleId))
       if (editingId === ruleId) setEditingId(null)
       toast({ title: "Rule deleted" })
+      setDeleteTarget(null)
     }
   }
 
@@ -1122,7 +1124,7 @@ function AutoModTab({ serverId, channels, open }: { serverId: string; channels: 
                 Edit
               </button>
               <button
-                onClick={() => handleDelete(rule.id)}
+                onClick={() => setDeleteTarget(rule)}
                 className="text-xs px-2 py-1 rounded hover:bg-red-500/20 transition-colors"
                 style={{ color: '#ed4245' }}
               >
@@ -1363,6 +1365,31 @@ function AutoModTab({ serverId, channels, open }: { serverId: string; channels: 
           </div>
         </div>
       )}
+
+      <Dialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>
+        <DialogContent style={{ background: '#313338', borderColor: '#1e1f22' }}>
+          <DialogHeader>
+            <DialogTitle className="text-white">Delete AutoMod rule?</DialogTitle>
+            <DialogDescription style={{ color: '#b5bac1' }}>
+              This action can&apos;t be undone. The rule <span className="font-semibold text-white">{deleteTarget?.name}</span> will stop moderating messages immediately.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="secondary" onClick={() => setDeleteTarget(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (!deleteTarget) return
+                handleDelete(deleteTarget.id)
+              }}
+            >
+              Delete rule
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }


### PR DESCRIPTION
### Motivation
- Remove blocking browser-native `window.confirm` usages in destructive flows to provide a consistent, product-native confirmation UX with keyboard trapping and clear irreversible copy.
- Align message deletion and moderation flows with expected desktop-app patterns (primary/secondary danger actions) for improved accessibility and parity with competitors.

### Description
- Replaced `window.confirm` in message deletion with a first-class in-app dialog in `MessageItem`, adding local dialog state, `Cancel` and `Delete message` actions, and irreversible explanatory copy (`apps/web/components/chat/message-item.tsx`).
- Switched AutoMod rule deletion in Server Settings to use a matching in-app confirmation dialog, routing the rule delete button through dialog state before calling the API (`apps/web/components/modals/server-settings-modal.tsx`).
- Reused the existing Radix-powered `Dialog`/`DialogContent`/`DialogHeader`/`DialogDescription`/`DialogFooter` components and `Button` variants to ensure focus trapping, keyboard accessibility, and consistent styling.
- Adjusted handlers so destructive actions close the dialog on success and reset dialog state on cancel or after deletion.

### Testing
- Ran `npm run -w apps/web lint` and it completed successfully.
- Ran `npm run -w apps/web type-check` (`tsc --noEmit`) and it completed successfully.
- Started the dev server (`next dev`) and produced a screenshot artifact for verification, but runtime rendering of some routes produced environment warnings (missing Supabase env vars) and a Google Fonts fetch fallback; the app booted and the UI dialog flows were verified in the running instance despite those environment limitations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c83c2d0c8832587572a7331d98efc)