### PR TITLE
Refactor typing indicator into a shared chat component

### DIFF
--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -16,6 +16,7 @@ import { ThreadPanel } from "@/components/chat/thread-panel"
 import { ThreadList } from "@/components/chat/thread-list"
 import { SearchModal } from "@/components/modals/search-modal"
 import { WorkspacePanel } from "@/components/chat/workspace-panel"
+import { TypingIndicator } from "@/components/chat/typing-indicator"
 import { NotificationBell } from "@/components/notifications/notification-bell"
 import {
   type OutboxEntry,
@@ -1169,22 +1170,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
           />
         </div>
 
-        {typingUsers.length > 0 && (
-          <div className="px-4 py-1 flex items-center gap-1.5 flex-shrink-0" style={{ minHeight: "24px" }}>
-            <span className="flex gap-0.5 items-end">
-              <span className="typing-dot" />
-              <span className="typing-dot" />
-              <span className="typing-dot" />
-            </span>
-            <span className="text-xs" style={{ color: "#949ba4" }}>
-              {typingUsers.length === 1
-                ? `${typingUsers[0].displayName} is typing…`
-                : typingUsers.length === 2
-                ? `${typingUsers[0].displayName} and ${typingUsers[1].displayName} are typing…`
-                : "Several people are typing…"}
-            </span>
-          </div>
-        )}
+        <TypingIndicator users={typingUsers.map((user) => user.displayName)} />
 
         <MessageInput
           channelName={channel.name}

--- a/apps/web/components/chat/typing-indicator.tsx
+++ b/apps/web/components/chat/typing-indicator.tsx
@@ -1,0 +1,35 @@
+interface TypingIndicatorProps {
+  users: string[]
+}
+
+function buildTypingText(users: string[]): string {
+  if (users.length === 1) {
+    return `${users[0]} is typing…`
+  }
+
+  if (users.length === 2) {
+    return `${users[0]} and ${users[1]} are typing…`
+  }
+
+  return `${users[0]} and ${users.length - 1} others are typing…`
+}
+
+/** Shared typing indicator for chat and DM surfaces. */
+export function TypingIndicator({ users }: TypingIndicatorProps) {
+  if (users.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="px-4 py-1 flex items-center gap-1.5 flex-shrink-0" style={{ minHeight: "24px" }}>
+      <span className="flex gap-0.5 items-end" aria-hidden="true">
+        <span className="typing-dot" />
+        <span className="typing-dot" />
+        <span className="typing-dot" />
+      </span>
+      <span className="text-xs text-muted-foreground">
+        {buildTypingText(users)}
+      </span>
+    </div>
+  )
+}

--- a/apps/web/components/dm/dm-channel-area.tsx
+++ b/apps/web/components/dm/dm-channel-area.tsx
@@ -10,6 +10,7 @@ import { MobileMenuButton } from "@/components/layout/mobile-nav"
 import { useToast } from "@/components/ui/use-toast"
 import { useTyping } from "@/hooks/use-typing"
 import { useAppStore } from "@/lib/stores/app-store"
+import { TypingIndicator } from "@/components/chat/typing-indicator"
 import { useShallow } from "zustand/react/shallow"
 
 interface User {
@@ -476,22 +477,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
       </div>
 
       {/* Typing indicator */}
-      {typingUsers.length > 0 && (
-        <div className="px-4 py-1 flex items-center gap-1.5 flex-shrink-0" style={{ minHeight: "24px" }}>
-          <span className="flex gap-0.5 items-end">
-            <span className="typing-dot" />
-            <span className="typing-dot" />
-            <span className="typing-dot" />
-          </span>
-          <span className="text-xs" style={{ color: "#949ba4" }}>
-            {typingUsers.length === 1
-              ? `${typingUsers[0].displayName} is typing…`
-              : typingUsers.length === 2
-              ? `${typingUsers[0].displayName} and ${typingUsers[1].displayName} are typing…`
-              : "Several people are typing…"}
-          </span>
-        </div>
-      )}
+      <TypingIndicator users={typingUsers.map((user) => user.displayName)} />
 
       {/* Input */}
       <div className="px-4 pb-4 flex-shrink-0">


### PR DESCRIPTION
### Motivation
- Remove duplicated typing-indicator UI and copy logic across channel and DM views and centralize behavior in a single component for consistency.
- Use a clearer multi-user string (`"<first user> and N others are typing…"`) instead of a generic fallback for better UX.
- Avoid adding `framer-motion` dependency for this small UI piece and reuse the existing `.typing-dot` animation pattern.

### Description
- Added `TypingIndicator` component at `apps/web/components/chat/typing-indicator.tsx` that renders the dot animation and shared copy generation via `buildTypingText(users)`.
- Replaced inline typing-indicator blocks in `apps/web/components/chat/chat-area.tsx` and `apps/web/components/dm/dm-channel-area.tsx` with `<TypingIndicator users={typingUsers.map((u) => u.displayName)} />`.
- Replaced inline color styling with the design token class `text-muted-foreground` in the new component.

### Testing
- Ran type checking with `npm run -w @vortex/web type-check` which succeeded.
- Ran lint/style-guardrail check with `npm run -w @vortex/web lint` which surfaced pre-existing style-guardrail issues and failed (these failures are repo baseline issues unrelated to the refactor).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4ff3696c8325bc7695c590c9e1ab)