### PR TITLE
Fix delete actions, channel/category drag-and-drop, and voice disconnect UX

### DIFF
--- a/apps/web/components/channels/announcement-channel.tsx
+++ b/apps/web/components/channels/announcement-channel.tsx
@@ -203,7 +203,7 @@ export function AnnouncementChannel({ channel, initialMessages, currentUserId, s
                   if (!error) setMessages((prev) => prev.map((m) => m.id === message.id ? { ...m, content, edited_at: new Date().toISOString() } : m))
                 }}
                 onDelete={async () => {
-                  const { error } = await supabase.from("messages").update({ deleted_at: new Date().toISOString() }).eq("id", message.id)
+                  const { error } = await supabase.from("messages").delete().eq("id", message.id)
                   if (!error) setMessages((prev) => prev.filter((m) => m.id !== message.id))
                 }}
                 onReaction={async (emoji) => {

--- a/apps/web/components/channels/forum-channel.tsx
+++ b/apps/web/components/channels/forum-channel.tsx
@@ -219,7 +219,7 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
                 if (!error) setMessages((prev) => prev.map((m) => m.id === activeThread.id ? { ...m, content, edited_at: new Date().toISOString() } : m))
               }}
               onDelete={async () => {
-                const { error } = await supabase.from("messages").update({ deleted_at: new Date().toISOString() }).eq("id", activeThread.id)
+                const { error } = await supabase.from("messages").delete().eq("id", activeThread.id)
                 if (!error) { setMessages((prev) => prev.filter((m) => m.id !== activeThread.id)); setView("list"); setActiveThread(null) }
               }}
               onReaction={async (emoji) => {
@@ -256,7 +256,7 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
                     if (!error) setMessages((prev) => prev.map((m) => m.id === reply.id ? { ...m, content, edited_at: new Date().toISOString() } : m))
                   }}
                   onDelete={async () => {
-                    const { error } = await supabase.from("messages").update({ deleted_at: new Date().toISOString() }).eq("id", reply.id)
+                    const { error } = await supabase.from("messages").delete().eq("id", reply.id)
                     if (!error) setMessages((prev) => prev.filter((m) => m.id !== reply.id))
                   }}
                   onReaction={async (emoji) => {

--- a/apps/web/components/channels/media-channel.tsx
+++ b/apps/web/components/channels/media-channel.tsx
@@ -187,7 +187,7 @@ export function MediaChannel({ channel, initialMessages, currentUserId, serverId
                   if (!error) setMessages((prev) => prev.map((m) => m.id === message.id ? { ...m, content, edited_at: new Date().toISOString() } : m))
                 }}
                 onDelete={async () => {
-                  const { error } = await supabase.from("messages").update({ deleted_at: new Date().toISOString() }).eq("id", message.id)
+                  const { error } = await supabase.from("messages").delete().eq("id", message.id)
                   if (!error) setMessages((prev) => prev.filter((m) => m.id !== message.id))
                 }}
                 onReaction={async (emoji) => {

--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -892,12 +892,11 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
                   onDelete={async () => {
                     const { error } = await supabase
                       .from("messages")
-                      .update({ deleted_at: new Date().toISOString() })
+                      .delete()
                       .eq("id", message.id)
-                    if (!error) {
-                      setMessages((prev) => prev.filter((m) => m.id !== message.id))
-                      setAndPersistOutbox((current) => removeOutboxEntry(current, message.id))
-                    }
+                    if (error) throw error
+                    setMessages((prev) => prev.filter((m) => m.id !== message.id))
+                    setAndPersistOutbox((current) => removeOutboxEntry(current, message.id))
                   }}
                   onReaction={async (emoji) => {
                     const existing = message.reactions.find(

--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -56,8 +56,13 @@ export function MessageItem({
   const isOwn = message.author_id === currentUserId
 
   async function confirmDelete() {
-    await onDelete()
-    setShowDeleteDialog(false)
+    try {
+      await onDelete()
+      setShowDeleteDialog(false)
+      toast({ title: "Message deleted" })
+    } catch (error: any) {
+      toast({ variant: "destructive", title: "Failed to delete message", description: error?.message ?? "Please try again." })
+    }
   }
 
   const displayName =

--- a/apps/web/components/chat/thread-panel.tsx
+++ b/apps/web/components/chat/thread-panel.tsx
@@ -326,7 +326,7 @@ export function ThreadPanel({ thread, currentUserId, onClose, onThreadUpdate }: 
                   onDelete={async () => {
                     const { error } = await supabase
                       .from("messages")
-                      .update({ deleted_at: new Date().toISOString() })
+                      .delete()
                       .eq("id", message.id)
                     if (!error) {
                       setMessages((prev) => prev.filter((m) => m.id !== message.id))

--- a/apps/web/components/layout/channel-sidebar.tsx
+++ b/apps/web/components/layout/channel-sidebar.tsx
@@ -10,6 +10,7 @@ import {
   DndContext,
   DragOverlay,
   PointerSensor,
+  useDroppable,
   useSensor,
   useSensors,
   closestCenter,
@@ -61,6 +62,16 @@ type GroupedChannels = {
   category: ChannelRow | null
   channels: ChannelRow[]
 }[]
+
+const CATEGORY_DRAG_PREFIX = "category:"
+
+function getCategoryDragId(categoryId: string) {
+  return `${CATEGORY_DRAG_PREFIX}${categoryId}`
+}
+
+function getCategoryIdFromDragId(id: string) {
+  return id.startsWith(CATEGORY_DRAG_PREFIX) ? id.slice(CATEGORY_DRAG_PREFIX.length) : null
+}
 
 function groupChannels(channels: ChannelRow[]): GroupedChannels {
   const sorted = [...channels].sort((a, b) => a.position - b.position)
@@ -250,6 +261,9 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
     if (!over) { setOverContainerId(null); return }
 
     const draggedId = active.id as string
+    if (getCategoryIdFromDragId(draggedId)) {
+      return
+    }
     const overId = over.id as string
 
     const targetContainer = itemsRef.current[overId] !== undefined ? overId : findContainer(overId)
@@ -290,6 +304,14 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
     const draggedId = active.id as string
     const overId = over.id as string
 
+    const draggedCategoryId = getCategoryIdFromDragId(draggedId)
+    const overCategoryId = getCategoryIdFromDragId(overId)
+
+    if (draggedCategoryId && overCategoryId && draggedCategoryId !== overCategoryId) {
+      persistCategoryOrder(draggedCategoryId, overCategoryId)
+      return
+    }
+
     // Read from ref to get the latest state (avoids stale closure from batched updates)
     const latestItems = itemsRef.current
     const sourceContainer = findContainer(draggedId)
@@ -311,6 +333,33 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
       // Cross-container move was already applied in handleDragOver; persist both
       persistChannelOrder(sourceContainer, latestItems[sourceContainer] ?? [])
       persistChannelOrder(targetContainer, latestItems[targetContainer] ?? [])
+    }
+  }
+
+  async function persistCategoryOrder(draggedCategoryId: string, overCategoryId: string) {
+    const categories = channels
+      .filter((channel) => channel.type === "category")
+      .sort((a, b) => a.position - b.position)
+    const oldIndex = categories.findIndex((category) => category.id === draggedCategoryId)
+    const newIndex = categories.findIndex((category) => category.id === overCategoryId)
+    if (oldIndex === -1 || newIndex === -1) return
+
+    const reordered = arrayMove(categories, oldIndex, newIndex)
+    const updates = reordered.map((category, index) => ({ id: category.id, position: index }))
+    updates.forEach(({ id, position }) => updateChannel(id, { position }))
+
+    const supabase = createClientSupabaseClient()
+    try {
+      const results = await Promise.all(
+        updates.map(({ id, position }) =>
+          supabase.from("channels").update({ position }).eq("id", id)
+        )
+      )
+      const failed = results.find(({ error }) => error)
+      if (failed?.error) throw failed.error
+    } catch (error: any) {
+      categories.forEach((category) => updateChannel(category.id, { position: category.position }))
+      toast({ variant: "destructive", title: "Failed to save category order", description: error.message })
     }
   }
 
@@ -348,6 +397,8 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
   }
 
   const activeChannel = activeId ? channels.find((c) => c.id === activeId) : null
+  const activeCategoryId = activeId ? getCategoryIdFromDragId(activeId) : null
+  const activeCategory = activeCategoryId ? channels.find((c) => c.id === activeCategoryId) : null
 
   // Rebuild grouped view from live items map to reflect drag state
   const liveGrouped = grouped.map(({ category }) => {
@@ -397,6 +448,10 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
             onDragOver={handleDragOver}
             onDragEnd={handleDragEnd}
           >
+            <SortableContext
+              items={grouped.filter((g) => g.category).map((g) => getCategoryDragId(g.category!.id))}
+              strategy={verticalListSortingStrategy}
+            >
             {liveGrouped.map(({ category, channels: categoryChannels }) => {
               const containerId = category?.id ?? NO_CATEGORY
               const isCollapsed = category ? collapsedCategories.has(category.id) : false
@@ -406,6 +461,7 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
                   {category && (
                     <CategoryHeader
                       category={category}
+                      containerId={containerId}
                       isCollapsed={isCollapsed}
                       canManageChannels={canManageChannels}
                       isDragOver={overContainerId === containerId && !!activeId}
@@ -416,6 +472,8 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
                       }}
                     />
                   )}
+
+                  {!category && <DropContainer id={containerId} />}
 
                   {!isCollapsed && (
                     <SortableContext
@@ -456,6 +514,7 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
                 </div>
               )
             })}
+            </SortableContext>
 
             <DragOverlay dropAnimation={null}>
               {activeChannel ? (
@@ -465,6 +524,14 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
                 >
                   <ChannelIcon channel={activeChannel} isVoiceActive={false} />
                   <span className="truncate">{activeChannel.name}</span>
+                </div>
+              ) : activeCategory ? (
+                <div
+                  className="flex items-center gap-2 px-2 py-1.5 rounded text-sm text-white shadow-lg opacity-90"
+                  style={{ background: '#313338', width: '208px' }}
+                >
+                  <ChevronDown className="w-3 h-3 tertiary-metadata" />
+                  <span className="truncate uppercase text-xs font-semibold tracking-wider">{activeCategory.name}</span>
                 </div>
               ) : null}
             </DragOverlay>
@@ -577,6 +644,7 @@ function ChannelIcon({ channel, isVoiceActive }: { channel: ChannelRow; isVoiceA
 
 function CategoryHeader({
   category,
+  containerId,
   isCollapsed,
   canManageChannels,
   isDragOver,
@@ -584,20 +652,32 @@ function CategoryHeader({
   onAddChannel,
 }: {
   category: ChannelRow
+  containerId: string
   isCollapsed: boolean
   canManageChannels: boolean
   isDragOver: boolean
   onToggle: () => void
   onAddChannel: () => void
 }) {
+  const { setNodeRef } = useDroppable({ id: containerId })
+  const sortable = useSortable({ id: getCategoryDragId(category.id), disabled: !canManageChannels })
+  const style = {
+    transform: CSS.Transform.toString(sortable.transform),
+    transition: sortable.transition,
+    opacity: sortable.isDragging ? 0.4 : 1,
+  }
+
   return (
     <div
+      ref={sortable.setNodeRef}
+      style={style}
       className={cn(
         "flex items-center justify-between px-2 py-1 group rounded mx-1 motion-interactive",
         isDragOver && "bg-white/5"
       )}
     >
       <button
+        ref={setNodeRef}
         type="button"
         onClick={onToggle}
         className="flex items-center gap-1 flex-1 min-w-0 text-left focus-ring rounded-sm"
@@ -613,21 +693,36 @@ function CategoryHeader({
         </span>
       </button>
       {canManageChannels && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={(e) => { e.stopPropagation(); onAddChannel() }}
-              className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-white motion-interactive focus-ring rounded-sm tertiary-metadata" aria-label={`Create channel in ${category.name}`}
-            >
-              <Plus className="w-4 h-4" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>Create Channel</TooltipContent>
-        </Tooltip>
+        <div className="flex items-center">
+          <span
+            {...sortable.attributes}
+            {...sortable.listeners}
+            className="opacity-0 group-hover:opacity-100 cursor-grab active:cursor-grabbing tertiary-metadata"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <GripVertical className="w-3 h-3" />
+          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); onAddChannel() }}
+                className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-white motion-interactive focus-ring rounded-sm tertiary-metadata" aria-label={`Create channel in ${category.name}`}
+              >
+                <Plus className="w-4 h-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Create Channel</TooltipContent>
+          </Tooltip>
+        </div>
       )}
     </div>
   )
+}
+
+function DropContainer({ id }: { id: string }) {
+  const { setNodeRef } = useDroppable({ id })
+  return <div ref={setNodeRef} className="h-0" aria-hidden />
 }
 
 function SortableChannelItem({

--- a/apps/web/components/layout/user-panel.tsx
+++ b/apps/web/components/layout/user-panel.tsx
@@ -126,7 +126,23 @@ export function UserPanel() {
           <Tooltip>
             <TooltipTrigger asChild>
               <button
-                onClick={() => setVoiceChannel(null, null)}
+                onClick={async () => {
+                  try {
+                    const latestUser = useAppStore.getState().currentUser
+                    if (latestUser) {
+                      const { error } = await supabase
+                        .from("voice_states")
+                        .delete()
+                        .eq("user_id", latestUser.id)
+                        .eq("channel_id", voiceChannelId)
+                      if (error) throw error
+                    }
+                    setVoiceChannel(null, null)
+                    toast({ title: "Disconnected from voice" })
+                  } catch (error: any) {
+                    toast({ variant: "destructive", title: "Failed to disconnect", description: error.message })
+                  }
+                }}
                 className="w-7 h-7 rounded flex items-center justify-center hover:bg-red-500/20 transition-colors"
                 style={{ color: '#f23f43' }}
               >

--- a/apps/web/components/modals/server-settings-modal.tsx
+++ b/apps/web/components/modals/server-settings-modal.tsx
@@ -29,9 +29,11 @@ interface Props {
 
 export function ServerSettingsModal({ open, onClose, server, isOwner, channels = [] }: Props) {
   const { toast } = useToast()
-  const { updateServer, servers } = useAppStore()
+  const { updateServer, removeServer, servers } = useAppStore()
   const liveServer = servers.find((s) => s.id === server.id) ?? server
   const [loading, setLoading] = useState(false)
+  const [deletingServer, setDeletingServer] = useState(false)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [name, setName] = useState(liveServer.name)
   const [description, setDescription] = useState(liveServer.description ?? "")
   const supabase = createClientSupabaseClient()
@@ -82,6 +84,25 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
   function copyInvite() {
     navigator.clipboard.writeText(liveServer.invite_code)
     toast({ title: "Invite code copied!" })
+  }
+
+  async function handleDeleteServer() {
+    setDeletingServer(true)
+    try {
+      const { error } = await supabase.from("servers").delete().eq("id", server.id)
+      if (error) throw error
+      removeServer(server.id)
+      toast({ title: "Server deleted" })
+      setShowDeleteConfirm(false)
+      onClose()
+      if (typeof window !== "undefined") {
+        window.location.assign("/channels/me")
+      }
+    } catch (error: any) {
+      toast({ variant: "destructive", title: "Failed to delete server", description: error.message })
+    } finally {
+      setDeletingServer(false)
+    }
   }
 
   return (
@@ -150,6 +171,23 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
                   Save Changes
                 </Button>
               )}
+
+              {isOwner && (
+                <div className="mt-6 rounded-md border p-4" style={{ borderColor: "rgba(242,63,67,0.45)", background: "rgba(242,63,67,0.08)" }}>
+                  <p className="text-sm font-semibold text-white">Danger Zone</p>
+                  <p className="mt-1 text-xs" style={{ color: "#fca5a5" }}>
+                    Deleting this server permanently removes all channels and messages.
+                  </p>
+                  <Button
+                    variant="destructive"
+                    className="mt-3"
+                    onClick={() => setShowDeleteConfirm(true)}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    Delete Server
+                  </Button>
+                </div>
+              )}
             </TabsContent>
 
             <TabsContent value="invites" className="mt-0 space-y-4">
@@ -193,7 +231,28 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
 
           </div>
         </Tabs>
-      </DialogContent>
+    </DialogContent>
+
+      <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <DialogContent style={{ background: '#313338', borderColor: '#1e1f22', color: '#f2f3f5' }}>
+          <DialogHeader>
+            <DialogTitle>Delete server?</DialogTitle>
+            <DialogDescription style={{ color: '#b5bac1' }}>
+              This action is irreversible and will permanently remove
+              <span className="font-semibold text-white"> {liveServer.name}</span>.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="secondary" onClick={() => setShowDeleteConfirm(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDeleteServer} disabled={deletingServer}>
+              {deletingServer && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Delete Server
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Dialog>
   )
 }


### PR DESCRIPTION
### Motivation
- Address several UX bugs: message delete button was effectively no-op, there was no way to delete a server, channels and categories could not be reordered/dragged reliably, and the voice "end" button did not clearly disconnect the user.

### Description
- Make message deletion a hard delete and surface success/error feedback by changing message delete flows to use `.delete()` and adding toasts on confirmation in the message UI and related channel/thread components.
- Add server deletion to Server Settings with a Danger Zone UI, confirmation dialog, backend delete call, store cleanup via `removeServer`, and redirect to `/channels/me` after success.
- Improve channel sidebar DnD by adding droppable category containers, category drag IDs, sortable category drag handles, an overlay for category dragging, and `persistCategoryOrder` to persist category reorder changes to the backend with optimistic updates and rollback on error.
- Update voice disconnect behavior in the user panel to remove the user's `voice_states` row on disconnect, clear local voice state via `setVoiceChannel(null,null)`, and show a success/error toast so the UI accurately reflects leaving voice.

### Testing
- Ran `npm run -s type-check` in `apps/web` and it passed. 
- Ran `npm run -s lint` in `apps/web` and it passed. 
- Started the dev server and captured a browser screenshot to validate UI changes (`artifact: browser:/tmp/codex_browser_invocations/.../bugfixes-overview.png`).
- Note: running root `npm run -s type-check` fails in `apps/signal` due to pre-existing missing WebRTC DOM types (`RTCSessionDescriptionInit`, `RTCIceCandidateInit`), which is unrelated to these web changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc72c5dd08325b744b242a3414384)