### PR TITLE
Split settings IA into quick modal and dedicated server admin route

### DIFF
--- a/apps/web/app/channels/[serverId]/settings/page.tsx
+++ b/apps/web/app/channels/[serverId]/settings/page.tsx
@@ -1,0 +1,62 @@
+import { notFound, redirect } from "next/navigation"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { ServerSettingsAdmin } from "@/components/settings/server-settings-admin"
+import type { RoleRow } from "@/types/database"
+
+export default async function ServerSettingsPage({ params: paramsPromise }: { params: Promise<{ serverId: string }> }) {
+  const { serverId } = await paramsPromise
+  const supabase = await createServerSupabaseClient()
+
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect("/login")
+
+  const { data: member } = await supabase
+    .from("server_members")
+    .select("server_id")
+    .eq("server_id", serverId)
+    .eq("user_id", user.id)
+    .single()
+
+  if (!member) notFound()
+
+  const { data: server } = await supabase
+    .from("servers")
+    .select("*")
+    .eq("id", serverId)
+    .single()
+
+  if (!server) notFound()
+
+  const { data: channels } = await supabase
+    .from("channels")
+    .select("id,name,type")
+    .eq("server_id", serverId)
+
+  const { data: memberRoles } = await supabase
+    .from("member_roles")
+    .select("role_id, roles(*)")
+    .eq("server_id", serverId)
+    .eq("user_id", user.id)
+
+  type MemberRoleWithRole = { role_id: string; roles: RoleRow | null }
+  const userRoles = ((memberRoles ?? []) as unknown as MemberRoleWithRole[])
+    .map((mr) => mr.roles)
+    .filter((r): r is RoleRow => r !== null)
+
+  const isOwner = server.owner_id === user.id
+  const canAccessAdminSettings = isOwner || userRoles.length > 0
+  if (!canAccessAdminSettings) notFound()
+
+  const webhookEligibleChannels = (channels ?? [])
+    .filter((channel) => ["text", "announcement", "forum", "media"].includes(channel.type))
+    .map((channel) => ({ id: channel.id, name: channel.name }))
+
+  return (
+    <ServerSettingsAdmin
+      serverId={serverId}
+      serverName={server.name}
+      isOwner={isOwner}
+      channels={webhookEligibleChannels}
+    />
+  )
+}

--- a/apps/web/components/modals/server-settings-modal.tsx
+++ b/apps/web/components/modals/server-settings-modal.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect, useRef } from "react"
+import Link from "next/link"
 import { Loader2, Copy, RefreshCw, Trash2, Webhook, Smile, Plus, Check, Shield, ShieldCheck, Zap } from "lucide-react"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
@@ -12,8 +13,6 @@ import { createClientSupabaseClient } from "@/lib/supabase/client"
 import { evaluateRule } from "@/lib/automod"
 import { useAppStore } from "@/lib/stores/app-store"
 import type { ServerRow, AutoModRuleRow, AutoModAction, ScreeningConfigRow } from "@/types/database"
-import { RoleManager } from "@/components/roles/role-manager"
-import { TemplateManager } from "@/components/modals/template-manager"
 
 interface Channel {
   id: string
@@ -101,41 +100,18 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
               <TabsTrigger value="overview" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: '#b5bac1' }}>
                 Overview
               </TabsTrigger>
-              <TabsTrigger value="roles" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: '#b5bac1' }}>
-                Roles
-              </TabsTrigger>
               <TabsTrigger value="invites" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: '#b5bac1' }}>
                 Invites
               </TabsTrigger>
-              {isOwner && (
-                <>
-                  <TabsTrigger value="emojis" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: '#b5bac1' }}>
-                    Emoji
-                  </TabsTrigger>
-                  <TabsTrigger value="webhooks" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: '#b5bac1' }}>
-                    Integrations
-                  </TabsTrigger>
-                  <div className="mt-2 mb-1 text-xs font-semibold uppercase tracking-wider" style={{ color: '#949ba4' }}>
-                    Moderation
-                  </div>
-                  <TabsTrigger value="moderation" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: '#b5bac1' }}>
-                    <Shield className="w-3.5 h-3.5 mr-1.5" />
-                    Settings
-                  </TabsTrigger>
-                  <TabsTrigger value="screening" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: '#b5bac1' }}>
-                    <ShieldCheck className="w-3.5 h-3.5 mr-1.5" />
-                    Screening
-                  </TabsTrigger>
-                  <TabsTrigger value="automod" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: '#b5bac1' }}>
-                    <Zap className="w-3.5 h-3.5 mr-1.5" />
-                    AutoMod
-                  </TabsTrigger>
-                  <TabsTrigger value="templates" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: '#b5bac1' }}>
-                    Templates
-                  </TabsTrigger>
-                </>
-              )}
             </TabsList>
