### PR TITLE
Upgrade channel header with dense power-user utilities and persistent panel state

### DIFF
--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -271,13 +271,21 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
 
   useEffect(() => {
     if (typeof window === "undefined") return
-    const stored = window.localStorage.getItem(threadPanelStorageKey)
-    setThreadPanelOpen(stored == null ? true : stored === "true")
+    try {
+      const stored = window.localStorage.getItem(threadPanelStorageKey)
+      setThreadPanelOpen(stored == null ? true : stored === "true")
+    } catch {
+      setThreadPanelOpen(true)
+    }
   }, [threadPanelStorageKey])
 
   useEffect(() => {
     if (typeof window === "undefined") return
-    window.localStorage.setItem(threadPanelStorageKey, String(threadPanelOpen))
+    try {
+      window.localStorage.setItem(threadPanelStorageKey, String(threadPanelOpen))
+    } catch {
+      // Best effort only. Ignore storage failures.
+    }
   }, [threadPanelOpen, threadPanelStorageKey])
 
   useEffect(() => {

--- a/apps/web/components/chat/thread-list.tsx
+++ b/apps/web/components/chat/thread-list.tsx
@@ -20,6 +20,7 @@ export function ThreadList({ channelId, activeThreadId, filter, onSelectThread }
   const [archivedThreads, setArchivedThreads] = useState<ThreadRow[]>([])
   const [expanded, setExpanded] = useState(true)
   const [loadingArchived, setLoadingArchived] = useState(false)
+  const shouldShowArchived = showArchived || filter === "archived"
 
   // Load active threads
   useEffect(() => {
@@ -30,7 +31,7 @@ export function ThreadList({ channelId, activeThreadId, filter, onSelectThread }
 
   // Load archived threads on demand
   useEffect(() => {
-    if (!showArchived) return
+    if (!shouldShowArchived) return
     setLoadingArchived(true)
     fetch(`/api/threads?channelId=${channelId}&archived=true`)
       .then((r) => r.json())
@@ -39,7 +40,7 @@ export function ThreadList({ channelId, activeThreadId, filter, onSelectThread }
         setLoadingArchived(false)
       })
       .catch(() => setLoadingArchived(false))
-  }, [showArchived, channelId])
+  }, [shouldShowArchived, channelId, filter])
 
   // Realtime updates
   useRealtimeThreads(
@@ -80,7 +81,7 @@ export function ThreadList({ channelId, activeThreadId, filter, onSelectThread }
   const visibleArchivedThreads = filter === "active" ? [] : archivedThreads
   const shouldAllowArchivedToggle = filter !== "active"
 
-  if (visibleThreads.length === 0 && !showArchived && filter !== "archived") return null
+  if (visibleThreads.length === 0 && !shouldShowArchived) return null
 
   return (
     <div
@@ -121,6 +122,7 @@ export function ThreadList({ channelId, activeThreadId, filter, onSelectThread }
 
           {shouldAllowArchivedToggle && (
             <button
+              type="button"
               onClick={() => setShowArchived((s) => !s)}
               className="flex items-center gap-2 w-full px-4 py-1.5 text-xs hover:bg-white/5 transition-colors"
               style={{ color: "#6d6f78" }}
@@ -130,7 +132,7 @@ export function ThreadList({ channelId, activeThreadId, filter, onSelectThread }
             </button>
           )}
 
-          {(showArchived || filter === "archived") && (
+          {shouldShowArchived && (
             <>
               {loadingArchived ? (
                 <div className="px-4 py-2 text-xs" style={{ color: "#6d6f78" }}>

--- a/apps/web/lib/stores/app-store.ts
+++ b/apps/web/lib/stores/app-store.ts
@@ -5,13 +5,21 @@ const MEMBER_LIST_STORAGE_KEY = "vortexchat:ui:member-list-open"
 
 function loadMemberListOpen(): boolean {
   if (typeof window === "undefined") return true
-  const stored = window.localStorage.getItem(MEMBER_LIST_STORAGE_KEY)
-  return stored == null ? true : stored === "true"
+  try {
+    const stored = window.localStorage.getItem(MEMBER_LIST_STORAGE_KEY)
+    return stored == null ? true : stored === "true"
+  } catch {
+    return true
+  }
 }
 
 function persistMemberListOpen(open: boolean) {
   if (typeof window === "undefined") return
-  window.localStorage.setItem(MEMBER_LIST_STORAGE_KEY, String(open))
+  try {
+    window.localStorage.setItem(MEMBER_LIST_STORAGE_KEY, String(open))
+  } catch {
+    // Best effort only. Ignore storage failures (private mode / restricted environments).
+  }
 }
 
 export interface MemberForMention {


### PR DESCRIPTION
### Motivation
- Provide a denser, power-user friendly channel header with quick access to search, pinned view, mentions/inbox, thread filters, help, and an overflow menu to improve discoverability and action density.
- Make the member list and thread panel toggles explicit and persistent so users keep their preferred layout across navigations.

### Description
- Enhanced `ChatArea` to render a compact top-bar with actions and menus including Search, Pinned, `NotificationBell`, thread filter dropdown, Help, and a compact overflow `DropdownMenu`, and wired the search trigger to the existing `SearchModal` (`apps/web/components/chat/chat-area.tsx`).
- Added a channel/user-scoped persisted thread panel open state saved to `localStorage` and made the thread panel toggle explicit in the header so the panel reopens when selecting a thread (`apps/web/components/chat/chat-area.tsx`).
- Persisted member list visibility in the global Zustand store by hydrating from and writing to `localStorage` via `loadMemberListOpen`/`persistMemberListOpen` helpers and updated the toggle to persist changes (`apps/web/lib/stores/app-store.ts`).
- Extended `ThreadList` to accept a `filter` prop (`"all" | "active" | "archived"`) and apply it to which threads/archived sections are visible and whether the archived toggle is shown (`apps/web/components/chat/thread-list.tsx`).

### Testing
- Ran `npm run lint` in `apps/web` and it succeeded. 
- Ran `npm run type-check` in `apps/web` and it succeeded. 
- Launched the dev server with `npm run dev` and verified the app starts (rendering limited by missing Supabase env vars in this environment). 
- Captured a Playwright screenshot of the running dev server to validate the header/top-bar UI layout (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699caf0041fc8325ad5d5a9e16b0dbfc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added search modal for finding messages
  * Introduced thread filtering options (view all, active, or archived threads)
  * New header controls: pinned view, notifications, help menu, and more options
  * Thread panel with toggle button for expanded thread viewing

* **Improvements**
  * UI state persistence: thread panel and member list visibility now saved across sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->