### PR TITLE
Improve emoji UX: custom emoji limit, categorized picker, GIF tab, and reaction hover

### DIFF
--- a/apps/web/app/api/servers/[serverId]/emojis/route.ts
+++ b/apps/web/app/api/servers/[serverId]/emojis/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createServerSupabaseClient } from "@/lib/supabase/server"
 
+const CUSTOM_EMOJI_LIMIT = 50
+
 /** GET /api/servers/[serverId]/emojis — Returns all custom emojis for a server (membership-gated). */
 export async function GET(
   _req: NextRequest,
@@ -61,6 +63,15 @@ export async function POST(
     return NextResponse.json({ error: "Only PNG, WebP, and GIF are allowed" }, { status: 415 })
   }
   if (file.size > 256 * 1024) return NextResponse.json({ error: "Emoji must be under 256 KB" }, { status: 413 })
+
+  const { count, error: countError } = await supabase
+    .from("server_emojis")
+    .select("id", { count: "exact", head: true })
+    .eq("server_id", serverId)
+  if (countError) return NextResponse.json({ error: countError.message }, { status: 500 })
+  if ((count ?? 0) >= CUSTOM_EMOJI_LIMIT) {
+    return NextResponse.json({ error: `Server has reached its ${CUSTOM_EMOJI_LIMIT} custom emoji limit` }, { status: 409 })
+  }
 
   const mimeToExt: Record<string, string> = { "image/png": "png", "image/webp": "webp", "image/gif": "gif" }
   const ext = mimeToExt[file.type] ?? "png"

--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -20,7 +20,18 @@ interface Props {
   onSent?: () => void
 }
 
-const COMMON_EMOJIS = ["😀", "😂", "❤️", "👍", "👎", "🔥", "✅", "🎉", "🤔", "👀", "😭", "💯"]
+const EMOJI_CATEGORIES = {
+  People: ["😀", "😂", "😍", "🤔", "😭", "😎", "🥳", "😴", "🤯", "🫶", "👍", "👎"],
+  Nature: ["🌱", "🌸", "🌳", "🍀", "🌊", "🔥", "☀️", "🌙", "⚡", "❄️", "🐶", "🦊"],
+  Food: ["🍕", "🍔", "🌮", "🍣", "🍜", "🍩", "🍪", "🍎", "🍉", "☕", "🍺", "🍿"],
+  Activities: ["⚽", "🏀", "🎮", "🎯", "🎸", "🎤", "🎨", "🧩", "♟️", "🏓", "🏆", "🎉"],
+  Travel: ["🚗", "🚕", "✈️", "🚆", "🛳️", "🚀", "🗺️", "🏝️", "🏔️", "🏕️", "🏙️", "🧳"],
+  Objects: ["📱", "💻", "⌚", "🎧", "📷", "💡", "🔑", "🧠", "💎", "🛠️", "📌", "📦"],
+  Symbols: ["❤️", "✅", "❌", "⚠️", "🔔", "⭐", "💯", "♻️", "☮️", "☑️", "➕", "➖"],
+  Flags: ["🏳️", "🏴", "🏁", "🇺🇸", "🇬🇧", "🇨🇦", "🇫🇷", "🇩🇪", "🇯🇵", "🇰🇷", "🇮🇳", "🇧🇷"],
+} as const
+
+const GIPHY_API_BASE = "https://api.giphy.com/v1/gifs"
 
 /** Composable message input with file attachments, emoji picker, @mention autocomplete, and reply-to indicator. */
 export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSend, onDraftChange, onTyping, onSent }: Props) {
@@ -29,6 +40,10 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
   const [files, setFiles] = useState<File[]>([])
   const [sending, setSending] = useState(false)
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
+  const [pickerTab, setPickerTab] = useState<"emoji" | "gif">("emoji")
+  const [gifQuery, setGifQuery] = useState("")
+  const [gifResults, setGifResults] = useState<Array<{ id: string; title: string; previewUrl: string; gifUrl: string }>>([])
+  const [gifLoading, setGifLoading] = useState(false)
   const fileRef = useRef<HTMLInputElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const emojiPickerRef = useRef<HTMLDivElement>(null)
@@ -82,6 +97,42 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
     document.addEventListener("mousedown", handlePointerDown)
     return () => document.removeEventListener("mousedown", handlePointerDown)
   }, [showEmojiPicker])
