### PR TITLE
Remove empty "No threads yet" placeholder from thread list

### DIFF
--- a/apps/web/components/chat/thread-list.tsx
+++ b/apps/web/components/chat/thread-list.tsx
@@ -6,7 +6,6 @@ import { format, formatDistanceToNow } from "date-fns"
 import type { ThreadRow } from "@/types/database"
 import { useRealtimeThreads } from "@/hooks/use-realtime-threads"
 import { cn } from "@/lib/utils/cn"
-import { BrandedEmptyState } from "@/components/ui/branded-empty-state"
 import { Skeleton } from "@/components/ui/skeleton"
 
 interface Props {
@@ -84,16 +83,7 @@ export function ThreadList({ channelId, activeThreadId, filter, onSelectThread }
   const shouldAllowArchivedToggle = filter !== "active"
 
   if (visibleThreads.length === 0 && !shouldShowArchived) {
-    return (
-      <div className="mx-2 mt-2 mb-3 border-t pt-3" style={{ borderColor: "#1e1f22" }}>
-        <BrandedEmptyState
-          icon={MessageSquare}
-          title="No threads yet"
-          description="When someone starts a thread, it will appear here for focused side conversations."
-          hint="Use the + button on any message to kick one off."
-        />
-      </div>
-    )
+    return null
   }
 
   return (


### PR DESCRIPTION
### Motivation
- The empty-state card showing "No threads yet" is unnecessary and should be removed so channels with no threads render no placeholder panel.

### Description
- Remove the `BrandedEmptyState` import from `apps/web/components/chat/thread-list.tsx`.
- Replace the empty-state JSX with `return null` when there are no visible threads and archived threads are not shown, so nothing is rendered in that case.

### Testing
- Ran `npm run type-check` in `apps/web` and the TypeScript check passed. 
- Ran ESLint on the file with `npx eslint` which reported a workspace configuration warning that the file was ignored. 
- Started the dev server and captured a Playwright screenshot to validate the UI change, noting the local runtime hit a missing Supabase env in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc4fcdab883259a99b7af5ffd0370)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the empty state message that appeared when no threads were available in the thread list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->