+            <p className="mt-3 px-2 text-xs leading-relaxed" style={{ color: '#949ba4' }}>
+              Need roles, moderation, integrations, or templates?
+            </p>
+            <Button asChild variant="ghost" className="mt-2 justify-start px-2 text-sm" style={{ color: '#b5bac1' }}>
+              <Link href={`/channels/${server.id}/settings`} onClick={onClose}>
+                Open Server Settings
+              </Link>
+            </Button>
           </div>
 
           {/* Main content */}
@@ -176,10 +152,6 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
               )}
             </TabsContent>
 
-            <TabsContent value="roles" className="mt-0">
-              <RoleManager serverId={server.id} isOwner={isOwner} />
-            </TabsContent>
-
             <TabsContent value="invites" className="mt-0 space-y-4">
               <div>
                 <Label className="text-xs font-semibold uppercase tracking-wider mb-2 block" style={{ color: '#b5bac1' }}>
@@ -216,29 +188,6 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
               </p>
             </TabsContent>
 
-            <TabsContent value="emojis" className="mt-0">
-              <EmojisTab serverId={server.id} />
-            </TabsContent>
-
-            <TabsContent value="webhooks" className="mt-0">
-              <WebhooksTab serverId={server.id} channels={channels} open={open} />
-            </TabsContent>
-
-            <TabsContent value="moderation" className="mt-0">
-              <ModerationTab serverId={server.id} open={open} />
-            </TabsContent>
-
-            <TabsContent value="screening" className="mt-0">
-              <ScreeningTab serverId={server.id} open={open} />
-            </TabsContent>
-
-            <TabsContent value="automod" className="mt-0">
-              <AutoModTab serverId={server.id} channels={channels} open={open} />
-            </TabsContent>
-
-            <TabsContent value="templates" className="mt-0">
-              {isOwner ? <TemplateManager serverId={server.id} /> : <p style={{ color: "#b5bac1" }}>Only the owner can import/export templates.</p>}
-            </TabsContent>
           </div>
         </Tabs>
       </DialogContent>
@@ -254,7 +203,7 @@ interface EmojiEntry {
   image_url: string
 }
 
