### PR TITLE
Promote Quick Switcher, Search and Inbox to top-level sidebar utilities

### DIFF
--- a/apps/web/components/layout/channel-sidebar.tsx
+++ b/apps/web/components/layout/channel-sidebar.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, useCallback } from "react"
 import { useRouter } from "next/navigation"
 import {
   Hash, Volume2, ChevronDown, ChevronRight,
-  Plus, Clipboard, Trash2, MessageSquare, Mic2, Megaphone, Image, Clock, GripVertical, CalendarDays
+  Plus, Clipboard, Trash2, MessageSquare, Mic2, Megaphone, Image, Clock, GripVertical, CalendarDays, Command, Search
 } from "lucide-react"
 import {
   DndContext,
@@ -35,8 +35,12 @@ import { useToast } from "@/components/ui/use-toast"
 import { CreateChannelModal } from "@/components/modals/create-channel-modal"
 import { ServerSettingsModal } from "@/components/modals/server-settings-modal"
 import { UserPanel } from "@/components/layout/user-panel"
+import { QuickSwitcherModal } from "@/components/modals/quickswitcher-modal"
+import { SearchModal } from "@/components/modals/search-modal"
 import { PERMISSIONS, hasPermission } from "@vortex/shared"
 import { useUnreadChannels } from "@/hooks/use-unread-channels"
+import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts"
+import { NotificationBell } from "@/components/notifications/notification-bell"
 
 const NO_CATEGORY = "__no_category__"
 
@@ -123,8 +127,15 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
   const [items, setItems] = useState<Record<string, string[]>>({})
   const [overContainerId, setOverContainerId] = useState<string | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null)
+  const [quickSwitcherOpen, setQuickSwitcherOpen] = useState(false)
+  const [searchOpen, setSearchOpen] = useState(false)
   const router = useRouter()
   const { toast } = useToast()
+
+  useKeyboardShortcuts({
+    onQuickSwitcher: useCallback(() => setQuickSwitcherOpen(true), []),
+    onSearch: useCallback(() => setSearchOpen(true), []),
+  })
 
   // Always reflects the latest committed items — used in drag handlers to avoid stale closures
   const itemsRef = useRef<Record<string, string[]>>({})
@@ -378,6 +389,32 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
           Events
         </button>
 
+        <div className="mx-2 mt-2 space-y-1">
+          <button
+            onClick={() => setQuickSwitcherOpen(true)}
+            className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm text-zinc-200 transition-colors hover:bg-white/10"
+          >
+            <span className="flex items-center gap-2">
+              <Command className="h-4 w-4" />
+              Quick Switcher
+            </span>
+            <span className="text-[10px] uppercase tracking-wide text-zinc-400">⌘K</span>
+          </button>
+
+          <button
+            onClick={() => setSearchOpen(true)}
+            className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm text-zinc-200 transition-colors hover:bg-white/10"
+          >
+            <span className="flex items-center gap-2">
+              <Search className="h-4 w-4" />
+              Search
+            </span>
+            <span className="text-[10px] uppercase tracking-wide text-zinc-400">⌘F</span>
+          </button>
+
+          <NotificationBell userId={currentUserId} variant="sidebar" />
+        </div>
+
         {/* Channel list */}
         <div className="flex-1 overflow-y-auto py-2">
           <DndContext
@@ -495,6 +532,17 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
           isOwner={isOwner}
           channels={webhookEligibleChannels}
         />
+
+        {quickSwitcherOpen && <QuickSwitcherModal onClose={() => setQuickSwitcherOpen(false)} />}
+        {searchOpen && (
+          <SearchModal
+            serverId={server.id}
+            onClose={() => setSearchOpen(false)}
+            onJumpToMessage={(channelId, messageId) => {
+              router.push(`/channels/${server.id}/${channelId}?message=${encodeURIComponent(messageId)}`)
+            }}
+          />
+        )}
 
         {/* Delete channel confirmation dialog */}
         <Dialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>

--- a/apps/web/components/layout/channels-shell.tsx
+++ b/apps/web/components/layout/channels-shell.tsx
@@ -1,19 +1,9 @@
 "use client"
 
-import { useState, useCallback } from "react"
 import { MobileNavProvider, MobileOverlay } from "./mobile-nav"
 import { ServerSidebarWrapper } from "./server-sidebar-wrapper"
