### PR TITLE
ChatArea: stronger unread marker, top-pagination, and reliable jump/scroll anchoring

### DIFF
--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -85,7 +85,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
   const draftPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const draftRef = useRef("")
   const prevChannelIdRef = useRef(channel.id)
-  const paginationRequestRef = useRef(false)
+  const paginationRequestRef = useRef<Promise<unknown> | null>(null)
   const messagesRef = useRef<MessageWithAuthor[]>(initialMessages)
   const supabase = useMemo(() => createClientSupabaseClient(), [])
   const router = useRouter()
@@ -293,20 +293,24 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     setPendingNewMessageCount(0)
     setHasMoreHistory(initialMessages.length >= 50)
     setIsPaginating(false)
-    paginationRequestRef.current = false
+    paginationRequestRef.current = null
   }, [initialMessages])
 
   const loadOlderMessages = useCallback(async () => {
     const container = messageScrollerRef.current
     const currentMessages = messagesRef.current
-    if (!container || paginationRequestRef.current || !hasMoreHistory || currentMessages.length === 0) return
+    if (!container || !hasMoreHistory || currentMessages.length === 0) return
 
-    paginationRequestRef.current = true
+    if (paginationRequestRef.current) {
+      await paginationRequestRef.current.catch(() => undefined)
+      return
+    }
+
     setIsPaginating(true)
     const previousHeight = container.scrollHeight
     const previousTop = container.scrollTop
 
-    try {
+    const paginationPromise = (async () => {
       const oldest = currentMessages[0]
       const before = encodeURIComponent(oldest.created_at)
 
@@ -340,8 +344,16 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
         const nextHeight = messageScrollerRef.current.scrollHeight
         messageScrollerRef.current.scrollTop = previousTop + (nextHeight - previousHeight)
       })
+    })()
+
+    paginationRequestRef.current = paginationPromise
+
+    try {
+      await paginationPromise
     } finally {
-      paginationRequestRef.current = false
+      if (paginationRequestRef.current === paginationPromise) {
+        paginationRequestRef.current = null
+      }
       setIsPaginating(false)
     }
   }, [channel.id, hasMoreHistory])
