### PR TITLE
Simplify channel header actions and close emoji picker on outside click

### DIFF
--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { AtSign, CircleHelp, Filter, Hash, MessageSquareText, MoreHorizontal, Pin, Search, Users, Briefcase } from "lucide-react"
+import { CircleHelp, Hash, MessageSquareText, Pin, Search, Users, Briefcase } from "lucide-react"
 import { createClientSupabaseClient } from "@/lib/supabase/client"
 import { useAppStore } from "@/lib/stores/app-store"
 import { useShallow } from "zustand/react/shallow"
@@ -14,17 +14,8 @@ import { useTyping } from "@/hooks/use-typing"
 import { useToast } from "@/components/ui/use-toast"
 import { ThreadPanel } from "@/components/chat/thread-panel"
 import { ThreadList } from "@/components/chat/thread-list"
-import { NotificationBell } from "@/components/notifications/notification-bell"
 import { SearchModal } from "@/components/modals/search-modal"
 import { WorkspacePanel } from "@/components/chat/workspace-panel"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import {
   type OutboxEntry,
   getDraft,
@@ -68,7 +59,6 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
   const [showSearchModal, setShowSearchModal] = useState(false)
   const [workspaceOpen, setWorkspaceOpen] = useState(false)
   const [threadPanelOpen, setThreadPanelOpen] = useState(true)
-  const [threadFilter, setThreadFilter] = useState<"all" | "active" | "archived">("all")
   const bottomRef = useRef<HTMLDivElement>(null)
   const messageScrollerRef = useRef<HTMLDivElement>(null)
   const previousLastMessageIdRef = useRef<string | null>(initialMessages[initialMessages.length - 1]?.id ?? null)
@@ -797,26 +787,6 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
               <Pin className="w-4 h-4" style={{ color: "#b5bac1" }} />
             </button>
 
-            <NotificationBell userId={currentUserId} />
-
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  className="motion-interactive motion-press p-1.5 rounded hover:bg-white/10"
-                  title="Thread filters"
-                  aria-label="Thread filters"
-                >
-                  <Filter className="w-4 h-4" style={{ color: "#b5bac1" }} />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-[180px]" style={{ background: "#232428", borderColor: "#1e1f22", color: "#dcddde" }}>
-                <DropdownMenuLabel>Thread filters</DropdownMenuLabel>
-                <DropdownMenuItem onClick={() => setThreadFilter("all")}>All threads</DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setThreadFilter("active")}>Active only</DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setThreadFilter("archived")}>Archived only</DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-
             <button
               onClick={() => toast({ title: "Help", description: "Shortcuts: Ctrl/Cmd+K (Quick Switcher), Ctrl/Cmd+F (Search)." })}
               className="motion-interactive motion-press p-1.5 rounded hover:bg-white/10"
@@ -826,32 +796,12 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
               <CircleHelp className="w-4 h-4" style={{ color: "#b5bac1" }} />
             </button>
 
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  className="motion-interactive motion-press p-1.5 rounded hover:bg-white/10"
-                  title="More options"
-                  aria-label="More options"
-                >
-                  <MoreHorizontal className="w-4 h-4" style={{ color: "#b5bac1" }} />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-[200px]" style={{ background: "#232428", borderColor: "#1e1f22", color: "#dcddde" }}>
-                <DropdownMenuLabel>Channel utilities</DropdownMenuLabel>
-                <DropdownMenuItem onClick={() => setShowSearchModal(true)}><Search className="w-3.5 h-3.5 mr-2" /> Search</DropdownMenuItem>
-                <DropdownMenuItem onClick={toggleMemberList}><Users className="w-3.5 h-3.5 mr-2" /> {memberListOpen ? "Hide" : "Show"} member list</DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setThreadPanelOpen((open) => !open)}><MessageSquareText className="w-3.5 h-3.5 mr-2" /> {threadPanelOpen ? "Hide" : "Show"} thread panel</DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => toast({ title: "Mentions inbox", description: "Your inbox highlights mentions and replies in real time." })}><AtSign className="w-3.5 h-3.5 mr-2" /> Mentions inbox</DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-
             <button
               onClick={toggleMemberList}
               className="motion-interactive motion-press p-1.5 rounded hover:bg-white/10"
               title={memberListOpen ? "Hide Member List" : "Show Member List"}
             >
