### PR TITLE
Harden voice reconnection with heartbeat and stale-peer GC

### DIFF
--- a/apps/web/lib/webrtc/use-voice.ts
+++ b/apps/web/lib/webrtc/use-voice.ts
@@ -42,7 +42,11 @@ interface UseVoiceReturn {
 }
 
 const HEARTBEAT_INTERVAL_MS = 5000
-const STALE_PEER_TIMEOUT_MS = 15000
+const DEFAULT_STALE_PEER_TIMEOUT_MS = 45000
+const envStalePeerTimeout = Number.parseInt(process.env.NEXT_PUBLIC_VOICE_STALE_PEER_TIMEOUT_MS ?? "", 10)
+const STALE_PEER_TIMEOUT_MS = Number.isFinite(envStalePeerTimeout) && envStalePeerTimeout >= HEARTBEAT_INTERVAL_MS * 3
+  ? envStalePeerTimeout
+  : DEFAULT_STALE_PEER_TIMEOUT_MS
 
 /** Manages WebRTC peer connections, media streams, audio processing, and signaling for a voice channel. */
 export function useVoice(channelId: string, userId: string, serverId?: string | null): UseVoiceReturn {
@@ -461,6 +465,23 @@ export function useVoice(channelId: string, userId: string, serverId?: string | 
                 for (const [peerId, lastSeen] of lastSeenByPeerRef.current.entries()) {
                   if (now - lastSeen <= STALE_PEER_TIMEOUT_MS) continue
                   const pc = peerConnections.current.get(peerId)
+                  const isConnected = pc?.connectionState === "connected"
+                  const isIceConnected = pc?.iceConnectionState === "connected" || pc?.iceConnectionState === "completed"
+                  const shouldKeepPeer = isConnected || isIceConnected
+                  if (shouldKeepPeer) {
+                    lastSeenByPeerRef.current.set(peerId, now)
+                    continue
+                  }
+
+                  const isEvictableState = !pc
+                    || pc.connectionState === "disconnected"
+                    || pc.connectionState === "failed"
+                    || pc.connectionState === "closed"
+                    || pc.iceConnectionState === "disconnected"
+                    || pc.iceConnectionState === "failed"
+                    || pc.iceConnectionState === "closed"
+                  if (!isEvictableState) continue
+
                   pc?.close()
                   peerConnections.current.delete(peerId)
                   lastSeenByPeerRef.current.delete(peerId)


### PR DESCRIPTION
### Motivation
- Improve resilience of the client-side voice stack so transient network drops don't leave ghost participants or stale mute/speaking state.
- Ensure reconnecting clients can rebuild peer state quickly and that lingering RTCPeerConnections are cleaned up automatically.

### Description
- Added heartbeat constants and refs (`HEARTBEAT_INTERVAL_MS`, `STALE_PEER_TIMEOUT_MS`, `heartbeatTimerRef`, `staleGcTimerRef`, `lastSeenByPeerRef`, `mutedRef`, `speakingRef`) to `useVoice` for liveness tracking and current-state capture in heartbeats.
- Emit and consume `peer-heartbeat` events to refresh peer last-seen timestamps and snapshot mute/speaking state, and added `peer-rejoin-request` / `peer-rejoin-state` handshake so new/reconnecting clients can request and receive current peer state.
- Start a rejoin request and periodic heartbeat on successful subscribe, and run a stale-peer GC loop that closes peer connections and removes ghost peers after no heartbeat within the timeout.
- Extend session cleanup to clear heartbeat/GC timers and reset last-seen tracking; keep heartbeat payloads using mutable refs so they always reflect current local mute/speaking values.
- Change is localized to the client voice logic in `apps/web/lib/webrtc/use-voice.ts`.

### Testing
- Ran TypeScript check with `npm --workspace apps/web run type-check`, which succeeded.
- Ran unit tests with `npm --workspace apps/web run test` (Vitest), all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e107ebcac8325be902182b1260451)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced voice connection reliability with automatic detection and cleanup of disconnected peers.
  * Improved synchronization of communication status across all participants.
  * Added automatic recovery mechanism for peer reconnections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->