@@ -349,47 +361,66 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
   const ensureMessageLoaded = useCallback(async (messageId: string) => {
     if (messagesRef.current.some((message) => message.id === messageId)) return true
 
-    let attempts = 0
-    let localHasMore = hasMoreHistory
-    let cursor = messagesRef.current[0]?.created_at ?? null
-
-    while (attempts < 8 && localHasMore && cursor) {
-      attempts += 1
-
-      let older: MessageWithAuthor[] | null = null
-      try {
-        const res = await fetch(`/api/messages?channelId=${channel.id}&before=${encodeURIComponent(cursor)}&limit=50`)
-        if (!res.ok) return false
-        older = await res.json() as MessageWithAuthor[]
-      } catch (error) {
-        console.error("Failed to load message jump target", error)
-        return false
-      }
-
-      if (!Array.isArray(older) || older.length === 0) {
-        localHasMore = false
-        setHasMoreHistory(false)
-        return false
-      }
-
-      setMessages((prev) => {
-        const known = new Set(prev.map((message) => message.id))
-        const merged = [...older.filter((message) => !known.has(message.id)), ...prev]
-        return sortMessagesChronologically(merged)
-      })
-
-      if (older.some((message) => message.id === messageId)) {
-        return true
-      }
-
-      cursor = older[0]?.created_at ?? null
-      if (older.length < 50) {
-        localHasMore = false
-        setHasMoreHistory(false)
-      }
+    if (paginationRequestRef.current) {
+      await paginationRequestRef.current.catch(() => undefined)
+      if (messagesRef.current.some((message) => message.id === messageId)) return true
     }
 
-    return false
+    setIsPaginating(true)
+    const paginationPromise = (async () => {
+      let attempts = 0
+      let localHasMore = hasMoreHistory
+      let cursor = messagesRef.current[0]?.created_at ?? null
+
+      while (attempts < 8 && localHasMore && cursor) {
+        attempts += 1
+
+        let older: MessageWithAuthor[] | null = null
+        try {
+          const res = await fetch(`/api/messages?channelId=${channel.id}&before=${encodeURIComponent(cursor)}&limit=50`)
+          if (!res.ok) return false
+          older = await res.json() as MessageWithAuthor[]
+        } catch (error) {
+          console.error("Failed to load message jump target", error)
+          return false
+        }
+
+        if (!Array.isArray(older) || older.length === 0) {
+          localHasMore = false
+          setHasMoreHistory(false)
+          return false
+        }
+
+        setMessages((prev) => {
+          const known = new Set(prev.map((message) => message.id))
+          const merged = [...older.filter((message) => !known.has(message.id)), ...prev]
+          return sortMessagesChronologically(merged)
+        })
+
+        if (older.some((message) => message.id === messageId)) {
+          return true
+        }
+
+        cursor = older[0]?.created_at ?? null
+        if (older.length < 50) {
+          localHasMore = false
+          setHasMoreHistory(false)
+        }
+      }
+
+      return false
+    })()
+
+    paginationRequestRef.current = paginationPromise
+
+    try {
+      return await paginationPromise
+    } finally {
+      if (paginationRequestRef.current === paginationPromise) {
+        paginationRequestRef.current = null
+      }
+      setIsPaginating(false)
+    }
   }, [channel.id, hasMoreHistory])
 
   useEffect(() => {
@@ -603,7 +634,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
   }, [channel.id, openThreadId])
 
   useEffect(() => {
-    const navigationSignature = `${jumpToMessageId ?? ""}:${openThreadId ?? ""}`
+    const navigationSignature = `${channel.id}:${serverId}:${jumpToMessageId ?? ""}:${openThreadId ?? ""}`
 
     if (jumpSignatureRef.current !== navigationSignature) {
       jumpSignatureRef.current = navigationSignature


### PR DESCRIPTION
### Motivation
- Improve the UX around unread/read-state markers so they remain visually prominent in dense message streams and make it obvious where new content starts. 
- Make query-driven jumps (search / thread links) reliable even when the target message lives in older pages that are not yet loaded. 
- Prevent jarring viewport jumps when older pages are prepended and keep unread counters/anchors accurate during realtime inserts and pagination.

### Description
- Added pagination and stability state to `ChatArea` with `isPaginating`, `hasMoreHistory`, and `paginationRequestRef` to guard concurrent loads and expose a top-of-list loading affordance; implemented in `apps/web/components/chat/chat-area.tsx`.
- Implemented `loadOlderMessages` which prepends older pages and preserves viewport position by measuring container `scrollHeight` before/after and adjusting `scrollTop` to anchor the user’s view.
- Added `ensureMessageLoaded` to iteratively fetch older pages when a `?message=` jump target is not present in-memory, making `scrollIntoView` targets deterministic; this is tied into the jump effect so jumps wait for the message to be loaded before scrolling/highlighting.
- Normalized realtime/upsert ordering by sorting the in-memory messages chronologically (tiebreak by id) on inserts/updates and strengthened the unread separator with a higher-contrast pill + gradient separator so it stands out in dense streams.
- Improved jump lifecycle by tracking a navigation signature for `message`/`thread` parameters so jump state resets only when the navigation context actually changes and preserving a consistent return-to-context entry point.

### Testing
- Ran type-check: `npm run -w apps/web type-check` (TypeScript `tsc --noEmit`) which completed successfully. 
- Ran unit tests: an initial test invocation `npm run -w apps/web test -- apps/web/lib/chat-outbox.test.ts` returned no matching files (invocation path error), then `npm run -w apps/web test -- lib/chat-outbox.test.ts` executed and passed (`1 file, 9 tests`).
- No frontend integration screenshot was produced because a Playwright Chromium launch crashed in this environment (SIGSEGV) when attempting to capture the running dev server, so no browser artifact was generated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dcacfce20832594aeb3e96e21a887)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Infinite-scroll pagination: older chat history loads in batches as you scroll to the top and preserves scroll position when items are prepended.
  * Message jumping: navigate to specific messages with smooth, cancel-safe scrolling and temporary highlighting.

* **Improvements**
  * Messages reliably maintain chronological order and merge updates seamlessly.
  * Loading indicator shows "Loading earlier messages..."; "New since last read" banner and separators restyled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->