### PR TITLE
Fix DM channel message sender relation join

### DIFF
--- a/apps/web/app/api/dm/channels/[channelId]/route.ts
+++ b/apps/web/app/api/dm/channels/[channelId]/route.ts
@@ -56,7 +56,7 @@ export async function GET(
 
   let query = supabase
     .from("direct_messages")
-    .select("id, dm_channel_id, sender_id, content, edited_at, deleted_at, created_at, sender:users!sender_id(id, username, display_name, avatar_url, status)")
+    .select("id, dm_channel_id, sender_id, content, edited_at, deleted_at, created_at, sender:users!direct_messages_sender_id_fkey(id, username, display_name, avatar_url, status)")
     .eq("dm_channel_id", channelId)
     .is("deleted_at", null)
     .order("created_at", { ascending: false })


### PR DESCRIPTION
### Motivation
- Channel-based DMs were failing to load sender profile data because the Supabase relation alias in the message query did not match the schema's foreign key name.

### Description
- Updated the messages query in `apps/web/app/api/dm/channels/[channelId]/route.ts` to use the correct relation alias `users!direct_messages_sender_id_fkey(...)` when selecting sender profile fields.

### Testing
- Ran `npm run -w apps/web type-check` and TypeScript checks succeeded.
- Attempted `npm run -w apps/web lint` which reported pre-existing style-guardrail violations unrelated to this change and caused the lint task to fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e3c941eb08325b08dda71cb6d918e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected database query alignment for direct message channel data retrieval to ensure proper data association and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->