### PR TITLE
Harden DM endpoints and client error handling

### DIFF
--- a/apps/web/app/api/dm/channels/[channelId]/messages/route.ts
+++ b/apps/web/app/api/dm/channels/[channelId]/messages/route.ts
@@ -13,16 +13,23 @@ export async function POST(
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
   // Verify membership
-  const { data: membership } = await supabase
+  const { data: membership, error: membershipError } = await supabase
     .from("dm_channel_members")
     .select("user_id")
     .eq("dm_channel_id", channelId)
     .eq("user_id", user.id)
-    .single()
+    .maybeSingle()
+
+  if (membershipError) return NextResponse.json({ error: membershipError.message }, { status: 500 })
 
   if (!membership) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
 
-  const body = await req.json()
+  let body: { content?: string }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
   const content = body.content?.trim()
   if (!content) return NextResponse.json({ error: "Content required" }, { status: 400 })
 

--- a/apps/web/app/api/dm/channels/[channelId]/route.ts
+++ b/apps/web/app/api/dm/channels/[channelId]/route.ts
@@ -12,37 +12,43 @@ export async function GET(
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
   // Verify membership
-  const { data: membership } = await supabase
+  const { data: membership, error: membershipError } = await supabase
     .from("dm_channel_members")
     .select("user_id")
     .eq("dm_channel_id", channelId)
     .eq("user_id", user.id)
-    .single()
+    .maybeSingle()
+
+  if (membershipError) return NextResponse.json({ error: membershipError.message }, { status: 500 })
 
   if (!membership) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
 
   // Fetch channel info (flat, no joins)
-  const { data: channel } = await supabase
+  const { data: channel, error: channelError } = await supabase
     .from("dm_channels")
     .select("id, name, icon_url, is_group, owner_id, updated_at")
     .eq("id", channelId)
-    .single()
+    .maybeSingle()
+  if (channelError) return NextResponse.json({ error: channelError.message }, { status: 500 })
+  if (!channel) return NextResponse.json({ error: "DM channel not found" }, { status: 404 })
 
   // Fetch member user_ids
-  const { data: memberRows } = await supabase
+  const { data: memberRows, error: memberRowsError } = await supabase
     .from("dm_channel_members")
     .select("user_id")
     .eq("dm_channel_id", channelId)
+  if (memberRowsError) return NextResponse.json({ error: memberRowsError.message }, { status: 500 })
 
   const memberIds = memberRows?.map((r) => r.user_id) ?? []
 
   // Fetch user profiles for members
-  const { data: memberUsers } = memberIds.length
+  const { data: memberUsers, error: memberUsersError } = memberIds.length
     ? await supabase
         .from("users")
         .select("id, username, display_name, avatar_url, status, status_message")
         .in("id", memberIds)
-    : { data: [] }
+    : { data: [], error: null }
+  if (memberUsersError) return NextResponse.json({ error: memberUsersError.message }, { status: 500 })
 
   const members = memberUsers ?? []
   const partner = channel && !channel.is_group

--- a/apps/web/app/api/dm/channels/route.ts
+++ b/apps/web/app/api/dm/channels/route.ts
@@ -19,16 +19,18 @@ export async function GET() {
   if (!channelIds.length) return NextResponse.json([])
 
   // 2. Fetch channel metadata
-  const { data: channelRows } = await supabase
+  const { data: channelRows, error: channelRowsError } = await supabase
     .from("dm_channels")
     .select("id, name, icon_url, is_group, owner_id, updated_at")
     .in("id", channelIds)
+  if (channelRowsError) return NextResponse.json({ error: channelRowsError.message }, { status: 500 })
 
   // 3. Fetch all members across these channels
-  const { data: allMemberRows } = await supabase
+  const { data: allMemberRows, error: allMemberRowsError } = await supabase
     .from("dm_channel_members")
     .select("dm_channel_id, user_id")
     .in("dm_channel_id", channelIds)
+  if (allMemberRowsError) return NextResponse.json({ error: allMemberRowsError.message }, { status: 500 })
 
   // 4. Fetch user profiles for all unique member IDs
   const allUserIds = Array.from(new Set((allMemberRows ?? []).map((m) => m.user_id)))
@@ -39,6 +41,7 @@ export async function GET() {
         .in("id", allUserIds)
     : null
   const userRows = userRowsQuery?.data ?? []
+  if (userRowsQuery?.error) return NextResponse.json({ error: userRowsQuery.error.message }, { status: 500 })
 
   const userMap = Object.fromEntries(userRows.map((u) => [u.id, u]))
 
@@ -51,12 +54,13 @@ export async function GET() {
   }
 
   // 5. Get latest message per channel
-  const { data: latest } = await supabase
+  const { data: latest, error: latestError } = await supabase
     .from("direct_messages")
     .select("dm_channel_id, content, created_at, sender_id")
     .in("dm_channel_id", channelIds)
     .is("deleted_at", null)
     .order("created_at", { ascending: false })
+  if (latestError) return NextResponse.json({ error: latestError.message }, { status: 500 })
 
   const latestMessages: Record<string, any> = {}
   for (const msg of latest ?? []) {
@@ -66,11 +70,12 @@ export async function GET() {
   }
 
   // 6. Get read states
-  const { data: reads } = await supabase
+  const { data: reads, error: readsError } = await supabase
     .from("dm_read_states")
     .select("dm_channel_id, last_read_at")
     .eq("user_id", user.id)
     .in("dm_channel_id", channelIds)
+  if (readsError) return NextResponse.json({ error: readsError.message }, { status: 500 })
 
   const readStates: Record<string, string> = {}
   for (const r of reads ?? []) {
@@ -111,7 +116,14 @@ export async function POST(req: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
-  const { userIds, name } = await req.json()
+  let parsedBody: { userIds?: string[]; name?: string }
+  try {
+    parsedBody = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const { userIds, name } = parsedBody
   if (!userIds?.length) return NextResponse.json({ error: "userIds required" }, { status: 400 })
 
   const allMembers = Array.from(new Set([user.id, ...userIds])) as string[]
@@ -121,33 +133,35 @@ export async function POST(req: NextRequest) {
     const partnerId = userIds[0] as string
 
     // Find existing 1:1 channel between current user and partner
-    const { data: userMems } = await supabase
+    const { data: userMems, error: userMemsError } = await supabase
       .from("dm_channel_members")
       .select("dm_channel_id")
       .eq("user_id", user.id)
+    if (userMemsError) return NextResponse.json({ error: userMemsError.message }, { status: 500 })
 
-    const userChannelIds = (userMems ?? []).map((m) => m.dm_channel_id)
+    const { data: partnerMems, error: partnerMemsError } = await supabase
+      .from("dm_channel_members")
+      .select("dm_channel_id")
+      .eq("user_id", partnerId)
+    if (partnerMemsError) return NextResponse.json({ error: partnerMemsError.message }, { status: 500 })
 
-    if (userChannelIds.length > 0) {
+    const userChannelIds = new Set((userMems ?? []).map((m) => m.dm_channel_id))
+    const sharedChannelIds = (partnerMems ?? [])
+      .map((m) => m.dm_channel_id)
+      .filter((id) => userChannelIds.has(id))
+
+    if (sharedChannelIds.length > 0) {
       // Get non-group channels from those IDs
-      const { data: nonGroupChannels } = await supabase
+      const { data: nonGroupChannels, error: nonGroupChannelsError } = await supabase
         .from("dm_channels")
         .select("id")
-        .in("id", userChannelIds)
+        .in("id", sharedChannelIds)
         .eq("is_group", false)
+      if (nonGroupChannelsError) return NextResponse.json({ error: nonGroupChannelsError.message }, { status: 500 })
 
-      for (const ch of nonGroupChannels ?? []) {
-        // Check if partner is also a member of this channel
-        const { data: partnerMem } = await supabase
-          .from("dm_channel_members")
-          .select("dm_channel_id")
-          .eq("dm_channel_id", ch.id)
-          .eq("user_id", partnerId)
-          .single()
-
-        if (partnerMem) {
-          return NextResponse.json({ id: ch.id, existing: true })
-        }
+      const existingChannel = (nonGroupChannels ?? [])[0]
+      if (existingChannel) {
+        return NextResponse.json({ id: existingChannel.id, existing: true })
       }
     }
   }

--- a/apps/web/components/user-profile-popover.tsx
+++ b/apps/web/components/user-profile-popover.tsx
@@ -76,13 +76,14 @@ export function UserProfilePopover({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ userIds: [userId] }),
       })
-      if (res.ok) {
-        const { id } = await res.json()
-        router.push(`/channels/me/${id}`)
+      const payload = await res.json().catch(() => ({ error: "Failed to open DM" })) as { id?: string; error?: string }
+      if (res.ok && payload.id) {
+        router.push(`/channels/me/${payload.id}`)
       } else {
-        const { error } = await res.json()
-        toast({ variant: "destructive", title: error || "Failed to open DM" })
+        toast({ variant: "destructive", title: payload.error || "Failed to open DM" })
       }
+    } catch {
+      toast({ variant: "destructive", title: "Failed to open DM" })
     } finally {
       setActionLoading(null)
     }


### PR DESCRIPTION
### Motivation

- Prevent opaque 500s and runtime errors when opening or listing DMs by surfacing database query errors as structured JSON responses. 
- Avoid unhandled exceptions caused by malformed or non-JSON request/response bodies when creating DM channels or sending DM messages. 
- Make client-side DM actions resilient to non-JSON or failed API responses so the UI shows a toast instead of throwing.

### Description

- Added explicit Supabase error checks and early JSON-error returns in the DM list endpoint (`GET /api/dm/channels`) so each DB query returns a structured 500 response on failure. 
- Hardened DM channel detail endpoint (`GET /api/dm/channels/[channelId]`) by using `maybeSingle()` for membership/channel lookups, returning 404 when a channel is missing, and returning DB errors as JSON. 
- Hardened DM message send endpoint (`POST /api/dm/channels/[channelId]/messages`) by switching membership validation to `maybeSingle()` and adding a try/catch around `req.json()` to return a 400 on invalid JSON. 
- Simplified 1:1 DM existence detection by intersecting member channel ID sets to avoid per-channel membership probes, and added error propagation for those queries. 
- Updated the user-profile popover `Message` action to safely parse responses and catch network/non-JSON failures, showing a toast on error instead of causing an uncaught client exception.

### Testing

- Ran `npm --workspace apps/web run type-check` and the TypeScript checks completed successfully. 
- Ran `npm --workspace apps/web run test` and the test suite passed (13 test files, 85 tests passed). 
- Ran `npm --workspace apps/web run test -- dm` with the dm filter which exited with no matching files (no tests under that filter).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e5546a9b0832583c82a6fa9920795)