### PR TITLE
fix: repair broken messaging after Codex changes

### DIFF
--- a/apps/web/hooks/use-tab-unread-title.ts
+++ b/apps/web/hooks/use-tab-unread-title.ts
@@ -18,7 +18,7 @@ export function useTabUnreadTitle(userId: string | null) {
         .from("notifications")
         .select("id", { count: "exact", head: true })
          .eq("user_id", currentUserId)
-        .is("read_at", null)
+        .eq("read", false)
       if (cancelled) return
       const unread = count ?? 0
       document.title = unread > 0 ? `(${unread}) VortexChat` : BASE_TITLE

--- a/apps/web/types/database.ts
+++ b/apps/web/types/database.ts
@@ -446,6 +446,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "messages_reply_to_id_fkey"
+            columns: ["reply_to_id"]
+            isOneToOne: false
+            referencedRelation: "messages"
+            referencedColumns: ["id"]
           }
         ]
       }

--- a/supabase/migrations/00029_ensure_reply_to_fk.sql
+++ b/supabase/migrations/00029_ensure_reply_to_fk.sql
@@ -1,0 +1,23 @@
+-- Ensure the self-referential FK on messages.reply_to_id exists so that
+-- PostgREST can expose the relationship for embedded queries.
+-- The constraint may be absent when the database was provisioned without
+-- running all migrations or when the schema cache is stale.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_constraint
+    WHERE  conname = 'messages_reply_to_id_fkey'
+    AND    conrelid = 'public.messages'::regclass
+  ) THEN
+    ALTER TABLE public.messages
+      ADD CONSTRAINT messages_reply_to_id_fkey
+        FOREIGN KEY (reply_to_id)
+        REFERENCES public.messages(id)
+        ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Notify PostgREST to reload its schema cache so the new relationship
+-- is immediately available for embedded queries.
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Two bugs introduced by the recent Codex commits:

1. notifications query used `.is("read_at", null)` but the `notifications` table has a boolean `read` column, not a timestamptz `read_at` column. This caused a 400 from Supabase on every page load, breaking the unread badge/title counter.  Fixed to `.eq("read", false)`.

2. All message queries now embed `reply_to:messages!messages_reply_to_id_fkey` but PostgREST's schema cache did not contain this self-referential FK, returning 400 for every messages fetch and triggering the React #418 hydration error.  Added migration 00029 to idempotently create the FK constraint and issue `NOTIFY pgrst, 'reload schema'`.  Also added the relationship to `database.ts` so TypeScript types stay accurate.

https://claude.ai/code/session_01KX8sBDg7ehcjNqM66BrgSi