-import { QuickSwitcherModal } from "@/components/modals/quickswitcher-modal"
-import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts"
 
 export function ChannelsShell({ children }: { children: React.ReactNode }) {
-  const [quickSwitcherOpen, setQuickSwitcherOpen] = useState(false)
-
-  useKeyboardShortcuts({
-    onQuickSwitcher: useCallback(() => setQuickSwitcherOpen(true), []),
-    onSearch: useCallback(() => setQuickSwitcherOpen(true), []),
-  })
-
   return (
     <MobileNavProvider>
       <div className="flex h-screen overflow-hidden" style={{ background: "#313338" }}>
@@ -23,7 +13,6 @@ export function ChannelsShell({ children }: { children: React.ReactNode }) {
           {children}
         </div>
       </div>
-      {quickSwitcherOpen && <QuickSwitcherModal onClose={() => setQuickSwitcherOpen(false)} />}
     </MobileNavProvider>
   )
 }

--- a/apps/web/components/notifications/notification-bell.tsx
+++ b/apps/web/components/notifications/notification-bell.tsx
@@ -29,9 +29,10 @@ const TYPE_ICONS: Record<string, React.ReactNode> = {
 
 interface Props {
   userId: string
+  variant?: "icon" | "sidebar"
 }
 
-export function NotificationBell({ userId }: Props) {
+export function NotificationBell({ userId, variant = "icon" }: Props) {
   const [supabase] = useState(() => createClientSupabaseClient())
   const router = useRouter()
   const [open, setOpen] = useState(false)
@@ -118,22 +119,43 @@ export function NotificationBell({ userId }: Props) {
   return (
     <div className="relative" ref={panelRef}>
       {/* Bell button */}
-      <button
-        onClick={() => setOpen((v) => !v)}
-        className="relative w-9 h-9 flex items-center justify-center rounded-full transition-colors hover:bg-white/10"
-        style={{ color: open ? "#f2f3f5" : "#949ba4" }}
-        title="Notifications"
-      >
-        <Bell className="w-5 h-5" />
-        {unreadCount > 0 && (
-          <span
-            className="absolute -top-0.5 -right-0.5 min-w-[16px] h-4 rounded-full flex items-center justify-center text-xs font-bold px-0.5"
-            style={{ background: "#f23f43", color: "white", fontSize: "10px" }}
-          >
-            {unreadCount > 99 ? "99+" : unreadCount}
+      {variant === "sidebar" ? (
+        <button
+          onClick={() => setOpen((v) => !v)}
+          className="relative flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm text-zinc-200 transition-colors hover:bg-white/10"
+          title="Inbox"
+        >
+          <span className="flex items-center gap-2">
+            <Bell className="h-4 w-4" />
+            Inbox
           </span>
-        )}
-      </button>
+          {unreadCount > 0 && (
+            <span
+              className="min-w-[18px] h-[18px] rounded-full px-1 text-[10px] font-bold flex items-center justify-center"
+              style={{ background: "#f23f43", color: "white" }}
+            >
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </span>
+          )}
+        </button>
+      ) : (
+        <button
+          onClick={() => setOpen((v) => !v)}
+          className="relative w-9 h-9 flex items-center justify-center rounded-full transition-colors hover:bg-white/10"
+          style={{ color: open ? "#f2f3f5" : "#949ba4" }}
+          title="Notifications"
+        >
+          <Bell className="w-5 h-5" />
+          {unreadCount > 0 && (
+            <span
+              className="absolute -top-0.5 -right-0.5 min-w-[16px] h-4 rounded-full flex items-center justify-center text-xs font-bold px-0.5"
+              style={{ background: "#f23f43", color: "white", fontSize: "10px" }}
+            >
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </span>
+          )}
+        </button>
+      )}
 
       {/* Panel */}
       {open && (


### PR DESCRIPTION
### Motivation
- Make productivity navigation discoverable by promoting Quick Switcher, global Search, and Inbox to persistent, top-level sidebar controls instead of hiding them behind keyboard-only or modal-only access.
- Surface keyboard hints and preserve existing modal UX while centralizing triggering to the server sidebar for a consistent entrypoint.

### Description
- Added a small productivity block in the channel sidebar with top-level buttons for Quick Switcher (`⌘K`), Search (`⌘F`), and Inbox and visible shortcut hints (file: `apps/web/components/layout/channel-sidebar.tsx`).
- Wired keyboard shortcuts in `ChannelSidebar` via `useKeyboardShortcuts` to open `QuickSwitcherModal` and `SearchModal`, and integrated `SearchModal` click handling to navigate to specific channel/message routes.
- Extended `NotificationBell` with a `variant` prop and implemented a `sidebar` variant that renders an inline Inbox button with an unread badge while keeping the existing icon-style bell (file: `apps/web/components/notifications/notification-bell.tsx`).
- Removed duplicate quick-switcher wiring from `ChannelsShell` so modals and shortcuts are anchored in the sidebar (file: `apps/web/components/layout/channels-shell.tsx`).

### Testing
- Ran lint with `npm run -w @vortex/web lint`, which completed successfully.
- Ran type checking with `npm run -w @vortex/web type-check` (`tsc --noEmit`) which completed successfully.
- Attempted to boot the dev server with `npm run -w @vortex/web dev`; Next compiled but runtime rendering requiring Supabase env vars failed for authenticated pages in this environment, so UI verification was limited (font download warnings and missing Supabase env prevented full authenticated validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c8b50d9408325854dffd7da53e162)