-              <Users className="w-5 h-5" style={{ color: memberListOpen ? '#f2f3f5' : '#949ba4' }} />
+              <Users className="w-4 h-4" style={{ color: memberListOpen ? '#f2f3f5' : '#949ba4' }} />
             </button>
 
             <button
@@ -859,7 +809,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
               className="motion-interactive motion-press p-1.5 rounded hover:bg-white/10"
               title={threadPanelOpen ? "Hide Thread Panel" : "Show Thread Panel"}
             >
-              <MessageSquareText className="w-5 h-5" style={{ color: threadPanelOpen ? '#f2f3f5' : '#949ba4' }} />
+              <MessageSquareText className="w-4 h-4" style={{ color: threadPanelOpen ? '#f2f3f5' : '#949ba4' }} />
             </button>
           </div>
         </div>
@@ -1008,7 +958,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
           <ThreadList
             channelId={channel.id}
             activeThreadId={activeThread?.id ?? null}
-            filter={threadFilter}
+            filter="all"
             onSelectThread={(thread) => {
               setActiveThread(thread)
               setThreadPanelOpen(true)

--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -31,6 +31,8 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const fileRef = useRef<HTMLInputElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const emojiPickerRef = useRef<HTMLDivElement>(null)
+  const emojiButtonRef = useRef<HTMLButtonElement>(null)
   const fileUrlCache = useRef(new Map<File, string>())
 
   // Mention autocomplete
@@ -64,6 +66,22 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
       el.style.height = Math.min(el.scrollHeight, 200) + "px"
     })
   }, [draft])
+
+  useEffect(() => {
+    if (!showEmojiPicker) return
+
+    function handlePointerDown(event: MouseEvent) {
+      const target = event.target as Node
+      const clickedInsidePicker = emojiPickerRef.current?.contains(target)
+      const clickedToggleButton = emojiButtonRef.current?.contains(target)
+      if (!clickedInsidePicker && !clickedToggleButton) {
+        setShowEmojiPicker(false)
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown)
+    return () => document.removeEventListener("mousedown", handlePointerDown)
+  }, [showEmojiPicker])
 
   async function handleSend() {
     if ((!content.trim() && files.length === 0) || sending) return
@@ -281,6 +299,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
         {/* Emoji picker toggle */}
         <div className="relative flex-shrink-0 mb-1">
           <button
+            ref={emojiButtonRef}
             onClick={() => setShowEmojiPicker(!showEmojiPicker)}
             className="motion-interactive motion-press hover:text-white"
             style={{ color: "#b5bac1" }}
@@ -291,6 +310,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
 
           {showEmojiPicker && (
             <div
+              ref={emojiPickerRef}
               data-state="open"
               className="panel-surface-motion absolute bottom-8 right-0 p-2 rounded-lg shadow-xl z-50 grid grid-cols-6 gap-1"
               style={{ background: "#2b2d31", border: "1px solid #1e1f22", width: "200px" }}


### PR DESCRIPTION
### Motivation

- Remove duplicated header controls that also appear in the top header to reduce clutter (notification bell, thread filter, and the three-dots menu). 
- Ensure the in-message emoji picker closes when clicking outside of it for a more natural UX. 
- Make header icons visually consistent by normalizing their sizes.

### Description

- Removed the duplicate notification bell, thread-filter dropdown, and “more options” dropdown from the channel header in `ChatArea` and cleaned up unused imports. 
- Removed local `threadFilter` state and always pass `"all"` into `ThreadList` since the per-channel filter UI was removed. 
- Normalized header icon sizing by changing `Users` and `MessageSquareText` icons to `w-4 h-4` to match other header icons. 
- Added outside-click dismissal for the emoji picker in `MessageInput` using refs (`emojiPickerRef`, `emojiButtonRef`) and a document `mousedown` listener so the picker closes when clicking away.

### Testing

- Ran type-check: `npm --prefix apps/web run type-check` — success. 
- Ran lint: `npm --prefix apps/web run lint` — failed due to existing style-guardrail violations across unrelated files (these were pre-existing and not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dba3fb454832597023b875b07013b)