### PR TITLE
Replace spinner-heavy states with skeletons and branded empty states

### DIFF
--- a/apps/web/app/channels/[serverId]/loading.tsx
+++ b/apps/web/app/channels/[serverId]/loading.tsx
@@ -1,0 +1,46 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function ServerLoading() {
+  return (
+    <div className="flex flex-1 overflow-hidden">
+      <aside className="w-60 flex-shrink-0 border-r px-3 py-4" style={{ background: "#2b2d31", borderColor: "#1e1f22" }}>
+        <Skeleton className="mb-4 h-8 w-full" />
+        <div className="space-y-2">
+          {Array.from({ length: 12 }).map((_, index) => (
+            <Skeleton key={index} className="h-7 w-full" />
+          ))}
+        </div>
+      </aside>
+
+      <main className="flex-1 border-r px-4 py-4" style={{ background: "#313338", borderColor: "#1e1f22" }}>
+        <Skeleton className="mb-4 h-10 w-full" />
+        <div className="space-y-4">
+          {Array.from({ length: 10 }).map((_, index) => (
+            <div key={index} className="flex gap-3">
+              <Skeleton className="h-10 w-10 rounded-full" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-3 w-32" />
+                <Skeleton className="h-3 w-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </main>
+
+      <aside className="w-60 flex-shrink-0 px-3 py-4" style={{ background: "#2b2d31" }}>
+        <Skeleton className="mb-3 h-3 w-20" />
+        <div className="space-y-3">
+          {Array.from({ length: 10 }).map((_, index) => (
+            <div key={index} className="flex items-center gap-2">
+              <Skeleton className="h-8 w-8 rounded-full" />
+              <div className="flex-1 space-y-1">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-2.5 w-28" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </aside>
+    </div>
+  )
+}

--- a/apps/web/app/channels/discover/page.tsx
+++ b/apps/web/app/channels/discover/page.tsx
@@ -5,6 +5,8 @@ import { useRouter } from "next/navigation"
 import { Search, Users, Compass, BadgeCheck, Star } from "lucide-react"
 import { MobileMenuButton } from "@/components/layout/mobile-nav"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Skeleton } from "@/components/ui/skeleton"
+import { BrandedEmptyState } from "@/components/ui/branded-empty-state"
 
 interface PublicServer {
   id: string
@@ -139,8 +141,30 @@ export default function DiscoverPage() {
 
       <div className="flex-1 overflow-y-auto px-8 py-6">
         {loading ? (
-          <div className="flex justify-center py-12"><div className="w-6 h-6 border-2 border-t-transparent rounded-full animate-spin" style={{ borderColor: "#5865f2", borderTopColor: "transparent" }} /></div>
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {Array.from({ length: 8 }).map((_, index) => (
+                <div key={index} className="rounded-lg p-4" style={{ background: "#2b2d31" }}>
+                  <Skeleton className="mb-3 h-20 w-full" />
+                  <Skeleton className="mb-2 h-4 w-2/3" />
+                  <Skeleton className="mb-3 h-3 w-full" />
+                  <div className="flex justify-between">
+                    <Skeleton className="h-3 w-16" />
+                    <Skeleton className="h-6 w-14" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
         ) : mode === "servers" ? (
+          servers.length === 0 ? (
+            <BrandedEmptyState
+              icon={Compass}
+              title="No servers found"
+              description="We couldn’t find public communities matching your filters yet."
+              hint="Try a broader term or switch to Apps to explore integrations."
+            />
+          ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
             {servers.map((server) => (
               <div key={server.id} className="rounded-lg overflow-hidden flex flex-col transition-transform hover:scale-[1.02]" style={{ background: "#2b2d31" }}>
@@ -158,7 +182,16 @@ export default function DiscoverPage() {
               </div>
             ))}
           </div>
+          )
         ) : (
+          apps.length === 0 ? (
+            <BrandedEmptyState
+              icon={BadgeCheck}
+              title="No apps in this lane"
+              description="No marketplace apps match your current search and category filters."
+              hint="Reset filters to all categories to discover more tools."
+            />
+          ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {apps.map((app) => (
               <div key={app.id} className="rounded-lg p-4" style={{ background: "#2b2d31" }}>
@@ -173,6 +206,7 @@ export default function DiscoverPage() {
               </div>
             ))}
           </div>
+          )
         )}
       </div>
     </div>

--- a/apps/web/components/chat/thread-list.tsx
+++ b/apps/web/components/chat/thread-list.tsx
@@ -6,6 +6,8 @@ import { format, formatDistanceToNow } from "date-fns"
 import type { ThreadRow } from "@/types/database"
 import { useRealtimeThreads } from "@/hooks/use-realtime-threads"
 import { cn } from "@/lib/utils/cn"
+import { BrandedEmptyState } from "@/components/ui/branded-empty-state"
+import { Skeleton } from "@/components/ui/skeleton"
 
 interface Props {
   channelId: string
@@ -81,7 +83,18 @@ export function ThreadList({ channelId, activeThreadId, filter, onSelectThread }
   const visibleArchivedThreads = filter === "active" ? [] : archivedThreads
   const shouldAllowArchivedToggle = filter !== "active"
 
-  if (visibleThreads.length === 0 && !shouldShowArchived) return null
+  if (visibleThreads.length === 0 && !shouldShowArchived) {
+    return (
+      <div className="mx-2 mt-2 mb-3 border-t pt-3" style={{ borderColor: "#1e1f22" }}>
+        <BrandedEmptyState
+          icon={MessageSquare}
+          title="No threads yet"
+          description="When someone starts a thread, it will appear here for focused side conversations."
+          hint="Use the + button on any message to kick one off."
+        />
+      </div>
+    )
+  }
 
   return (
     <div
@@ -135,8 +148,9 @@ export function ThreadList({ channelId, activeThreadId, filter, onSelectThread }
           {shouldShowArchived && (
             <>
               {loadingArchived ? (
-                <div className="px-4 py-2 text-xs" style={{ color: "#6d6f78" }}>
-                  Loading…
+                <div className="space-y-2 px-4 py-2">
+                  <Skeleton className="h-7 w-full" />
+                  <Skeleton className="h-7 w-11/12" />
                 </div>
               ) : (
                 visibleArchivedThreads.map((thread) => (

--- a/apps/web/components/chat/thread-panel.tsx
+++ b/apps/web/components/chat/thread-panel.tsx
@@ -9,6 +9,7 @@ import { MessageInput } from "@/components/chat/message-input"
 import { useRealtimeThreadMessages } from "@/hooks/use-realtime-threads"
 import { cn } from "@/lib/utils/cn"
 import { useToast } from "@/components/ui/use-toast"
+import { Skeleton } from "@/components/ui/skeleton"
 
 interface Props {
   thread: ThreadRow
@@ -274,8 +275,16 @@ export function ThreadPanel({ thread, currentUserId, onClose, onThreadUpdate }: 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto">
         {loading ? (
-          <div className="px-4 py-6 text-sm text-center" style={{ color: "#949ba4" }}>
-            Loading messages…
+          <div className="space-y-4 px-3 py-4">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <div key={index} className="flex gap-2">
+                <Skeleton className="h-8 w-8 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-3 w-24" />
+                  <Skeleton className="h-3 w-full" />
+                </div>
+              </div>
+            ))}
           </div>
         ) : messages.length === 0 ? (
           <div className="px-4 py-6 text-sm text-center" style={{ color: "#949ba4" }}>

--- a/apps/web/components/dm/dm-list.tsx
+++ b/apps/web/components/dm/dm-list.tsx
@@ -7,6 +7,8 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { Users, Plus } from "lucide-react"
 import { cn } from "@/lib/utils/cn"
 import { format, isToday } from "date-fns"
+import { Skeleton } from "@/components/ui/skeleton"
+import { BrandedEmptyState } from "@/components/ui/branded-empty-state"
 
 interface DMChannel {
   id: string
@@ -101,8 +103,19 @@ export function DMList({ onNavigate }: { onNavigate?: () => void } = {}) {
 
   if (loading) {
     return (
-      <div className="flex-1 flex items-center justify-center">
-        <div className="w-4 h-4 border-2 border-t-transparent rounded-full animate-spin" style={{ borderColor: "#5865f2", borderTopColor: "transparent" }} />
+      <div className="flex h-full flex-col px-2 pt-3">
+        <Skeleton className="mb-3 h-3 w-28" />
+        <div className="space-y-2">
+          {Array.from({ length: 7 }).map((_, index) => (
+            <div key={index} className="flex items-center gap-3 rounded-md px-2 py-1.5">
+              <Skeleton className="h-8 w-8 rounded-full" />
+              <div className="flex-1 space-y-1">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-2.5 w-32" />
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     )
   }
@@ -126,8 +139,13 @@ export function DMList({ onNavigate }: { onNavigate?: () => void } = {}) {
       {/* Channel list */}
       <div className="flex-1 overflow-y-auto px-2 space-y-0.5">
         {channels.length === 0 && (
-          <div className="text-center py-6 px-3">
-            <p className="text-xs" style={{ color: "#4e5058" }}>No conversations yet</p>
+          <div className="px-2 py-4">
+            <BrandedEmptyState
+              icon={Users}
+              title="Your DMs are quiet"
+              description="Start a new conversation to see your messages, status updates, and call history here."
+              hint="Tip: Right-click a member and choose Message to open a DM."
+            />
           </div>
         )}
         {channels.map((ch) => {

--- a/apps/web/components/layout/member-list.tsx
+++ b/apps/web/components/layout/member-list.tsx
@@ -11,6 +11,7 @@ import { ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem } 
 import { useToast } from "@/components/ui/use-toast"
 import type { RoleRow } from "@/types/database"
 import type { RealtimeChannel } from "@supabase/supabase-js"
+import { Skeleton } from "@/components/ui/skeleton"
 
 interface Props {
   serverId: string
@@ -50,11 +51,13 @@ export function MemberList({ serverId }: Props) {
   const { memberListOpen, currentUser } = useAppStore()
   const [members, setMembers] = useState<MemberData[]>([])
   const [presence, setPresence] = useState<PresenceState>({})
+  const [loadingMembers, setLoadingMembers] = useState(true)
   const channelRef = useRef<RealtimeChannel | null>(null)
   const supabase = createClientSupabaseClient()
 
   useEffect(() => {
     async function fetchMembers() {
+      setLoadingMembers(true)
       // Fetch members and roles separately — no FK between server_members and member_roles
       const [membersRes, rolesRes] = await Promise.all([
         supabase
@@ -85,6 +88,7 @@ export function MemberList({ serverId }: Props) {
       }))
 
       setMembers(merged)
+      setLoadingMembers(false)
 
       // Push lightweight member data to store for mention autocomplete
       useAppStore.getState().setMembers(serverId, merged.map((m) => ({
@@ -166,8 +170,22 @@ export function MemberList({ serverId }: Props) {
       style={{ background: "#2b2d31" }}
     >
       <ScrollArea className="flex-1 py-4">
+        {loadingMembers && (
+          <div className="space-y-3 px-3">
+            {Array.from({ length: 9 }).map((_, index) => (
+              <div key={index} className="flex items-center gap-2">
+                <Skeleton className="h-8 w-8 rounded-full" />
+                <div className="flex-1 space-y-1">
+                  <Skeleton className="h-3 w-20" />
+                  <Skeleton className="h-2.5 w-28" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
         {/* Online */}
-        {onlineMembers.length > 0 && (
+        {!loadingMembers && onlineMembers.length > 0 && (
           <div className="mb-2">
             <div
               className="px-4 py-1 text-xs font-semibold uppercase tracking-wider mb-1"
@@ -186,7 +204,7 @@ export function MemberList({ serverId }: Props) {
         )}
 
         {/* Offline */}
-        {offlineMembers.length > 0 && (
+        {!loadingMembers && offlineMembers.length > 0 && (
           <div>
             <div
               className="px-4 py-1 text-xs font-semibold uppercase tracking-wider mb-1"

--- a/apps/web/components/modals/search-modal.tsx
+++ b/apps/web/components/modals/search-modal.tsx
@@ -5,6 +5,8 @@ import { Search, X, Loader2, Hash, Calendar } from "lucide-react"
 import { format } from "date-fns"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import type { MessageWithAuthor } from "@/types/database"
+import { BrandedEmptyState } from "@/components/ui/branded-empty-state"
+import { Skeleton } from "@/components/ui/skeleton"
 
 interface Props {
   serverId: string
@@ -101,21 +103,38 @@ export function SearchModal({ serverId, onClose, onJumpToMessage }: Props) {
         {/* Results */}
         <div className="flex-1 overflow-y-auto">
           {!query.trim() ? (
-            <div className="flex flex-col items-center justify-center py-12 gap-2">
-              <Search className="w-10 h-10" style={{ color: "#4e5058" }} />
-              <p className="text-sm" style={{ color: "#949ba4" }}>
-                Search messages across this server
-              </p>
-              <p className="text-xs" style={{ color: "#4e5058" }}>
-                Use quotes for exact phrases, e.g. &quot;hello world&quot;
-              </p>
+            <div className="px-4 py-10">
+              <BrandedEmptyState
+                icon={Search}
+                title="Search this server"
+                description="Find messages, links, and snippets across every channel you can access."
+                hint="Use quotes for exact phrases, e.g. “hello world”."
+              />
             </div>
           ) : results.length === 0 && !loading ? (
-            <div className="flex flex-col items-center justify-center py-12 gap-2">
-              <p className="text-sm" style={{ color: "#949ba4" }}>No results for &ldquo;{query}&rdquo;</p>
+            <div className="px-4 py-10">
+              <BrandedEmptyState
+                icon={Calendar}
+                title="No results yet"
+                description={`No results for “${query}”.`}
+                hint="Try fewer words, another channel keyword, or a different timeframe."
+              />
             </div>
           ) : (
             <>
+              {loading && results.length === 0 && (
+                <div className="space-y-3 px-4 py-4">
+                  {Array.from({ length: 5 }).map((_, index) => (
+                    <div key={index} className="flex gap-3">
+                      <Skeleton className="h-8 w-8 rounded-full" />
+                      <div className="flex-1 space-y-2">
+                        <Skeleton className="h-3 w-40" />
+                        <Skeleton className="h-3 w-full" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
               {total > 0 && (
                 <div className="px-4 py-2 text-xs" style={{ color: "#949ba4" }}>
                   {total} result{total !== 1 ? "s" : ""}

--- a/apps/web/components/ui/branded-empty-state.tsx
+++ b/apps/web/components/ui/branded-empty-state.tsx
@@ -1,0 +1,22 @@
+import type { LucideIcon } from "lucide-react"
+
+interface Props {
+  icon: LucideIcon
+  title: string
+  description: string
+  hint?: string
+}
+
+export function BrandedEmptyState({ icon: Icon, title, description, hint }: Props) {
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center justify-center rounded-2xl border border-white/10 bg-[#232428] px-6 py-10 text-center">
+      <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-[#5865f2]/20 text-[#9da7ff]">
+        <Icon className="h-7 w-7" />
+      </div>
+      <h3 className="text-base font-semibold text-white">{title}</h3>
+      <p className="mt-1 text-sm" style={{ color: "#b5bac1" }}>{description}</p>
+      {hint && <p className="mt-3 text-xs" style={{ color: "#949ba4" }}>{hint}</p>}
+    </div>
+  )
+}
+

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -1,0 +1,6 @@
+import { cn } from "@/lib/utils/cn"
+
+export function Skeleton({ className }: { className?: string }) {
+  return <div className={cn("animate-pulse rounded-md bg-white/10", className)} aria-hidden="true" />
+}
+


### PR DESCRIPTION
### Motivation

- Improve perceived loading performance by replacing spinner-heavy UIs with low-fidelity skeletons for channel list, message feed, and member panel.
- Provide consistent, branded empty states for discover, threads, DMs, and search to make empty views more informative and on-brand.
- Centralize loading/empty UI patterns via small reusable primitives to reduce duplication and simplify future updates.

### Description

- Added a `Skeleton` component at `apps/web/components/ui/skeleton.tsx` to render pulse placeholders and a `BrandedEmptyState` component at `apps/web/components/ui/branded-empty-state.tsx` for themed empty-state cards.
- Introduced a server loading shell at `apps/web/app/channels/[serverId]/loading.tsx` that renders skeletons for the channel sidebar, main message feed, and member panel.
- Replaced spinner flows and added empty-state UIs in several places: `apps/web/components/dm/dm-list.tsx`, `apps/web/components/chat/thread-list.tsx`, `apps/web/components/chat/thread-panel.tsx`, `apps/web/components/layout/member-list.tsx`, `apps/web/components/modals/search-modal.tsx`, and `apps/web/app/channels/discover/page.tsx`.
- Commit includes 2 new files and updates across multiple components to use the new primitives and present branded empty states when result sets are empty.

### Testing

- Ran targeted ESLint on the changed files which reported only configuration-based warnings for ignored files via `npx eslint ...` (warnings only). 
- Ran `npm run lint -- --filter=@vortex/web` which completed successfully. 
- Ran `npm run type-check -- --filter=@vortex/web` (`tsc --noEmit`) which completed successfully with no type errors. 
- Started the dev server and captured a Playwright screenshot of the Discover empty state (artifact: `browser:/tmp/codex_browser_invocations/335075afc55e7b3f/artifacts/artifacts/discover-empty-state.png`); the server compiled and the screenshot was produced, though runtime warnings were logged for Google Fonts and a missing Supabase env during a `/login` request (non-blocking to the UI changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc0787060832592811999fdea814e)