-function EmojisTab({ serverId }: { serverId: string }) {
+export function EmojisTab({ serverId }: { serverId: string }) {
   const { toast } = useToast()
   const [emojis, setEmojis] = useState<EmojiEntry[]>([])
   const [loading, setLoading] = useState(true)
@@ -378,7 +327,7 @@ interface WebhookEntry {
   created_at: string
 }
 
-function WebhooksTab({ serverId, channels, open }: { serverId: string; channels: Channel[]; open: boolean }) {
+export function WebhooksTab({ serverId, channels, open }: { serverId: string; channels: Channel[]; open: boolean }) {
   const { toast } = useToast()
   const [webhooks, setWebhooks] = useState<WebhookEntry[]>([])
   const [loading, setLoading] = useState(true)
@@ -553,7 +502,7 @@ interface ModerationSettings {
   screening_enabled: boolean
 }
 
-function ModerationTab({ serverId, open }: { serverId: string; open: boolean }) {
+export function ModerationTab({ serverId, open }: { serverId: string; open: boolean }) {
   const { toast } = useToast()
   const [settings, setSettings] = useState<ModerationSettings | null>(null)
   const [loading, setLoading] = useState(true)
@@ -677,7 +626,7 @@ function ModerationTab({ serverId, open }: { serverId: string; open: boolean }) 
 
 // ── Screening Tab ────────────────────────────────────────────────────────────
 
-function ScreeningTab({ serverId, open }: { serverId: string; open: boolean }) {
+export function ScreeningTab({ serverId, open }: { serverId: string; open: boolean }) {
   const { toast } = useToast()
   const [config, setConfig] = useState<ScreeningConfigRow | null>(null)
   const [loading, setLoading] = useState(true)
@@ -939,7 +888,7 @@ function ruleToForm(rule: AutoModRuleRow): AutoModRuleForm {
   }
 }
 
-function AutoModTab({ serverId, channels, open }: { serverId: string; channels: Channel[]; open: boolean }) {
+export function AutoModTab({ serverId, channels, open }: { serverId: string; channels: Channel[]; open: boolean }) {
   const { toast } = useToast()
   const [rules, setRules] = useState<AutoModRuleRow[]>([])
   const [loading, setLoading] = useState(true)

--- a/apps/web/components/settings/server-settings-admin.tsx
+++ b/apps/web/components/settings/server-settings-admin.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { Shield, ShieldCheck, Zap } from "lucide-react"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { RoleManager } from "@/components/roles/role-manager"
+import { TemplateManager } from "@/components/modals/template-manager"
+import { AutoModTab, EmojisTab, ModerationTab, ScreeningTab, WebhooksTab } from "@/components/modals/server-settings-modal"
+
+interface Channel {
+  id: string
+  name: string
+}
+
+interface Props {
+  serverId: string
+  serverName: string
+  isOwner: boolean
+  channels: Channel[]
+}
+
+export function ServerSettingsAdmin({ serverId, serverName, isOwner, channels }: Props) {
+  return (
+    <main className="flex-1 overflow-y-auto p-6" style={{ background: "#1e1f22" }}>
+      <div className="mx-auto max-w-6xl">
+        <h1 className="text-2xl font-semibold text-white">Server Settings</h1>
+        <p className="mt-1 text-sm" style={{ color: "#949ba4" }}>{serverName}</p>
+
+        <Tabs defaultValue="roles" className="mt-6 flex gap-6">
+          <div className="w-56 flex-shrink-0">
+            <TabsList className="flex h-auto w-full flex-col gap-1 bg-transparent p-0">
+              <TabsTrigger value="roles" className="w-full justify-start">Roles</TabsTrigger>
+              <TabsTrigger value="emojis" className="w-full justify-start">Emoji</TabsTrigger>
+              <TabsTrigger value="webhooks" className="w-full justify-start">Integrations</TabsTrigger>
+              <div className="mt-2 mb-1 px-3 text-xs font-semibold uppercase tracking-wider" style={{ color: "#949ba4" }}>
+                Moderation
+              </div>
+              <TabsTrigger value="moderation" className="w-full justify-start">
+                <Shield className="mr-1.5 h-3.5 w-3.5" />
+                Settings
+              </TabsTrigger>
+              <TabsTrigger value="screening" className="w-full justify-start">
+                <ShieldCheck className="mr-1.5 h-3.5 w-3.5" />
+                Screening
+              </TabsTrigger>
+              <TabsTrigger value="automod" className="w-full justify-start">
+                <Zap className="mr-1.5 h-3.5 w-3.5" />
+                AutoMod
+              </TabsTrigger>
+              <TabsTrigger value="templates" className="w-full justify-start">Templates</TabsTrigger>
+            </TabsList>
+          </div>
+
+          <div className="min-w-0 flex-1 rounded-md p-4" style={{ background: "#313338" }}>
+            <TabsContent value="roles" className="mt-0">
+              <RoleManager serverId={serverId} isOwner={isOwner} />
+            </TabsContent>
+            <TabsContent value="emojis" className="mt-0">
+              <EmojisTab serverId={serverId} />
+            </TabsContent>
+            <TabsContent value="webhooks" className="mt-0">
+              <WebhooksTab serverId={serverId} channels={channels} open />
+            </TabsContent>
+            <TabsContent value="moderation" className="mt-0">
+              <ModerationTab serverId={serverId} open />
+            </TabsContent>
+            <TabsContent value="screening" className="mt-0">
+              <ScreeningTab serverId={serverId} open />
+            </TabsContent>
+            <TabsContent value="automod" className="mt-0">
+              <AutoModTab serverId={serverId} channels={channels} open />
+            </TabsContent>
+            <TabsContent value="templates" className="mt-0">
+              {isOwner ? <TemplateManager serverId={serverId} /> : <p style={{ color: "#b5bac1" }}>Only the owner can import/export templates.</p>}
+            </TabsContent>
+          </div>
+        </Tabs>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
### Motivation

- Separate lightweight user-facing settings (kept as a fast modal) from heavier server administration to preserve modal speed for common actions and migrate complex flows to a dedicated route. 
- Provide a clear CTA from the modal into a full-page server admin UX so admins have a single place for Roles, Moderation, Integrations, templates, and other heavy tasks.

### Description

- Focused `ServerSettingsModal` on lightweight actions (Overview + Invites) and added a CTA linking to the dedicated admin route at `/channels/[serverId]/settings` (`apps/web/components/modals/server-settings-modal.tsx`).
- Exported advanced tab components (`EmojisTab`, `WebhooksTab`, `ModerationTab`, `ScreeningTab`, `AutoModTab`) from the modal module so they can be reused in the full-page admin UI without duplicating logic (`apps/web/components/modals/server-settings-modal.tsx`).
- Added a full-page `ServerSettingsAdmin` component implementing the complete tabbed admin experience (Roles, Emoji, Integrations, Moderation, Screening, AutoMod, Templates) at `apps/web/components/settings/server-settings-admin.tsx`.
- Added a server settings route `apps/web/app/channels/[serverId]/settings/page.tsx` that enforces auth/membership checks, computes permission context (owner/member roles), fetches webhook-eligible channels, and renders the admin page.

### Testing

- Ran `cd apps/web && npm run -s type-check`, which succeeded for the `web` package.
- Ran `cd apps/web && npm run -s lint`, which succeeded.
- Ran workspace type-check `npm run -s type-check --filter=web` via turborepo which surfaced a failure in an unrelated package (`apps/signal` WebRTC type errors); the failure is external to these changes and did not affect `apps/web` type-check/lint results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c8cfd7c148325ac79471452f08a8c)