### PR TITLE
Add apps platform: catalog, install flow, runtime, marketplace UI, and security docs

### DIFF
--- a/apps/web/app/api/apps/discover/route.ts
+++ b/apps/web/app/api/apps/discover/route.ts
@@ -1,21 +1,34 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createServerSupabaseClient } from "@/lib/supabase/server"
 
+function sanitizeIlikeQuery(value: string) {
+  return value
+    .replace(/[,%]/g, "")
+    .replace(/[().]/g, "")
+    .replace(/\*/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+// Allow unauthenticated browsing — public marketplace endpoint.
 export async function GET(req: NextRequest) {
   const supabase = await createServerSupabaseClient()
-  const db = supabase as any
   const query = req.nextUrl.searchParams.get("q")?.trim()
   const category = req.nextUrl.searchParams.get("category")?.trim()
 
-  let builder = db
-    .from("app_catalog")
+  let builder = supabase
+    .from("app_catalog_public")
     .select("id, slug, name, description, category, trust_badge, average_rating, review_count, permissions")
     .eq("is_published", true)
     .order("review_count", { ascending: false })
 
   if (query) {
-    builder = builder.or(`name.ilike.%${query}%,description.ilike.%${query}%`)
+    const safeQuery = sanitizeIlikeQuery(query)
+    if (safeQuery) {
+      builder = builder.or(`name.ilike.%${safeQuery}%,description.ilike.%${safeQuery}%`)
+    }
   }
+
   if (category && category !== "all") {
     builder = builder.eq("category", category)
   }

--- a/apps/web/app/api/servers/[serverId]/apps/route.ts
+++ b/apps/web/app/api/servers/[serverId]/apps/route.ts
@@ -1,11 +1,21 @@
 import { NextRequest, NextResponse } from "next/server"
+import type { SupabaseClient } from "@supabase/supabase-js"
 import { createServerSupabaseClient } from "@/lib/supabase/server"
 import { getMemberPermissions, hasPermission } from "@/lib/permissions"
+import type { Database } from "@/types/database"
+import { validateInstallPermissions } from "@/lib/apps/runtime"
 
-async function canManageApps(serverId: string, userId: string) {
-  const supabase = await createServerSupabaseClient()
+async function canManageApps(
+  supabase: SupabaseClient<Database>,
+  serverId: string,
+  userId: string
+) {
   const { isAdmin, permissions } = await getMemberPermissions(supabase, serverId, userId)
-  return { allowed: isAdmin || hasPermission(permissions, "MANAGE_WEBHOOKS") }
+  return {
+    allowed: isAdmin
+      || hasPermission(permissions, "MANAGE_WEBHOOKS")
+      || hasPermission(permissions, "USE_APPLICATION_COMMANDS"),
+  }
 }
 
 export async function GET(
@@ -14,11 +24,10 @@ export async function GET(
 ) {
   const { serverId } = await params
   const supabase = await createServerSupabaseClient()
-  const db = supabase as any
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
-  const { data, error } = await db
+  const { data, error } = await supabase
     .from("server_app_installs")
     .select("id, app_id, install_scopes, granted_permissions, installed_at, app_catalog(name, slug, trust_badge)")
     .eq("server_id", serverId)
@@ -34,17 +43,23 @@ export async function POST(
 ) {
   const { serverId } = await params
   const supabase = await createServerSupabaseClient()
-  const db = supabase as any
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
-  const manager = await canManageApps(serverId, user.id)
+  const manager = await canManageApps(supabase, serverId, user.id)
   if (!manager.allowed) return NextResponse.json({ error: "Missing permissions to install apps." }, { status: 403 })
 
-  const { appId } = await req.json()
+  let parsedBody: { appId?: string; requestedPermissions?: string[] }
+  try {
+    parsedBody = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  const { appId, requestedPermissions } = parsedBody
   if (!appId) return NextResponse.json({ error: "appId required" }, { status: 400 })
 
-  const { data: app, error: appError } = await db
+  const { data: app, error: appError } = await supabase
     .from("app_catalog")
     .select("id, install_scopes, permissions")
     .eq("id", appId)
@@ -52,21 +67,31 @@ export async function POST(
 
   if (appError || !app) return NextResponse.json({ error: "App not found" }, { status: 404 })
 
-  const { data, error } = await db
+  const requested = Array.isArray(requestedPermissions) && requestedPermissions.length > 0
+    ? requestedPermissions
+    : app.permissions
+
+  const isValidPermissions = validateInstallPermissions(requested, app.permissions)
+  if (!isValidPermissions) {
+    return NextResponse.json({ error: "Invalid permission selection for install." }, { status: 400 })
+  }
+  const validatedPermissions = requested
+
+  const { data, error } = await supabase
     .from("server_app_installs")
     .insert({
       app_id: app.id,
       server_id: serverId,
       installed_by: user.id,
       install_scopes: app.install_scopes,
-      granted_permissions: app.permissions,
+      granted_permissions: validatedPermissions,
     })
     .select("id, app_id, install_scopes, granted_permissions, installed_at")
     .single()
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
 
-  await db.rpc("bump_app_usage", {
+  await supabase.rpc("bump_app_usage", {
     p_app_id: app.id,
     p_server_id: serverId,
     p_metric_key: "app.install",
@@ -82,17 +107,16 @@ export async function DELETE(
 ) {
   const { serverId } = await params
   const supabase = await createServerSupabaseClient()
-  const db = supabase as any
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
-  const manager = await canManageApps(serverId, user.id)
+  const manager = await canManageApps(supabase, serverId, user.id)
   if (!manager.allowed) return NextResponse.json({ error: "Missing permissions to uninstall apps." }, { status: 403 })
 
   const appId = req.nextUrl.searchParams.get("appId")
   if (!appId) return NextResponse.json({ error: "appId required" }, { status: 400 })
 
-  const { error } = await db
+  const { error } = await supabase
     .from("server_app_installs")
     .delete()
     .eq("server_id", serverId)
@@ -100,7 +124,7 @@ export async function DELETE(
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
 
-  await db.rpc("bump_app_usage", {
+  await supabase.rpc("bump_app_usage", {
     p_app_id: appId,
     p_server_id: serverId,
     p_metric_key: "app.uninstall",

--- a/apps/web/app/channels/discover/page.tsx
+++ b/apps/web/app/channels/discover/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState, useCallback } from "react"
+import { useEffect, useState, useCallback, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { Search, Users, Compass, BadgeCheck, Star } from "lucide-react"
 import { MobileMenuButton } from "@/components/layout/mobile-nav"
@@ -51,22 +51,35 @@ export default function DiscoverPage() {
     if (res.ok) setApps(await res.json())
   }, [])
 
-  useEffect(() => {
-    const run = async () => {
-      setLoading(true)
-      await Promise.all([fetchServers(), fetchApps(undefined, category)])
-      setLoading(false)
-    }
-    run()
-  }, [fetchServers, fetchApps, category])
+  const previousCategoryRef = useRef(category)
 
   useEffect(() => {
-    const t = setTimeout(async () => {
-      setLoading(true)
-      await Promise.all([fetchServers(query), fetchApps(query, category)])
-      setLoading(false)
-    }, 300)
-    return () => clearTimeout(t)
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const categoryChanged = previousCategoryRef.current !== category
+
+    const runFetch = async (debounceMs: number) => {
+      if (timer) clearTimeout(timer)
+      const execute = async () => {
+        setLoading(true)
+        await Promise.all([fetchServers(query || undefined), fetchApps(query || undefined, category)])
+        if (!cancelled) setLoading(false)
+      }
+
+      if (debounceMs > 0) {
+        timer = setTimeout(execute, debounceMs)
+      } else {
+        await execute()
+      }
+    }
+
+    runFetch(query && !categoryChanged ? 300 : 0)
+    previousCategoryRef.current = category
+
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
   }, [query, fetchServers, fetchApps, category])
 
   async function joinServer(inviteCode: string) {
@@ -111,6 +124,7 @@ export default function DiscoverPage() {
           <div className="flex gap-2 mt-3">
             {APP_CATEGORIES.map((item) => (
               <button
+                type="button"
                 key={item}
                 onClick={() => setCategory(item)}
                 className="px-2.5 py-1 rounded text-xs capitalize"
@@ -138,7 +152,7 @@ export default function DiscoverPage() {
                   {server.description && <p className="text-xs line-clamp-2 flex-1 mb-3" style={{ color: "#949ba4" }}>{server.description}</p>}
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-1.5 text-xs" style={{ color: "#949ba4" }}><Users className="w-3 h-3" /><span>{server.member_count.toLocaleString()}</span></div>
-                    <button onClick={() => joinServer(server.invite_code)} className="px-3 py-1 rounded text-xs font-semibold" style={{ background: "#5865f2", color: "white" }}>Join</button>
+                    <button type="button" onClick={() => joinServer(server.invite_code)} className="px-3 py-1 rounded text-xs font-semibold" style={{ background: "#5865f2", color: "white" }}>Join</button>
                   </div>
                 </div>
               </div>

--- a/apps/web/components/settings/apps-tab.tsx
+++ b/apps/web/components/settings/apps-tab.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react"
 import { BadgeCheck, Shield, Star, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { useToast } from "@/components/ui/use-toast"
 
 interface InstalledApp {
   id: string
@@ -26,37 +27,103 @@ interface DiscoverApp {
   review_count: number
 }
 
-export function AppsTab({ serverId }: { serverId: string }) {
+interface AppsTabProps {
+  serverId: string
+  canManageApps: boolean
+}
+
+async function readErrorMessage(res: Response) {
+  try {
+    const payload = await res.json()
+    if (payload?.error) return String(payload.error)
+  } catch {
+    // fallback to text
+  }
+
+  try {
+    const text = await res.text()
+    if (text) return text
+  } catch {
+    // ignore
+  }
+
+  return `Request failed (${res.status})`
+}
+
+export function AppsTab({ serverId, canManageApps }: AppsTabProps) {
+  const { toast } = useToast()
   const [installed, setInstalled] = useState<InstalledApp[]>([])
   const [market, setMarket] = useState<DiscoverApp[]>([])
   const [loading, setLoading] = useState(true)
+  const [busyAppId, setBusyAppId] = useState<string | null>(null)
 
   async function refresh() {
     setLoading(true)
-    const [installedRes, marketRes] = await Promise.all([
-      fetch(`/api/servers/${serverId}/apps`),
-      fetch(`/api/apps/discover`),
-    ])
+    try {
+      const [installedRes, marketRes] = await Promise.all([
+        fetch(`/api/servers/${serverId}/apps`),
+        fetch(`/api/apps/discover`),
+      ])
 
-    if (installedRes.ok) setInstalled(await installedRes.json())
-    if (marketRes.ok) setMarket(await marketRes.json())
-    setLoading(false)
+      if (!installedRes.ok) throw new Error(await readErrorMessage(installedRes))
+      if (!marketRes.ok) throw new Error(await readErrorMessage(marketRes))
+
+      setInstalled(await installedRes.json())
+      setMarket(await marketRes.json())
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Failed to load apps",
+        description: error instanceof Error ? error.message : "Unknown error",
+      })
+    } finally {
+      setLoading(false)
+    }
   }
 
   useEffect(() => { refresh() }, [serverId])
 
   async function install(appId: string) {
-    await fetch(`/api/servers/${serverId}/apps`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ appId }),
-    })
-    refresh()
+    setBusyAppId(appId)
+    try {
+      const res = await fetch(`/api/servers/${serverId}/apps`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ appId }),
+      })
+      if (!res.ok) throw new Error(await readErrorMessage(res))
+      await refresh()
+      toast({ title: "App installed" })
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Install failed",
+        description: error instanceof Error ? error.message : "Unknown error",
+      })
+    } finally {
+      setBusyAppId(null)
+    }
   }
 
   async function uninstall(appId: string) {
-    await fetch(`/api/servers/${serverId}/apps?appId=${appId}`, { method: "DELETE" })
-    refresh()
+    const confirmed = window.confirm("Uninstall this app from the server?")
+    if (!confirmed) return
+
+    setBusyAppId(appId)
+    try {
+      const res = await fetch(`/api/servers/${serverId}/apps?appId=${appId}`, { method: "DELETE" })
+      if (!res.ok) throw new Error(await readErrorMessage(res))
+      await refresh()
+      toast({ title: "App uninstalled" })
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Uninstall failed",
+        description: error instanceof Error ? error.message : "Unknown error",
+      })
+    } finally {
+      setBusyAppId(null)
+    }
   }
 
   const installedIds = new Set(installed.map((app) => app.app_id))
@@ -80,7 +147,12 @@ export function AppsTab({ serverId }: { serverId: string }) {
                     Scopes: {entry.install_scopes.join(", ")} · Permissions: {entry.granted_permissions.join(", ")}
                   </p>
                 </div>
-                <Button variant="ghost" size="sm" onClick={() => uninstall(entry.app_id)}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={!canManageApps || busyAppId === entry.app_id}
+                  onClick={() => uninstall(entry.app_id)}
+                >
                   <Trash2 className="w-4 h-4" />
                 </Button>
               </div>
@@ -103,7 +175,11 @@ export function AppsTab({ serverId }: { serverId: string }) {
                   <Shield className="w-3 h-3 inline mr-1" />{app.category} · <Star className="w-3 h-3 inline mr-1" />{app.average_rating.toFixed(1)} ({app.review_count})
                 </p>
               </div>
-              <Button size="sm" disabled={installedIds.has(app.id)} onClick={() => install(app.id)}>
+              <Button
+                size="sm"
+                disabled={!canManageApps || installedIds.has(app.id) || busyAppId === app.id}
+                onClick={() => install(app.id)}
+              >
                 {installedIds.has(app.id) ? "Installed" : "Install"}
               </Button>
             </div>

--- a/apps/web/components/settings/server-settings-admin.tsx
+++ b/apps/web/components/settings/server-settings-admin.tsx
@@ -63,7 +63,7 @@ export function ServerSettingsAdmin({ serverId, serverName, isOwner, channels }:
               <WebhooksTab serverId={serverId} channels={channels} open />
             </TabsContent>
             <TabsContent value="apps" className="mt-0">
-              <AppsTab serverId={serverId} />
+              <AppsTab serverId={serverId} canManageApps={isOwner} />
             </TabsContent>
             <TabsContent value="moderation" className="mt-0">
               <ModerationTab serverId={serverId} open />

--- a/apps/web/lib/apps/runtime.test.ts
+++ b/apps/web/lib/apps/runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   AppInteractionRuntime,
   redactCredentials,
@@ -23,6 +23,33 @@ describe("apps runtime", () => {
 
     expect(result.ok).toBe(true)
     expect(result.message).toBe("green")
+  })
+
+  it("fails unregistered commands", async () => {
+    const runtime = new AppInteractionRuntime()
+    const result = await runtime.executeCommand("/missing", {
+      appId: "app-1",
+      serverId: "server-1",
+      actorId: "user-1",
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  it("isolates commands by app id", async () => {
+    const runtime = new AppInteractionRuntime()
+    runtime.registerCommand({
+      name: "/status",
+      appId: "app-1",
+      execute: () => ({ ok: true, message: "ok" }),
+    })
+
+    const result = await runtime.executeCommand("/status", {
+      appId: "app-2",
+      serverId: "server-1",
+      actorId: "user-1",
+    })
+
+    expect(result.ok).toBe(false)
   })
 
   it("tracks event subscriptions", () => {
@@ -52,6 +79,56 @@ describe("apps runtime", () => {
     expect(first.ok).toBe(true)
     expect(second.ok).toBe(false)
     expect(second.message).toContain("Rate limit")
+  })
+
+  it("resets rate limit after window", async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00Z"))
+      const runtime = new AppInteractionRuntime()
+      runtime.registerCommand({
+        name: "/ping",
+        appId: "app-1",
+        execute: () => ({ ok: true, message: "pong" }),
+      })
+
+      const rule = { requestsPerMinute: 1 }
+      const first = await runtime.executeCommand("/ping", { appId: "app-1", serverId: "s1", actorId: "u1" }, rule)
+      const second = await runtime.executeCommand("/ping", { appId: "app-1", serverId: "s1", actorId: "u1" }, rule)
+
+      vi.setSystemTime(new Date("2024-01-01T00:01:01Z"))
+      const third = await runtime.executeCommand("/ping", { appId: "app-1", serverId: "s1", actorId: "u1" }, rule)
+
+      expect(first.ok).toBe(true)
+      expect(second.ok).toBe(false)
+      expect(third.ok).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("returns safe error when command execution throws", async () => {
+    const runtime = new AppInteractionRuntime()
+    const logger = { error: vi.fn() }
+
+    runtime.registerCommand({
+      name: "/boom",
+      appId: "app-1",
+      execute: () => {
+        throw new Error("kaboom")
+      },
+    })
+
+    const result = await runtime.executeCommand("/boom", {
+      appId: "app-1",
+      serverId: "s1",
+      actorId: "u1",
+      logger,
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain("App command failed")
+    expect(logger.error).toHaveBeenCalled()
   })
 
   it("validates install permissions and redacts credentials for webhook compatibility", () => {

--- a/apps/web/lib/apps/runtime.ts
+++ b/apps/web/lib/apps/runtime.ts
@@ -18,6 +18,9 @@ export interface RuntimeContext {
   serverId: string
   actorId: string
   payload?: Record<string, unknown>
+  logger?: {
+    error: (...args: unknown[]) => void
+  }
 }
 
 export interface RuntimeResponse {
@@ -45,9 +48,13 @@ export class AppInteractionRuntime {
   private subscriptions: EventSubscription[] = []
   private usage = new Map<string, InteractionRecord[]>()
 
+  private commandKey(appId: string, name: string) {
+    return `${appId}:${name.trim().toLowerCase()}`
+  }
+
   registerCommand(command: CommandDefinition) {
     const normalized = command.name.trim().toLowerCase()
-    this.commands.set(normalized, { ...command, name: normalized })
+    this.commands.set(this.commandKey(command.appId, normalized), { ...command, name: normalized })
   }
 
   subscribeToEvent(subscription: EventSubscription) {
@@ -82,7 +89,7 @@ export class AppInteractionRuntime {
   }
 
   async executeCommand(name: string, context: RuntimeContext, rule?: RateLimitRule) {
-    const command = this.commands.get(name.trim().toLowerCase())
+    const command = this.commands.get(this.commandKey(context.appId, name))
     if (!command) {
       return { ok: false, message: `Command ${name} is not registered.` }
     }
@@ -98,7 +105,19 @@ export class AppInteractionRuntime {
       }
     }
 
-    return command.execute(context)
+    try {
+      return await command.execute(context)
+    } catch (error) {
+      if (context.logger) {
+        context.logger.error("app command failed", { appId: context.appId, error })
+      } else {
+        console.error("app command failed", { appId: context.appId, error })
+      }
+      return {
+        ok: false,
+        message: error instanceof Error ? `App command failed. ${error.message}` : "App command failed.",
+      }
+    }
   }
 }
 

--- a/apps/web/types/database.ts
+++ b/apps/web/types/database.ts
@@ -1123,9 +1123,289 @@ export type Database = {
         }
         Relationships: []
       }
+      app_catalog: {
+        Row: {
+          id: string
+          slug: string
+          name: string
+          description: string | null
+          category: string
+          icon_url: string | null
+          homepage_url: string | null
+          identity: Json
+          install_scopes: string[]
+          permissions: string[]
+          trust_badge: Database['public']['Enums']['app_trust_badge'] | null
+          average_rating: number
+          review_count: number
+          is_published: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          slug: string
+          name: string
+          description?: string | null
+          category?: string
+          icon_url?: string | null
+          homepage_url?: string | null
+          identity?: Json
+          install_scopes?: string[]
+          permissions?: string[]
+          trust_badge?: Database['public']['Enums']['app_trust_badge'] | null
+          average_rating?: number
+          review_count?: number
+          is_published?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          slug?: string
+          name?: string
+          description?: string | null
+          category?: string
+          icon_url?: string | null
+          homepage_url?: string | null
+          identity?: Json
+          install_scopes?: string[]
+          permissions?: string[]
+          trust_badge?: Database['public']['Enums']['app_trust_badge'] | null
+          average_rating?: number
+          review_count?: number
+          is_published?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      app_catalog_credentials: {
+        Row: {
+          app_id: string
+          credentials: Json
+          updated_at: string
+        }
+        Insert: {
+          app_id: string
+          credentials?: Json
+          updated_at?: string
+        }
+        Update: {
+          app_id?: string
+          credentials?: Json
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "app_catalog_credentials_app_id_fkey"
+            columns: ["app_id"]
+            isOneToOne: true
+            referencedRelation: "app_catalog"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      app_reviews: {
+        Row: {
+          id: string
+          app_id: string
+          user_id: string
+          rating: number
+          body: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          app_id: string
+          user_id: string
+          rating: number
+          body?: string | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          app_id?: string
+          user_id?: string
+          rating?: number
+          body?: string | null
+          created_at?: string
+        }
+        Relationships: []
+      }
+      server_app_installs: {
+        Row: {
+          id: string
+          app_id: string
+          server_id: string
+          installed_by: string
+          install_scopes: string[]
+          granted_permissions: string[]
+          installed_at: string
+        }
+        Insert: {
+          id?: string
+          app_id: string
+          server_id: string
+          installed_by: string
+          install_scopes?: string[]
+          granted_permissions?: string[]
+          installed_at?: string
+        }
+        Update: {
+          id?: string
+          app_id?: string
+          server_id?: string
+          installed_by?: string
+          install_scopes?: string[]
+          granted_permissions?: string[]
+          installed_at?: string
+        }
+        Relationships: []
+      }
+      server_app_install_credentials: {
+        Row: {
+          app_install_id: string
+          credentials: Json
+          updated_at: string
+        }
+        Insert: {
+          app_install_id: string
+          credentials?: Json
+          updated_at?: string
+        }
+        Update: {
+          app_install_id?: string
+          credentials?: Json
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      app_commands: {
+        Row: {
+          id: string
+          app_id: string
+          command_name: string
+          description: string | null
+          schema: Json
+          enabled: boolean
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          app_id: string
+          command_name: string
+          description?: string | null
+          schema?: Json
+          enabled?: boolean
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          app_id?: string
+          command_name?: string
+          description?: string | null
+          schema?: Json
+          enabled?: boolean
+          created_at?: string
+        }
+        Relationships: []
+      }
+      app_event_subscriptions: {
+        Row: {
+          id: string
+          app_install_id: string
+          event_key: string
+          enabled: boolean
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          app_install_id: string
+          event_key: string
+          enabled?: boolean
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          app_install_id?: string
+          event_key?: string
+          enabled?: boolean
+          created_at?: string
+        }
+        Relationships: []
+      }
+      app_rate_limits: {
+        Row: {
+          app_id: string
+          requests_per_minute: number
+          burst: number
+          updated_at: string
+        }
+        Insert: {
+          app_id: string
+          requests_per_minute?: number
+          burst?: number
+          updated_at?: string
+        }
+        Update: {
+          app_id?: string
+          requests_per_minute?: number
+          burst?: number
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      app_usage_metrics: {
+        Row: {
+          id: number
+          app_id: string
+          server_id: string | null
+          metric_key: string
+          metric_value: number
+          occurred_at: string
+        }
+        Insert: {
+          id?: number
+          app_id: string
+          server_id?: string | null
+          metric_key: string
+          metric_value?: number
+          occurred_at?: string
+        }
+        Update: {
+          id?: number
+          app_id?: string
+          server_id?: string | null
+          metric_key?: string
+          metric_value?: number
+          occurred_at?: string
+        }
+        Relationships: []
+      }
     }
     Views: {
-      [_ in never]: never
+      app_catalog_public: {
+        Row: {
+          id: string
+          slug: string
+          name: string
+          description: string | null
+          category: string
+          icon_url: string | null
+          homepage_url: string | null
+          identity: Json
+          install_scopes: string[]
+          permissions: string[]
+          trust_badge: Database['public']['Enums']['app_trust_badge'] | null
+          average_rating: number
+          review_count: number
+          is_published: boolean
+          created_at: string
+          updated_at: string
+        }
+        Relationships: []
+      }
     }
     Functions: {
       is_server_member: {
@@ -1198,9 +1478,17 @@ export type Database = {
         Args: { p_name: string; p_description: string; p_icon_url: string; p_template: Json }
         Returns: Database['public']['Tables']['servers']['Row']
       }
+      recompute_app_rating: {
+        Args: { p_app_id: string }
+        Returns: void
+      }
+      bump_app_usage: {
+        Args: { p_app_id: string; p_server_id: string; p_metric_key: string; p_metric_value?: number }
+        Returns: void
+      }
     }
     Enums: {
-      [_ in never]: never
+      app_trust_badge: 'verified' | 'partner' | 'internal'
     }
     CompositeTypes: {
       [_ in never]: never

--- a/docs/app-security-model.md
+++ b/docs/app-security-model.md
@@ -14,7 +14,7 @@ This document defines the Vortex app platform security posture for app identity,
 
 - Install entries are in `server_app_installs` and scoped to a server.
 - `install_scopes` and `granted_permissions` are stored with the install snapshot.
-- Credentials are stored as JSON and must be redacted for UI/log rendering.
+- Credentials are stored in dedicated credential tables (`app_catalog_credentials`, `server_app_install_credentials`) with restrictive RLS and are not exposed in public catalog/install reads.
 - Permissions are deny-by-default: requested permissions must exist in granted permissions.
 
 ## 3) Command + event interaction runtime
@@ -34,7 +34,7 @@ This document defines the Vortex app platform security posture for app identity,
 
 - Existing webhook routes remain unchanged (`/api/servers/[serverId]/webhooks`, `/api/webhooks/[token]`).
 - App installs do not mutate webhook token format or webhook delivery contract.
-- Apps may carry webhook credentials, but credential rendering is redacted.
+- Any app-stored webhook-like credentials are isolated in credential tables and only redacted values should be rendered in application logs/UI.
 
 ## 6) Test coverage
 

--- a/supabase/migrations/00021_apps_platform.sql
+++ b/supabase/migrations/00021_apps_platform.sql
@@ -1,4 +1,4 @@
--- Apps platform: identity, install scopes/permissions, credentials, commands/events, analytics and rate limits.
+-- Apps platform: identity, install scopes/permissions, commands/events, analytics and rate limits.
 
 DO $$
 BEGIN
@@ -18,12 +18,17 @@ CREATE TABLE IF NOT EXISTS public.app_catalog (
   identity JSONB NOT NULL DEFAULT '{}'::jsonb,
   install_scopes TEXT[] NOT NULL DEFAULT ARRAY['server']::TEXT[],
   permissions TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
-  credentials JSONB NOT NULL DEFAULT '{}'::jsonb,
   trust_badge public.app_trust_badge,
   average_rating NUMERIC(3,2) NOT NULL DEFAULT 0,
   review_count INTEGER NOT NULL DEFAULT 0,
   is_published BOOLEAN NOT NULL DEFAULT TRUE,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.app_catalog_credentials (
+  app_id UUID PRIMARY KEY REFERENCES public.app_catalog(id) ON DELETE CASCADE,
+  credentials JSONB NOT NULL DEFAULT '{}'::jsonb,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
@@ -44,9 +49,14 @@ CREATE TABLE IF NOT EXISTS public.server_app_installs (
   installed_by UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
   install_scopes TEXT[] NOT NULL DEFAULT ARRAY['server']::TEXT[],
   granted_permissions TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
-  credentials JSONB NOT NULL DEFAULT '{}'::jsonb,
   installed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   UNIQUE (app_id, server_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.server_app_install_credentials (
+  app_install_id UUID PRIMARY KEY REFERENCES public.server_app_installs(id) ON DELETE CASCADE,
+  credentials JSONB NOT NULL DEFAULT '{}'::jsonb,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS public.app_commands (
@@ -85,17 +95,75 @@ CREATE TABLE IF NOT EXISTS public.app_usage_metrics (
   occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+CREATE INDEX IF NOT EXISTS idx_app_reviews_app_id ON public.app_reviews(app_id);
+CREATE INDEX IF NOT EXISTS idx_app_usage_metrics_app_id ON public.app_usage_metrics(app_id);
+CREATE INDEX IF NOT EXISTS idx_app_usage_metrics_server_id ON public.app_usage_metrics(server_id);
+CREATE INDEX IF NOT EXISTS idx_app_usage_metrics_occurred_at ON public.app_usage_metrics(occurred_at);
+CREATE INDEX IF NOT EXISTS idx_app_usage_metrics_app_id_occurred_at ON public.app_usage_metrics(app_id, occurred_at DESC);
+
+CREATE OR REPLACE FUNCTION public.app_catalog_set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS app_catalog_update_ts_tr ON public.app_catalog;
+CREATE TRIGGER app_catalog_update_ts_tr
+BEFORE UPDATE ON public.app_catalog
+FOR EACH ROW
+EXECUTE FUNCTION public.app_catalog_set_updated_at();
+
 ALTER TABLE public.app_catalog ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.app_catalog_credentials ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.app_reviews ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.server_app_installs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.server_app_install_credentials ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.app_commands ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.app_event_subscriptions ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.app_rate_limits ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.app_usage_metrics ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "apps are discoverable"
+-- Do not expose base app_catalog rows to anon/authenticated directly.
+REVOKE ALL ON TABLE public.app_catalog FROM anon, authenticated;
+GRANT SELECT ON TABLE public.app_catalog TO authenticated;
+REVOKE ALL ON TABLE public.app_catalog_credentials FROM anon, authenticated;
+REVOKE ALL ON TABLE public.server_app_install_credentials FROM anon, authenticated;
+
+CREATE OR REPLACE VIEW public.app_catalog_public AS
+SELECT
+  id,
+  slug,
+  name,
+  description,
+  category,
+  icon_url,
+  homepage_url,
+  identity,
+  install_scopes,
+  permissions,
+  trust_badge,
+  average_rating,
+  review_count,
+  is_published,
+  created_at,
+  updated_at
+FROM public.app_catalog
+WHERE is_published = TRUE;
+
+GRANT SELECT ON public.app_catalog_public TO anon, authenticated;
+
+CREATE POLICY "authenticated read app catalog"
   ON public.app_catalog FOR SELECT
-  USING (is_published = TRUE);
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY "service-role manage app credentials"
+  ON public.app_catalog_credentials FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
 
 CREATE POLICY "members read installs"
   ON public.server_app_installs FOR SELECT
@@ -105,9 +173,27 @@ CREATE POLICY "owners manage installs"
   ON public.server_app_installs FOR ALL
   USING (public.is_server_owner(server_id));
 
+CREATE POLICY "owners manage install credentials"
+  ON public.server_app_install_credentials FOR ALL
+  USING (EXISTS (
+    SELECT 1 FROM public.server_app_installs sai
+    WHERE sai.id = app_install_id
+      AND public.is_server_owner(sai.server_id)
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.server_app_installs sai
+    WHERE sai.id = app_install_id
+      AND public.is_server_owner(sai.server_id)
+  ));
+
 CREATE POLICY "members read commands"
   ON public.app_commands FOR SELECT
-  USING (EXISTS (SELECT 1 FROM public.server_app_installs sai WHERE sai.app_id = app_commands.app_id AND public.is_server_member(sai.server_id)));
+  USING (EXISTS (
+    SELECT 1
+    FROM public.server_app_installs sai
+    WHERE sai.app_id = app_commands.app_id
+      AND public.is_server_member(sai.server_id)
+  ));
 
 CREATE POLICY "members read subscriptions"
   ON public.app_event_subscriptions FOR SELECT
@@ -147,7 +233,7 @@ CREATE POLICY "members read usage"
 CREATE OR REPLACE FUNCTION public.recompute_app_rating(p_app_id UUID)
 RETURNS VOID
 LANGUAGE plpgsql
-SECURITY DEFINER
+SECURITY INVOKER
 SET search_path = public
 AS $$
 BEGIN
@@ -163,12 +249,17 @@ $$;
 CREATE OR REPLACE FUNCTION public.bump_app_usage(p_app_id UUID, p_server_id UUID, p_metric_key TEXT, p_metric_value INTEGER DEFAULT 1)
 RETURNS VOID
 LANGUAGE sql
-SECURITY DEFINER
+SECURITY INVOKER
 SET search_path = public
 AS $$
   INSERT INTO public.app_usage_metrics(app_id, server_id, metric_key, metric_value)
   VALUES (p_app_id, p_server_id, p_metric_key, COALESCE(p_metric_value, 1));
 $$;
+
+REVOKE EXECUTE ON FUNCTION public.recompute_app_rating(UUID) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.bump_app_usage(UUID, UUID, TEXT, INTEGER) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.recompute_app_rating(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.bump_app_usage(UUID, UUID, TEXT, INTEGER) TO authenticated;
 
 CREATE OR REPLACE FUNCTION public.on_app_review_change()
 RETURNS TRIGGER


### PR DESCRIPTION
### Motivation
- Provide a first-class apps platform so servers can discover, install, and manage third‑party apps with explicit scopes and permissions. 
- Support slash‑like commands and event subscriptions while protecting server resources with per‑app rate limits and usage analytics. 
- Preserve existing webhook behavior while enabling apps to carry credentials and be reviewed/trusted in a marketplace. 

### Description
- Introduces a Supabase migration `supabase/migrations/00021_apps_platform.sql` adding `app_catalog`, `server_app_installs`, `app_commands`, `app_event_subscriptions`, `app_rate_limits`, `app_usage_metrics`, review/trust fields, RLS policies, helper functions (`bump_app_usage`, `recompute_app_rating`) and seeded marketplace rows. 
- Adds server APIs for discovery and lifecycle: `GET /api/apps/discover` (search + category) and `GET/POST/DELETE /api/servers/[serverId]/apps` (install/uninstall with permission checks and usage RPC bumps). 
- Implements an in‑process app interaction runtime at `apps/web/lib/apps/runtime.ts` providing command registration/execution, event subscription registry, per‑app rate limiting, `validateInstallPermissions`, and `redactCredentials` for UI/log safety. 
- Adds UI surfaces: a marketplace view in Discover (`apps/web/app/channels/discover/page.tsx`) and an **Apps** tab in server settings with install/uninstall (`apps/web/components/settings/apps-tab.tsx` + server settings integration). 
- Adds documentation `docs/app-security-model.md` describing trust badges, install model, runtime controls, analytics, and webhook compatibility. 
- Adds unit tests `apps/web/lib/apps/runtime.test.ts` covering command execution, subscriptions, rate limits, permission validation, and credential redaction. 

### Testing
- Ran unit tests with `npm run -w apps/web test` and all tests passed (`10 files, 65 tests`).
- Ran TypeScript check with `npm run -w apps/web type-check` which succeeded after type fixes. 
- Ran linter with `npm run -w apps/web lint` which completed without errors. 
- Started the dev server (`next dev`) and captured a Discover screenshot to validate the UI; local Supabase env vars were not present so the dev server redirected to the login flow during that run (dev server itself launched successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca68ae5348325ad61f2a4d8a8ccbd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new apps marketplace where users can discover and install community-created and verified applications.
  * Added app installation and management interface within server settings, allowing users to install, uninstall, and manage installed apps.
  * Implemented app ratings, reviews, and trust badges to help users identify quality and verified applications.
  * Added app categories (Productivity, Operations, Community) for improved discoverability.
  * Apps now support interactive commands and event subscriptions for enhanced server automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->