### PR TITLE
Wire theme presets to core shell surfaces via shared background tokens

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -30,6 +30,8 @@
     --motion-duration-panel: 220ms;
     --motion-ease-standard: cubic-bezier(0.2, 0, 0, 1);
     --motion-ease-emphasized: cubic-bezier(0.16, 1, 0.3, 1);
+    --app-bg-primary: #313338;
+    --app-bg-secondary: #2b2d31;
   }
 }
 
@@ -252,6 +254,8 @@
   --card: 220 7% 18%;
   --accent: 235 86% 65%;
   --ring: 235 86% 65%;
+  --app-bg-primary: #313338;
+  --app-bg-secondary: #2b2d31;
 }
 
 [data-theme-preset="midnight-neon"] {
@@ -267,6 +271,8 @@
   --accent: 186 100% 57%;
   --primary: 186 100% 57%;
   --ring: 315 100% 67%;
+  --app-bg-primary: #1b1f31;
+  --app-bg-secondary: #151829;
 }
 
 [data-theme-preset="synthwave"] {
@@ -282,6 +288,8 @@
   --accent: 323 89% 66%;
   --primary: 271 89% 72%;
   --ring: 188 98% 62%;
+  --app-bg-primary: #2a1e46;
+  --app-bg-secondary: #23193b;
 }
 
 [data-theme-preset="carbon"] {
@@ -291,6 +299,8 @@
   --accent: 160 84% 40%;
   --primary: 217 100% 70%;
   --ring: 160 84% 40%;
+  --app-bg-primary: #1f2124;
+  --app-bg-secondary: #191b1e;
 }
 
 /* Font scale */

