### PR TITLE
fix: repair profile themes and custom CSS injection

### DIFF
--- a/apps/web/app/channels/layout.tsx
+++ b/apps/web/app/channels/layout.tsx
@@ -34,7 +34,7 @@ export default async function ChannelsLayout({
 
   return (
     <AppProvider user={profile} servers={servers}>
-      <div className="flex h-screen overflow-hidden" style={{ background: '#313338' }}>
+      <div className="flex h-screen overflow-hidden" style={{ background: 'var(--app-bg-primary)' }}>
         <ServerSidebar />
         {children}
       </div>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -41,6 +41,7 @@
   }
   body {
     @apply bg-background text-foreground;
+    background-color: var(--app-bg-primary);
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 
@@ -248,59 +249,131 @@
 /* ─── Appearance settings ─────────────────────────────────────────────────── */
 
 
-/* Theme presets */
+/* Theme presets – every preset declares all tokens so switching themes is
+   fully self-contained with no leftover values from a previous preset. */
+
 [data-theme-preset="discord"] {
+  /* Core surface palette */
   --background: 223 7% 20%;
+  --foreground: 220 9% 95%;
   --card: 220 7% 18%;
+  --card-foreground: 220 9% 95%;
+  --popover: 220 7% 14%;
+  --popover-foreground: 220 9% 95%;
+  /* Brand / interactive */
+  --primary: 235 86% 65%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 220 6% 18%;
+  --secondary-foreground: 215 8% 73%;
   --accent: 235 86% 65%;
+  --accent-foreground: 0 0% 100%;
+  /* Neutral */
+  --muted: 220 5% 30%;
+  --muted-foreground: 215 8% 60%;
+  --border: 220 6% 25%;
+  --input: 220 6% 18%;
   --ring: 235 86% 65%;
+  /* Destructive */
+  --destructive: 359 87% 57%;
+  --destructive-foreground: 0 0% 100%;
+  /* App-specific surfaces (used by sidebar / shell) */
   --app-bg-primary: #313338;
   --app-bg-secondary: #2b2d31;
+  --app-bg-tertiary: #1e1f22;
+  --app-accent-color: #5865f2;
 }
 
 [data-theme-preset="midnight-neon"] {
+  /* Core surface palette */
   --background: 236 30% 9%;
   --foreground: 210 40% 98%;
   --card: 236 27% 12%;
+  --card-foreground: 210 40% 98%;
   --popover: 236 30% 8%;
+  --popover-foreground: 210 40% 98%;
+  /* Brand / interactive */
+  --primary: 186 100% 57%;
+  --primary-foreground: 230 40% 8%;
+  --secondary: 234 19% 18%;
+  --secondary-foreground: 217 24% 76%;
+  --accent: 186 100% 57%;
+  --accent-foreground: 230 40% 8%;
+  /* Neutral */
   --muted: 234 19% 24%;
   --muted-foreground: 217 24% 76%;
-  --border: 233 22% 46%;
-  --input: 234 19% 18%;
-  --destructive: 357 85% 62%;
-  --accent: 186 100% 57%;
-  --primary: 186 100% 57%;
+  --border: 234 22% 22%;
+  --input: 234 19% 14%;
   --ring: 315 100% 67%;
+  /* Destructive */
+  --destructive: 357 85% 62%;
+  --destructive-foreground: 0 0% 100%;
+  /* App-specific surfaces */
   --app-bg-primary: #1b1f31;
   --app-bg-secondary: #151829;
+  --app-bg-tertiary: #0f1120;
+  --app-accent-color: #00e5ff;
 }
 
 [data-theme-preset="synthwave"] {
+  /* Core surface palette */
   --background: 258 30% 11%;
   --foreground: 286 33% 96%;
   --card: 264 32% 14%;
+  --card-foreground: 286 33% 96%;
   --popover: 264 36% 10%;
+  --popover-foreground: 286 33% 96%;
+  /* Brand / interactive */
+  --primary: 271 89% 72%;
+  --primary-foreground: 260 40% 8%;
+  --secondary: 262 23% 20%;
+  --secondary-foreground: 280 26% 79%;
+  --accent: 323 89% 66%;
+  --accent-foreground: 260 40% 8%;
+  /* Neutral */
   --muted: 262 23% 27%;
   --muted-foreground: 280 26% 79%;
-  --border: 266 24% 48%;
-  --input: 262 23% 20%;
-  --destructive: 353 80% 63%;
-  --accent: 323 89% 66%;
-  --primary: 271 89% 72%;
+  --border: 264 22% 28%;
+  --input: 262 23% 16%;
   --ring: 188 98% 62%;
+  /* Destructive */
+  --destructive: 353 80% 63%;
+  --destructive-foreground: 0 0% 100%;
+  /* App-specific surfaces */
   --app-bg-primary: #2a1e46;
   --app-bg-secondary: #23193b;
+  --app-bg-tertiary: #1a1030;
+  --app-accent-color: #f92aad;
 }
 
 [data-theme-preset="carbon"] {
+  /* Core surface palette */
   --background: 220 7% 12%;
+  --foreground: 215 20% 90%;
   --card: 220 7% 15%;
+  --card-foreground: 215 20% 90%;
   --popover: 220 10% 9%;
-  --accent: 160 84% 40%;
+  --popover-foreground: 215 20% 90%;
+  /* Brand / interactive */
   --primary: 217 100% 70%;
+  --primary-foreground: 220 40% 8%;
+  --secondary: 220 7% 18%;
+  --secondary-foreground: 215 14% 65%;
+  --accent: 160 84% 40%;
+  --accent-foreground: 220 40% 8%;
+  /* Neutral */
+  --muted: 220 6% 22%;
+  --muted-foreground: 215 10% 55%;
+  --border: 220 6% 20%;
+  --input: 220 6% 14%;
   --ring: 160 84% 40%;
+  /* Destructive */
+  --destructive: 359 87% 57%;
+  --destructive-foreground: 0 0% 100%;
+  /* App-specific surfaces */
   --app-bg-primary: #1f2124;
   --app-bg-secondary: #191b1e;
+  --app-bg-tertiary: #141618;
+  --app-accent-color: #3ba55c;
 }
 
 /* Font scale */

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -35,7 +35,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="dark">
-      <body className={inter.className} style={{ background: '#313338' }}>
+      <body className={inter.className} style={{ background: 'var(--app-bg-primary)' }}>
         {children}
         <Toaster />
       </body>

--- a/apps/web/components/layout/app-provider.tsx
+++ b/apps/web/components/layout/app-provider.tsx
@@ -40,23 +40,14 @@ export function AppProvider({ user, servers, children }: AppProviderProps) {
 
     const customCssStyleId = "vortex-custom-theme-css"
     let styleTag = document.getElementById(customCssStyleId) as HTMLStyleElement | null
-    const createdByThisEffect = !styleTag
     if (!styleTag) {
       styleTag = document.createElement("style")
       styleTag.id = customCssStyleId
       document.head.appendChild(styleTag)
     }
     styleTag.textContent = customCss.trim()
-
-    return () => {
-      if (createdByThisEffect && styleTag?.parentNode) {
-        styleTag.parentNode.removeChild(styleTag)
-      }
-      delete root.dataset.messageDisplay
-      delete root.dataset.fontScale
-      delete root.dataset.saturation
-      delete root.dataset.themePreset
-    }
+    // No cleanup: attributes and style tag persist until the app unmounts (page unload).
+    // Removing them on every dependency change caused a visible theme flash on each re-render.
   }, [messageDisplay, fontScale, saturation, themePreset, customCss])
 
   // Auto-sync presence: marks user online on mount, offline on tab close

--- a/apps/web/components/modals/profile-settings-modal.tsx
+++ b/apps/web/components/modals/profile-settings-modal.tsx
@@ -38,18 +38,39 @@ const BANNER_PRESETS = [
 const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"]
 const MAX_AVATAR_SIZE = 5 * 1024 * 1024 // 5MB
 
-const CSS_TEMPLATE = `/* Vortex Custom Theme Template */
+const CSS_TEMPLATE = `/**
+ * Vortex Custom Theme – BetterDiscord-compatible
+ *
+ * Paste any BetterDiscord / Vencord theme here.
+ * @import and url() are supported for HTTPS fonts & images.
+ *
+ * Example: import a Google Font
+ * @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
+ */
+
 :root {
-  --background: 225 15% 10%;
-  --card: 230 17% 12%;
-  --accent: 264 85% 68%;
-  --ring: 190 95% 58%;
+  /* Override app surface colors */
+  --app-bg-primary: #1e1e2e;
+  --app-bg-secondary: #181825;
+  --app-bg-tertiary: #11111b;
+
+  /* Override Tailwind design tokens (HSL without hsl() wrapper) */
+  --background: 240 21% 15%;
+  --card: 240 21% 12%;
+  --popover: 240 24% 10%;
+  --foreground: 226 64% 88%;
+  --muted: 240 14% 28%;
+  --muted-foreground: 228 20% 70%;
+  --border: 240 14% 22%;
+  --input: 240 14% 18%;
+  --primary: 267 84% 81%;
+  --accent: 316 73% 69%;
+  --ring: 267 84% 81%;
 }
 
-/* Optional per-component overrides */
-.message-content a {
-  color: #3ec5ff;
-}`
+/* Optional: style specific elements */
+.message-content a { color: #89b4fa; }
+`
 
 /** Tabbed user settings dialog covering profile editing, account security (2FA, passkeys, sessions), and appearance preferences. */
 export function ProfileSettingsModal({ open, onClose, user }: Props) {
@@ -658,27 +679,55 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
       <div>
         <h3 className="text-base font-semibold text-white mb-1">Theme Presets</h3>
         <p className="text-sm mb-4" style={{ color: "#949ba4" }}>
-          Pick a next-gen Discord-inspired skin, then layer your own CSS on top.
+          Pick a skin — changes apply instantly. Layer your own CSS on top for full BetterDiscord-style customization.
         </p>
         <div className="grid grid-cols-2 gap-3">
           {([
-            { key: "discord", label: "Discord Classic" },
-            { key: "midnight-neon", label: "Midnight Neon" },
-            { key: "synthwave", label: "Synthwave" },
-            { key: "carbon", label: "Carbon Glass" },
+            {
+              key: "discord",
+              label: "Discord Classic",
+              desc: "Familiar dark blue-grey",
+              swatches: ["#313338", "#5865f2", "#23a55a"],
+            },
+            {
+              key: "midnight-neon",
+              label: "Midnight Neon",
+              desc: "Deep navy + cyan glow",
+              swatches: ["#1b1f31", "#00e5ff", "#f700ff"],
+            },
+            {
+              key: "synthwave",
+              label: "Synthwave",
+              desc: "Retro purple + pink",
+              swatches: ["#2a1e46", "#f92aad", "#7c3aed"],
+            },
+            {
+              key: "carbon",
+              label: "Carbon Glass",
+              desc: "Near-black + green",
+              swatches: ["#1f2124", "#3ba55c", "#5b8af0"],
+            },
           ] as const).map((preset) => (
             <button
               type="button"
               key={preset.key}
               onClick={() => setThemePreset(preset.key)}
-              className="rounded-lg border px-3 py-2 text-left"
+              className="rounded-lg border px-3 py-2.5 text-left flex flex-col gap-2"
               style={{
                 background: themePreset === preset.key ? "rgba(88,101,242,0.15)" : "#2b2d31",
                 borderColor: themePreset === preset.key ? "#5865f2" : "#1e1f22",
                 color: themePreset === preset.key ? "#f2f3f5" : "#b5bac1",
               }}
             >
-              {preset.label}
+              <div className="flex items-center justify-between w-full">
+                <span className="text-sm font-medium">{preset.label}</span>
+                <div className="flex gap-1">
+                  {preset.swatches.map((color) => (
+                    <span key={color} className="w-3.5 h-3.5 rounded-full flex-shrink-0" style={{ background: color }} />
+                  ))}
+                </div>
+              </div>
+              <span className="text-xs" style={{ color: "#72767d" }}>{preset.desc}</span>
             </button>
           ))}
         </div>
@@ -734,26 +783,40 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
 
       <div>
         <h3 className="text-base font-semibold text-white mb-1">Custom CSS</h3>
-        <p className="text-sm mb-3" style={{ color: "#949ba4" }}>Like BetterDiscord/Vencord, your CSS is injected after the preset. Keep it client-safe and style-only.</p>
+        <p className="text-sm mb-3" style={{ color: "#949ba4" }}>
+          Paste any BetterDiscord / Vencord theme here — <code className="rounded px-1 text-xs" style={{ background: "#1e1f22", color: "#dcddde" }}>@import</code> and <code className="rounded px-1 text-xs" style={{ background: "#1e1f22", color: "#dcddde" }}>url()</code> are supported for HTTPS resources. Your CSS is injected on top of the preset, so you have full control.
+        </p>
         <textarea
           value={customCss}
           onChange={(event) => setCustomCss(event.target.value)}
           placeholder={CSS_TEMPLATE}
-          className="w-full min-h-[180px] rounded-lg border p-3 text-xs font-mono"
-          style={{ background: "#1e1f22", borderColor: "#1e1f22", color: "#dcddde" }}
+          spellCheck={false}
+          className="w-full min-h-[240px] rounded-lg border p-3 text-xs font-mono leading-relaxed"
+          style={{ background: "#1e1f22", borderColor: customCss.length > 50000 ? "#f23f43" : "#1e1f22", color: "#dcddde", resize: "vertical" }}
         />
-        <div className="mt-2 flex gap-2">
-          <Button type="button" variant="outline" onClick={() => setCustomCss(CSS_TEMPLATE)}>Use Template</Button>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={async () => {
-              await navigator.clipboard.writeText(CSS_TEMPLATE)
-              toast({ title: "Template copied" })
-            }}
-          >
-            Copy Template
-          </Button>
+        <div className="mt-1.5 flex items-center justify-between">
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={() => setCustomCss(CSS_TEMPLATE)}>Use Template</Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={async () => {
+                await navigator.clipboard.writeText(CSS_TEMPLATE)
+                toast({ title: "Template copied" })
+              }}
+            >
+              Copy Template
+            </Button>
+            {customCss.trim() && (
+              <Button type="button" variant="outline" size="sm" onClick={() => setCustomCss("")} style={{ color: "#f23f43", borderColor: "rgba(242,63,67,0.4)" }}>
+                Clear
+              </Button>
+            )}
+          </div>
+          <span className="text-xs tabular-nums" style={{ color: customCss.length > 50000 ? "#f23f43" : "#4e5058" }}>
+            {customCss.length.toLocaleString()} / 50,000
+          </span>
         </div>
       </div>
 

--- a/apps/web/lib/stores/appearance-store.ts
+++ b/apps/web/lib/stores/appearance-store.ts
@@ -49,9 +49,17 @@ const SATURATION_LEVELS: Saturation[] = ["normal", "reduced"]
 function sanitizeCustomCss(value: unknown): string {
   if (typeof value !== "string") return ""
   return value
-    .replace(/@import\b[^;]*;?/gi, "")
-    .replace(/url\s*\(/gi, "/* blocked:url( */(")
-    .slice(0, 12000)
+    // Block expression() – IE/legacy XSS vector
+    .replace(/expression\s*\(/gi, "/* blocked:expression */(")
+    // Block -moz-binding – old Firefox XSS vector
+    .replace(/-moz-binding\s*:/gi, "/* blocked */:")
+    // Block behavior: – IE XSS vector
+    .replace(/behavior\s*:/gi, "/* blocked */:")
+    // Block javascript: URLs inside url()
+    .replace(/url\s*\(\s*(['"]?)javascript:/gi, "url($1data:text/plain,blocked")
+    // Block data: URLs for non-image/font types (e.g. data:text/html XSS)
+    .replace(/url\s*\(\s*(['"]?)data:(?!image\/|font\/|application\/font|application\/x-font)/gi, "url($1data:text/plain,blocked")
+    .slice(0, 50000)
 }
 
 export const useAppearanceStore = create<AppearanceState>()(

--- a/supabase/migrations/00028_increase_custom_css_limit.sql
+++ b/supabase/migrations/00028_increase_custom_css_limit.sql
@@ -1,0 +1,9 @@
+-- Increase the custom CSS character limit from 12,000 to 50,000 to support
+-- full BetterDiscord / Vencord themes (many popular themes exceed 12 KB).
+
+ALTER TABLE public.users
+  DROP CONSTRAINT IF EXISTS users_appearance_settings_custom_css_length_check;
+
+ALTER TABLE public.users
+  ADD CONSTRAINT users_appearance_settings_custom_css_length_check
+  CHECK (length(coalesce(appearance_settings->>'customCss', '')) <= 50000);


### PR DESCRIPTION
- Custom CSS sanitizer was replacing url() with malformed CSS, breaking any theme that uses images or external fonts. Rewrite sanitizer to only block actual XSS vectors (expression(), -moz-binding, behavior:, javascript: URLs, non-image data: URLs) while allowing @import and url() for HTTPS resources, enabling full BetterDiscord/Vencord theme compatibility.

- Increase custom CSS limit from 12 000 → 50 000 chars (migration + store + UI character counter) to support popular community themes.

- app-provider.tsx cleanup was deleting all data-theme-preset/font-scale attributes on every dependency change, causing a visible theme flash on each keystroke in the CSS editor. Remove the cleanup so attributes persist for the page lifetime.

- body and main channel container had hardcoded #313338 inline styles that overrode CSS variables. Change both to var(--app-bg-primary) so all four theme presets actually change the app background.

- Expand each theme preset to declare the full token set (--foreground, --card, --popover, --muted, --border, --input, --app-bg-tertiary, --app-accent-color, etc.) so switching between presets is fully self-contained with no leftover values.

- Add globals.css body rule using var(--app-bg-primary) as a reliable fallback for the body background.

- Improve Appearance tab UI: theme preset buttons now show color swatches and a short description; CSS editor is resizable with a live character counter; Clear button added; template updated with a BetterDiscord-compatible example including @import and :root overrides.

https://claude.ai/code/session_01RW2SBHUj3j33ANeC9XhaL9