### PR TITLE
Add in-app inbox notifications for message mentions and replies

### DIFF
--- a/apps/web/app/api/messages/route.ts
+++ b/apps/web/app/api/messages/route.ts
@@ -408,6 +408,8 @@ export async function POST(request: Request) {
   // --- Insert in-app inbox notifications for mentions/replies (fire-and-forget) ---
   Promise.resolve()
     .then(async () => {
+      const MAX_NOTIFICATION_BODY_LENGTH = 512
+      const serviceSupabase = await createServiceRoleClient()
       const recipientIds = new Set<string>()
 
       for (const mentionedUserId of mentions) {
@@ -418,7 +420,7 @@ export async function POST(request: Request) {
 
       let replyAuthorId: string | null = null
       if (replyToId) {
-        const { data: repliedMessage } = await supabase
+        const { data: repliedMessage } = await serviceSupabase
           .from("messages")
           .select("author_id")
           .eq("id", replyToId)
@@ -432,15 +434,13 @@ export async function POST(request: Request) {
 
       if (recipientIds.size === 0) return
 
-      const serviceSupabase = await createServiceRoleClient()
-      const bodyPreview = content?.trim() || "Sent an attachment"
+      const bodyPreview = (content?.trim() || "Sent an attachment").slice(0, MAX_NOTIFICATION_BODY_LENGTH)
       const rows = Array.from(recipientIds).map((recipientId) => {
-        const isReplyTarget = replyAuthorId === recipientId
         const isMentionTarget = mentions.includes(recipientId)
 
         return {
           user_id: recipientId,
-          type: isMentionTarget ? "mention" as const : isReplyTarget ? "reply" as const : "system" as const,
+          type: isMentionTarget ? "mention" as const : "reply" as const,
           title: isMentionTarget
             ? `${senderName} mentioned you`
             : `${senderName} replied to your message`,


### PR DESCRIPTION
### Motivation
- Ensure in-app inbox receives persistent notifications for message mentions and replies to improve parity with push notifications and make mention/reply events discoverable in the UI.
- Allow the server to fan out notifications under RLS by using a service-role client so cross-user inbox inserts succeed.

### Description
- Add a fire-and-forget block in `POST /api/messages` that computes recipients from `mentions` and the `replyToId` author, deduplicates them, and skips self-notifications.
- Resolve the reply target author via a lightweight query and include them as a recipient when appropriate.
- Use `createServiceRoleClient()` to insert `notifications` rows (fields: `user_id`, `type`, `title`, `body`, `server_id`, `channel_id`, `message_id`) so notifications deep-link to the related chat message.
- Wrap the operation in a `Promise` and swallow errors to avoid affecting the main message send path, and prefer `mention` type when a recipient is both a mention and a reply target.

### Testing
- Ran type-check with `npm -C apps/web run type-check`, which succeeded. ✅
- Ran lint/style-guardrails via `npm -C apps/web run lint -- app/api/messages/route.ts`, which surfaced pre-existing style-guardrail violations unrelated to this change and caused the lint step to fail. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dff6e76d48325b814f44c8132158b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-app inbox notifications when you're mentioned in a message
  * Added in-app inbox notifications when someone replies to your message

<!-- end of auto-generated comment: release notes by coderabbit.ai -->