--- a/apps/web/components/dm/dm-area.tsx
+++ b/apps/web/components/dm/dm-area.tsx
@@ -86,7 +86,7 @@ export function DMArea({ partner, currentUserId, initialMessages }: Props) {
   const partnerInitials = partnerName.slice(0, 2).toUpperCase()
 
   return (
-    <div className="flex flex-col flex-1 overflow-hidden" style={{ background: "#313338" }}>
+    <div className="flex flex-col flex-1 overflow-hidden" style={{ background: "var(--app-bg-primary)" }}>
       {/* Header */}
       <div
         className="flex items-center gap-3 px-4 py-3 border-b flex-shrink-0"

--- a/apps/web/components/dm/dm-channel-area.tsx
+++ b/apps/web/components/dm/dm-channel-area.tsx
@@ -254,7 +254,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
 
   if (loadError) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center gap-3" style={{ background: "#313338" }}>
+      <div className="flex-1 flex flex-col items-center justify-center gap-3" style={{ background: "var(--app-bg-primary)" }}>
         <p className="text-sm" style={{ color: "#949ba4" }}>Failed to load conversation.</p>
         <button
           onClick={() => loadMessages()}
@@ -269,7 +269,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
 
   if (!channel) {
     return (
-      <div className="flex-1 flex items-center justify-center" style={{ background: "#313338" }}>
+      <div className="flex-1 flex items-center justify-center" style={{ background: "var(--app-bg-primary)" }}>
         <div className="w-5 h-5 border-2 border-t-transparent rounded-full animate-spin" style={{ borderColor: "#5865f2", borderTopColor: "transparent" }} />
       </div>
     )
@@ -281,7 +281,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
   const partnerInitials = displayName.slice(0, 2).toUpperCase()
 
   return (
-    <div className="flex flex-col flex-1 overflow-hidden" style={{ background: "#313338" }}>
+    <div className="flex flex-col flex-1 overflow-hidden" style={{ background: "var(--app-bg-primary)" }}>
       {/* Header */}
       <div className="flex items-center gap-3 px-4 py-3 border-b flex-shrink-0" style={{ borderColor: "#1e1f22" }}>
         <MobileMenuButton />

--- a/apps/web/components/dm/friends-sidebar.tsx
+++ b/apps/web/components/dm/friends-sidebar.tsx
@@ -215,7 +215,7 @@ export function FriendsSidebar() {
   const pendingSentList = tab === "pending" ? friends.pending_sent : []
 
   return (
-    <div className="flex flex-col h-full" style={{ background: "#313338" }}>
+    <div className="flex flex-col h-full" style={{ background: "var(--app-bg-primary)" }}>
       {/* Header */}
       <div
         className="flex items-center gap-2 px-4 py-3 border-b flex-shrink-0"

--- a/apps/web/components/dm/me-shell.tsx
+++ b/apps/web/components/dm/me-shell.tsx
@@ -11,7 +11,7 @@ function DMListPanel() {
       {/* Desktop: always visible */}
       <div
         className="hidden md:flex w-60 flex-shrink-0 flex-col overflow-hidden"
-        style={{ background: "#2b2d31" }}
+        style={{ background: "var(--app-bg-secondary)" }}
       >
         <DMList />
       </div>
@@ -20,7 +20,7 @@ function DMListPanel() {
       {sidebarOpen && (
         <div
           className="md:hidden fixed inset-y-0 left-0 z-50 flex w-60 flex-col overflow-hidden"
-          style={{ background: "#2b2d31" }}
+          style={{ background: "var(--app-bg-secondary)" }}
         >
           <DMList onNavigate={() => setSidebarOpen(false)} />
         </div>

--- a/apps/web/components/layout/channels-shell.tsx
+++ b/apps/web/components/layout/channels-shell.tsx
@@ -6,7 +6,7 @@ import { ServerSidebarWrapper } from "./server-sidebar-wrapper"
 export function ChannelsShell({ children }: { children: React.ReactNode }) {
   return (
     <MobileNavProvider>
-      <div className="flex h-screen overflow-hidden" style={{ background: "#313338" }}>
+      <div className="flex h-screen overflow-hidden" style={{ background: "var(--app-bg-primary)" }}>
         <ServerSidebarWrapper />
         <MobileOverlay />
         <div className="flex flex-1 overflow-hidden min-w-0">

--- a/apps/web/components/layout/member-list.tsx
+++ b/apps/web/components/layout/member-list.tsx
@@ -172,7 +172,7 @@ export function MemberList({ serverId }: Props) {
   return (
     <div
       className="w-60 flex-shrink-0 flex flex-col"
-      style={{ background: "#2b2d31" }}
+      style={{ background: "var(--app-bg-secondary)" }}
     >
       <ScrollArea className="flex-1 py-4">
         {loadingMembers && (


### PR DESCRIPTION
### Motivation
- Theme preset selections in user settings were not visibly affecting the main app surfaces because those containers used hard-coded background colors instead of theme-aware tokens.

### Description
- Added two shared CSS variables `--app-bg-primary` and `--app-bg-secondary` to `apps/web/app/globals.css` and mapped them for each preset (`discord`, `midnight-neon`, `synthwave`, `carbon`).
- Replaced hard-coded background colors with `var(--app-bg-primary)` on main shell containers: `apps/web/components/layout/channels-shell.tsx`, `apps/web/components/dm/dm-area.tsx`, `apps/web/components/dm/dm-channel-area.tsx`, and `apps/web/components/dm/friends-sidebar.tsx`.
- Replaced hard-coded background color with `var(--app-bg-secondary)` for the member/DM side panels in `apps/web/components/layout/member-list.tsx` and `apps/web/components/dm/me-shell.tsx` so presets drive both primary and secondary surfaces.

### Testing
- Ran TypeScript check with `npm run type-check` in `apps/web`, which completed successfully (✅).
- Ran lint via `npm run lint` in `apps/web`, which failed due to existing `lint:style-guardrails` baseline violations unrelated to this change (⚠️).
- Started the dev server (`npm run dev`) and executed a Playwright script to capture a screenshot of the `/login` page; the server started and the screenshot was produced, but the page returned a runtime error due to missing Supabase environment variables in this environment (⚠️).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e204482f08325a96d390311f0736c)