### PR TITLE
Align composer keybindings with Discord behavior

### DIFF
--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -8,6 +8,7 @@ import { useAppStore } from "@/lib/stores/app-store"
 import { useShallow } from "zustand/react/shallow"
 import { useMentionAutocomplete } from "@/hooks/use-mention-autocomplete"
 import { MentionSuggestions } from "@/components/chat/mention-suggestions"
+import { resolveComposerKeybinding } from "@/lib/composer-keybindings"
 
 interface Props {
   channelName: string
@@ -152,21 +153,37 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    // Let mention autocomplete consume the event first
-    if (mention.isOpen) {
-      if (e.key === "Enter" || e.key === "Tab") {
-        const selected = mention.filteredMembers[mention.selectedIndex]
-        if (selected) {
-          e.preventDefault()
-          insertMention(selected)
-          return
-        }
-      }
-      if (mention.handleKeyDown(e)) return
+    const mentionHandledNavigation = mention.handleKeyDown(e)
+    const selected = mention.filteredMembers[mention.selectedIndex]
+    const action = resolveComposerKeybinding(e.key, e.shiftKey, {
+      isMentionOpen: mention.isOpen,
+      hasMentionSelection: Boolean(selected),
+      hasDraftContent: content.length > 0,
+      mentionHandledNavigation,
+    })
+
+    if (action.preventDefault) {
+      e.preventDefault()
     }
 
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault()
+    if (action.acceptMention && selected) {
+      insertMention(selected)
+      return
+    }
+
+    if (action.closeMention) {
+      mention.close()
+      return
+    }
+
+    if (action.clearDraft) {
+      setContent("")
+      onDraftChange("")
+      setCursorPosition(0)
+      return
+    }
+
+    if (action.sendMessage) {
       handleSend()
     }
   }

--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -179,7 +179,7 @@ export const MessageItem = memo(function MessageItem({
         for (const node of renderTextBlock(before, keyCounter)) { segments.push(node); keyCounter++ }
       }
       const lang = cbMatch[1] || ""
-      const code = cbMatch[2].trimEnd()
+      const code = cbMatch[2]
       segments.push(
         <pre key={`cb-${keyCounter++}`} className="my-1 p-3 rounded overflow-x-auto text-sm" style={{ background: "#1e1f22", fontFamily: "monospace", color: "#dcddde", border: "1px solid #232428" }}>
           {lang && <div className="text-xs mb-1" style={{ color: "#5865f2", fontFamily: "sans-serif" }}>{lang}</div>}

--- a/apps/web/lib/composer-keybindings.test.ts
+++ b/apps/web/lib/composer-keybindings.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest"
+import { resolveComposerKeybinding } from "@/lib/composer-keybindings"
+
+const baseState = {
+  isMentionOpen: false,
+  hasMentionSelection: false,
+  hasDraftContent: false,
+  mentionHandledNavigation: false,
+}
+
+describe("resolveComposerKeybinding", () => {
+  it("sends on Enter", () => {
+    const action = resolveComposerKeybinding("Enter", false, baseState)
+    expect(action).toEqual({
+      preventDefault: true,
+      sendMessage: true,
+      acceptMention: false,
+      closeMention: false,
+      clearDraft: false,
+    })
+  })
+
+  it("allows newline on Shift+Enter", () => {
+    const action = resolveComposerKeybinding("Enter", true, baseState)
+    expect(action.sendMessage).toBe(false)
+    expect(action.preventDefault).toBe(false)
+  })
+
+  it("accepts mention on Tab", () => {
+    const action = resolveComposerKeybinding("Tab", false, {
+      ...baseState,
+      isMentionOpen: true,
+      hasMentionSelection: true,
+    })
+
+    expect(action.acceptMention).toBe(true)
+    expect(action.preventDefault).toBe(true)
+    expect(action.sendMessage).toBe(false)
+  })
+
+  it("accepts mention on Enter without shift", () => {
+    const action = resolveComposerKeybinding("Enter", false, {
+      ...baseState,
+      isMentionOpen: true,
+      hasMentionSelection: true,
+    })
+
+    expect(action.acceptMention).toBe(true)
+    expect(action.sendMessage).toBe(false)
+  })
+
+  it("closes mention picker on Escape before clearing draft", () => {
+    const closeMention = resolveComposerKeybinding("Escape", false, {
+      ...baseState,
+      isMentionOpen: true,
+      hasDraftContent: true,
+    })
+    expect(closeMention.closeMention).toBe(true)
+    expect(closeMention.clearDraft).toBe(false)
+
+    const clearDraft = resolveComposerKeybinding("Escape", false, {
+      ...baseState,
+      isMentionOpen: false,
+      hasDraftContent: true,
+    })
+    expect(clearDraft.closeMention).toBe(false)
+    expect(clearDraft.clearDraft).toBe(true)
+  })
+
+  it("does not accept mention with Shift+Enter", () => {
+    const action = resolveComposerKeybinding("Enter", true, {
+      ...baseState,
+      isMentionOpen: true,
+      hasMentionSelection: true,
+    })
+
+    expect(action.acceptMention).toBe(false)
+    expect(action.sendMessage).toBe(false)
+    expect(action.preventDefault).toBe(false)
+  })
+
+  it("respects mention navigation handlers", () => {
+    const action = resolveComposerKeybinding("ArrowDown", false, {
+      ...baseState,
+      isMentionOpen: true,
+      mentionHandledNavigation: true,
+    })
+
+    expect(action.preventDefault).toBe(true)
+    expect(action.sendMessage).toBe(false)
+    expect(action.acceptMention).toBe(false)
+  })
+})

--- a/apps/web/lib/composer-keybindings.ts
+++ b/apps/web/lib/composer-keybindings.ts
@@ -1,0 +1,84 @@
+export interface ComposerKeybindingState {
+  isMentionOpen: boolean
+  hasMentionSelection: boolean
+  hasDraftContent: boolean
+  mentionHandledNavigation: boolean
+}
+
+export interface ComposerKeybindingResult {
+  preventDefault: boolean
+  sendMessage: boolean
+  acceptMention: boolean
+  closeMention: boolean
+  clearDraft: boolean
+}
+
+/**
+ * Keyboard action resolver for Discord-like composer behavior.
+ */
+export function resolveComposerKeybinding(
+  key: string,
+  shiftKey: boolean,
+  state: ComposerKeybindingState
+): ComposerKeybindingResult {
+  if (state.mentionHandledNavigation) {
+    return {
+      preventDefault: true,
+      sendMessage: false,
+      acceptMention: false,
+      closeMention: false,
+      clearDraft: false,
+    }
+  }
+
+  if (state.isMentionOpen) {
+    if (key === "Escape") {
+      return {
+        preventDefault: true,
+        sendMessage: false,
+        acceptMention: false,
+        closeMention: true,
+        clearDraft: false,
+      }
+    }
+
+    if (key === "Tab" || (key === "Enter" && !shiftKey)) {
+      return {
+        preventDefault: state.hasMentionSelection,
+        sendMessage: false,
+        acceptMention: state.hasMentionSelection,
+        closeMention: false,
+        clearDraft: false,
+      }
+    }
+  }
+
+  if (key === "Enter" && !shiftKey) {
+    return {
+      preventDefault: true,
+      sendMessage: true,
+      acceptMention: false,
+      closeMention: false,
+      clearDraft: false,
+    }
+  }
+
+  if (key === "Escape" && state.hasDraftContent) {
+    return {
+      preventDefault: true,
+      sendMessage: false,
+      acceptMention: false,
+      closeMention: false,
+      clearDraft: true,
+    }
+  }
+
+  return {
+    preventDefault: false,
+    sendMessage: false,
+    acceptMention: false,
+    closeMention: false,
+    clearDraft: false,
+  }
+}
+


### PR DESCRIPTION
### Motivation

- Ensure the message composer key flows match Discord parity: Enter sends, Shift+Enter inserts a newline, Tab/Enter accept mentions, Escape closes the mention picker before clearing a draft, and inline/code formatting is preserved.
- Centralize keyboard decision logic so `MessageInput` handling is easier to reason about and test.
- Add unit coverage for the keybinding behavior to prevent regressions.

### Description

- Add a dedicated resolver `resolveComposerKeybinding` in `apps/web/lib/composer-keybindings.ts` that encodes the Discord-like keyboard rules and exposes typed inputs/outputs.
- Update `MessageInput` (`apps/web/components/chat/message-input.tsx`) to use the resolver and apply actions for `sendMessage`, `acceptMention`, `closeMention`, and `clearDraft` accordingly, while preserving `Shift+Enter` as newline and honoring mention navigation handlers.
- Preserve fenced code block content by removing the trailing `trimEnd()` on code block captures in `apps/web/components/chat/message-item.tsx` so code formatting is rendered exactly as entered.
- Add unit tests in `apps/web/lib/composer-keybindings.test.ts` that exercise Enter/Shift+Enter, Tab/Enter mention acceptance, Escape behavior, and mention navigation handling.

### Testing

- Ran the test suite with `npm --prefix apps/web test`, and the run completed successfully with all test files passing.
- Test summary: `Test Files  13 passed` and `Tests  85 passed`, including the new `lib/composer-keybindings.test.ts` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e15fde37c8325a01cf7414dcb1a8a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Code blocks now preserve trailing whitespace for accurate formatting and alignment.

* **Refactor**
  * Improved message composer keyboard shortcut handling with a centralized keybinding resolver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->