### PR TITLE
Fix Postgres-compatible policy creation in server emoji migration

### DIFF
--- a/supabase/migrations/00025_server_emoji_storage.sql
+++ b/supabase/migrations/00025_server_emoji_storage.sql
@@ -9,27 +9,75 @@ VALUES (
   ARRAY['image/png', 'image/gif', 'image/webp']
 ) ON CONFLICT (id) DO NOTHING;
 
-CREATE POLICY IF NOT EXISTS "Anyone can view server emojis"
-  ON storage.objects FOR SELECT
-  USING (bucket_id = 'server-emojis');
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'Anyone can view server emojis'
+  ) THEN
+    CREATE POLICY "Anyone can view server emojis"
+      ON storage.objects FOR SELECT
+      USING (bucket_id = 'server-emojis');
+  END IF;
+END
+$$;
 
-CREATE POLICY IF NOT EXISTS "Admins can upload server emojis"
-  ON storage.objects FOR INSERT
-  WITH CHECK (
-    bucket_id = 'server-emojis' AND
-    public.has_permission(((storage.foldername(name))[1])::uuid, 128)
-  );
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'Admins can upload server emojis'
+  ) THEN
+    CREATE POLICY "Admins can upload server emojis"
+      ON storage.objects FOR INSERT
+      WITH CHECK (
+        bucket_id = 'server-emojis' AND
+        public.has_permission(((storage.foldername(name))[1])::uuid, 128)
+      );
+  END IF;
+END
+$$;
 
-CREATE POLICY IF NOT EXISTS "Admins can update server emojis"
-  ON storage.objects FOR UPDATE
-  USING (
-    bucket_id = 'server-emojis' AND
-    public.has_permission(((storage.foldername(name))[1])::uuid, 128)
-  );
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'Admins can update server emojis'
+  ) THEN
+    CREATE POLICY "Admins can update server emojis"
+      ON storage.objects FOR UPDATE
+      USING (
+        bucket_id = 'server-emojis' AND
+        public.has_permission(((storage.foldername(name))[1])::uuid, 128)
+      );
+  END IF;
+END
+$$;
 
-CREATE POLICY IF NOT EXISTS "Admins can delete server emojis"
-  ON storage.objects FOR DELETE
-  USING (
-    bucket_id = 'server-emojis' AND
-    public.has_permission(((storage.foldername(name))[1])::uuid, 128)
-  );
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'Admins can delete server emojis'
+  ) THEN
+    CREATE POLICY "Admins can delete server emojis"
+      ON storage.objects FOR DELETE
+      USING (
+        bucket_id = 'server-emojis' AND
+        public.has_permission(((storage.foldername(name))[1])::uuid, 128)
+      );
+  END IF;
+END
+$$;


### PR DESCRIPTION
### Motivation
- The `CREATE POLICY IF NOT EXISTS` syntax used in the migration is not supported in some Postgres environments and caused a syntax error during migration, so policy creation must be made Postgres-compatible and idempotent.

### Description
- Replaced each `CREATE POLICY IF NOT EXISTS` statement in `supabase/migrations/00025_server_emoji_storage.sql` with a `DO $$ ... IF NOT EXISTS (SELECT 1 FROM pg_policies ...) THEN CREATE POLICY ... END IF; $$;` block to check `pg_policies` before creating the policy.
- Kept the original policy logic and predicates intact for the `SELECT`, `INSERT`, `UPDATE`, and `DELETE` policies on `storage.objects` (same bucket check and `public.has_permission(...)` usage).

### Testing
- Reviewed the resulting SQL to ensure it is valid Postgres syntax and that each policy predicate was preserved. 
- Inspected the updated file contents using `nl -ba supabase/migrations/00025_server_emoji_storage.sql` to verify the inserted `DO $$` blocks. 
- Verified the changes via `git diff -- supabase/migrations/00025_server_emoji_storage.sql` to confirm the intended replacements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e152806cc83259572d5dbcee29ab0)