+
+  useEffect(() => {
+    if (!showEmojiPicker || pickerTab !== "gif") return
+    const apiKey = process.env.NEXT_PUBLIC_GIPHY_API_KEY
+    if (!apiKey) {
+      setGifResults([])
+      return
+    }
+
+    const controller = new AbortController()
+    const timeout = setTimeout(async () => {
+      setGifLoading(true)
+      try {
+        const endpoint = gifQuery.trim()
+          ? `${GIPHY_API_BASE}/search?api_key=${apiKey}&q=${encodeURIComponent(gifQuery)}&limit=12&rating=pg-13`
+          : `${GIPHY_API_BASE}/trending?api_key=${apiKey}&limit=12&rating=pg-13`
+        const res = await fetch(endpoint, { signal: controller.signal })
+        const json = await res.json()
+        setGifResults((json.data ?? []).map((gif: any) => ({
+          id: gif.id,
+          title: gif.title || "GIF",
+          previewUrl: gif.images.fixed_width_small_still.url,
+          gifUrl: gif.images.original.url,
+        })))
+      } catch {
+        setGifResults([])
+      } finally {
+        setGifLoading(false)
+      }
+    }, 250)
+
+    return () => {
+      clearTimeout(timeout)
+      controller.abort()
+    }
+  }, [showEmojiPicker, pickerTab, gifQuery])
 
   async function handleSend() {
     if ((!content.trim() && files.length === 0) || sending) return
@@ -312,25 +363,91 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
             <div
               ref={emojiPickerRef}
               data-state="open"
-              className="panel-surface-motion absolute bottom-8 right-0 p-2 rounded-lg shadow-xl z-50 grid grid-cols-6 gap-1"
-              style={{ background: "#2b2d31", border: "1px solid #1e1f22", width: "200px" }}
+              className="panel-surface-motion absolute bottom-8 right-0 p-2 rounded-lg shadow-xl z-50"
+              style={{ background: "#2b2d31", border: "1px solid #1e1f22", width: "320px" }}
             >
-              {COMMON_EMOJIS.map((emoji) => (
+              <div className="mb-2 flex items-center gap-2">
                 <button
-                  key={emoji}
-                  onClick={() => {
-                    const next = content + emoji
-                    setContent(next)
-                    setCursorPosition(next.length)
-                    onDraftChange(next)
-                    setShowEmojiPicker(false)
-                    textareaRef.current?.focus()
-                  }}
-                  className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-white/10 rounded text-lg"
+                  onClick={() => setPickerTab("emoji")}
+                  className="px-2 py-1 rounded text-xs font-medium"
+                  style={{ background: pickerTab === "emoji" ? "#5865f2" : "transparent", color: "#f2f3f5" }}
                 >
-                  {emoji}
+                  Emoji
                 </button>
-              ))}
+                <button
+                  onClick={() => setPickerTab("gif")}
+                  className="px-2 py-1 rounded text-xs font-medium"
+                  style={{ background: pickerTab === "gif" ? "#5865f2" : "transparent", color: "#f2f3f5" }}
+                >
+                  GIFs
+                </button>
+              </div>
+
+              {pickerTab === "emoji" ? (
+                <div className="max-h-72 overflow-y-auto pr-1 space-y-2">
+                  {Object.entries(EMOJI_CATEGORIES).map(([category, emojis]) => (
+                    <div key={category}>
+                      <p className="text-[10px] font-semibold uppercase mb-1" style={{ color: "#949ba4" }}>{category}</p>
+                      <div className="grid grid-cols-8 gap-1">
+                        {emojis.map((emoji) => (
+                          <button
+                            key={`${category}-${emoji}`}
+                            onClick={() => {
+                              const next = content + emoji
+                              setContent(next)
+                              setCursorPosition(next.length)
+                              onDraftChange(next)
+                              setShowEmojiPicker(false)
+                              textareaRef.current?.focus()
+                            }}
+                            className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-white/10 rounded text-lg"
+                          >
+                            {emoji}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <input
+                    value={gifQuery}
+                    onChange={(e) => setGifQuery(e.target.value)}
+                    placeholder="Search GIFs"
+                    className="w-full px-2 py-1.5 rounded text-xs focus:outline-none"
+                    style={{ background: "#1e1f22", color: "#dcddde" }}
+                  />
+                  {!process.env.NEXT_PUBLIC_GIPHY_API_KEY ? (
+                    <p className="text-xs" style={{ color: "#949ba4" }}>
+                      Add NEXT_PUBLIC_GIPHY_API_KEY to enable GIF search.
+                    </p>
+                  ) : gifLoading ? (
+                    <p className="text-xs" style={{ color: "#949ba4" }}>Loading GIFs…</p>
+                  ) : (
+                    <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
+                      {gifResults.map((gif) => (
+                        <button
+                          key={gif.id}
+                          onClick={() => {
+                            const spacer = content.trim() ? " " : ""
+                            const next = `${content}${spacer}${gif.gifUrl}`
+                            setContent(next)
+                            setCursorPosition(next.length)
+                            onDraftChange(next)
+                            setShowEmojiPicker(false)
+                            textareaRef.current?.focus()
+                          }}
+                          className="rounded overflow-hidden hover:opacity-90"
+                          title={gif.title}
+                        >
+                          <img src={gif.previewUrl} alt={gif.title} className="w-full h-16 object-cover" />
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -11,6 +11,8 @@ import { Button } from "@/components/ui/button"
 import { useToast } from "@/components/ui/use-toast"
 import type { MessageWithAuthor, AttachmentRow, ThreadRow } from "@/types/database"
 import { cn } from "@/lib/utils/cn"
+import { useAppStore } from "@/lib/stores/app-store"
+import { useShallow } from "zustand/react/shallow"
 import { LinkEmbed, extractFirstUrl } from "@/components/chat/link-embed"
 import { WorkspaceReferenceEmbed, extractWorkspaceReference } from "@/components/chat/workspace-reference-embed"
 import { ServerEmojiImage } from "@/components/chat/server-emoji-context"
@@ -56,6 +58,10 @@ export const MessageItem = memo(function MessageItem({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const { toast } = useToast()
   const isOwn = message.author_id === currentUserId
+  const { activeServerId, membersByServer } = useAppStore(
+    useShallow((s) => ({ activeServerId: s.activeServerId, membersByServer: s.members }))
+  )
+  const memberLookup = activeServerId ? membersByServer[activeServerId] ?? [] : []
 
   async function confirmDelete() {
     try {
@@ -382,10 +388,17 @@ export const MessageItem = memo(function MessageItem({
                   {/* Reactions */}
                   {Object.entries(reactionGroups).length > 0 && (
                     <div className="flex flex-wrap gap-1 mt-2">
-                      {Object.entries(reactionGroups).map(([emoji, { count, hasOwn }]) => (
+                      {Object.entries(reactionGroups).map(([emoji, { count, hasOwn, users }]) => (
                         <button
                           key={emoji}
                           onClick={() => onReaction(emoji)}
+                          title={users
+                            .map((id) => {
+                              if (id === currentUserId) return "You"
+                              const member = memberLookup.find((m) => m.user_id === id)
+                              return member?.nickname || member?.display_name || member?.username || "Unknown user"
+                            })
+                            .join(", ")}
                           className="motion-interactive motion-press flex items-center gap-1 px-2 py-0.5 rounded-full text-sm hover:-translate-y-px"
                           aria-label={`Toggle ${emoji} reaction`}
                           style={{

--- a/apps/web/components/modals/server-settings-modal.tsx
+++ b/apps/web/components/modals/server-settings-modal.tsx
@@ -269,6 +269,8 @@ interface EmojiEntry {
   image_url: string
 }
 
+const CUSTOM_EMOJI_LIMIT = 50
+
 /** Emoji management tab — lists server custom emojis with upload, rename, and delete controls. */
 export function EmojisTab({ serverId }: { serverId: string }) {
   const { toast } = useToast()
@@ -289,6 +291,10 @@ export function EmojisTab({ serverId }: { serverId: string }) {
   async function handleUpload() {
     const file = fileRef.current?.files?.[0]
     if (!file || !newName.trim()) return
+    if (emojis.length >= CUSTOM_EMOJI_LIMIT) {
+      toast({ variant: "destructive", title: `Emoji limit reached (${CUSTOM_EMOJI_LIMIT})` })
+      return
+    }
     setUploading(true)
     const form = new FormData()
     form.append("file", file)
@@ -296,12 +302,16 @@ export function EmojisTab({ serverId }: { serverId: string }) {
     const res = await fetch(`/api/servers/${serverId}/emojis`, { method: "POST", body: form })
     if (res.ok) {
       const emoji = await res.json()
-      setEmojis((prev) => [...prev, emoji])
+      setEmojis((prev) => {
+        const withoutSameName = prev.filter((entry) => entry.name !== emoji.name)
+        return [...withoutSameName, emoji].sort((a, b) => a.name.localeCompare(b.name))
+      })
       setNewName("")
       if (fileRef.current) fileRef.current.value = ""
       toast({ title: "Emoji uploaded" })
     } else {
-      toast({ variant: "destructive", title: "Failed to upload emoji" })
+      const error = await res.json().catch(() => null)
+      toast({ variant: "destructive", title: error?.error || "Failed to upload emoji" })
     }
     setUploading(false)
   }
@@ -320,6 +330,9 @@ export function EmojisTab({ serverId }: { serverId: string }) {
         <p className="text-white font-semibold mb-0.5">Custom Emoji</p>
         <p className="text-xs" style={{ color: '#949ba4' }}>
           Upload custom emoji to use in messages on this server. Max 256 KB, PNG/GIF/WEBP.
+        </p>
+        <p className="text-xs mt-1" style={{ color: '#b5bac1' }}>
+          {emojis.length} / {CUSTOM_EMOJI_LIMIT} custom emojis used.
         </p>
       </div>
 
@@ -344,7 +357,7 @@ export function EmojisTab({ serverId }: { serverId: string }) {
           </button>
           <button
             onClick={handleUpload}
-            disabled={uploading || !newName.trim()}
+            disabled={uploading || !newName.trim() || emojis.length >= CUSTOM_EMOJI_LIMIT}
             className="px-3 py-2 rounded text-sm font-semibold disabled:opacity-50"
             style={{ background: '#5865f2', color: 'white' }}
           >

--- a/supabase/migrations/00025_server_emoji_storage.sql
+++ b/supabase/migrations/00025_server_emoji_storage.sql
@@ -1,0 +1,35 @@
+-- Server emoji storage bucket + RLS policies
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'server-emojis',
+  'server-emojis',
+  TRUE,
+  262144,
+  ARRAY['image/png', 'image/gif', 'image/webp']
+) ON CONFLICT (id) DO NOTHING;
+
+CREATE POLICY IF NOT EXISTS "Anyone can view server emojis"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'server-emojis');
+
+CREATE POLICY IF NOT EXISTS "Admins can upload server emojis"
+  ON storage.objects FOR INSERT
+  WITH CHECK (
+    bucket_id = 'server-emojis' AND
+    public.has_permission(((storage.foldername(name))[1])::uuid, 128)
+  );
+
+CREATE POLICY IF NOT EXISTS "Admins can update server emojis"
+  ON storage.objects FOR UPDATE
+  USING (
+    bucket_id = 'server-emojis' AND
+    public.has_permission(((storage.foldername(name))[1])::uuid, 128)
+  );
+
+CREATE POLICY IF NOT EXISTS "Admins can delete server emojis"
+  ON storage.objects FOR DELETE
+  USING (
+    bucket_id = 'server-emojis' AND
+    public.has_permission(((storage.foldername(name))[1])::uuid, 128)
+  );


### PR DESCRIPTION
### Motivation
- Provide a better emoji experience by adding a sensible per-server custom emoji cap and clearer UI feedback when uploads fail.  
- Improve out-of-the-box emoji discovery by surfacing category groups and adding GIF browsing for richer reactions.  
- Make reactions more informative by exposing who reacted on hover so users can see participants without extra clicks.  

### Description
- Enforce a server custom emoji limit (`50`) in the upload API at `apps/web/app/api/servers/[serverId]/emojis/route.ts` and return a clear `409` when the cap is reached.  
- Add a Supabase migration `supabase/migrations/00025_server_emoji_storage.sql` to create the `server-emojis` storage bucket and apply appropriate RLS policies for public read and admin-managed uploads.  
- Update the Server Settings Emoji tab (`apps/web/components/modals/server-settings-modal.tsx`) to show usage (`x / 50`), prevent uploads when full, dedupe/sort replacements, and surface API error messages.  
- Replace the simple inline quick list with a richer emoji picker (`apps/web/components/chat/message-input.tsx`) organized into categories (People, Nature, Food, Activities, Travel, Objects, Symbols, Flags) and add a GIF tab that queries Giphy (trending/search) when `NEXT_PUBLIC_GIPHY_API_KEY` is configured.  
- Enhance message reaction UI (`apps/web/components/chat/message-item.tsx`) to show who reacted via the reaction button `title` by resolving known server member names (shows "You" for current user).  

### Testing
- Ran type checking with `npm run -w apps/web type-check` which succeeded.  
- Ran unit tests with `npm run -w apps/web test` (Vitest) which passed (all test files passed).  
- Ran the repository linter with `npm run -w apps/web lint` which failed due to existing repo-wide style-guardrail violations unrelated to the emoji changes (style token guardrail errors surfaced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df6ff206883258795bd0d620ba593)