### PR TITLE
fix: replace broken reply_to FK-embed with two-query hydration

### DIFF
--- a/apps/web/app/api/messages/route.ts
+++ b/apps/web/app/api/messages/route.ts
@@ -15,7 +15,20 @@ import { getChannelPermissions, hasPermission } from "@/lib/permissions"
 import { filterMentionsByBlockState } from "@/lib/blocking"
 import { validateAttachments } from "@/lib/attachment-validation"
 
-const MESSAGE_PROJECTION = `*, author:users!messages_author_id_fkey(*), attachments(*), reactions(*), reply_to:messages!messages_reply_to_id_fkey(*, author:users!messages_author_id_fkey(*))`
+// Base projection — does NOT embed reply_to via FK join because the
+// self-referential FK is not guaranteed to be in PostgREST's schema cache.
+// Reply-to messages are hydrated in a separate query by withReplyTo().
+const MESSAGE_PROJECTION = `*, author:users!messages_author_id_fkey(*), attachments(*), reactions(*)`
+const REPLY_PROJECTION   = `*, author:users!messages_author_id_fkey(*)`
+
+/** Fetch parent messages for any rows that have reply_to_id set and stitch them in. */
+async function withReplyTo(supabase: Awaited<ReturnType<typeof createServerSupabaseClient>>, rows: any[]): Promise<any[]> {
+  const ids = [...new Set(rows.map((r: any) => r.reply_to_id).filter(Boolean))] as string[]
+  if (!ids.length) return rows.map((r: any) => ({ ...r, reply_to: null }))
+  const { data } = await supabase.from("messages").select(REPLY_PROJECTION).in("id", ids)
+  const map = new Map((data ?? []).map((m: any) => [m.id, m]))
+  return rows.map((r: any) => ({ ...r, reply_to: r.reply_to_id ? (map.get(r.reply_to_id) ?? null) : null }))
+}
 
 export async function GET(request: Request) {
   const supabase = await createServerSupabaseClient()
@@ -94,7 +107,7 @@ export async function GET(request: Request) {
     )
 
     return NextResponse.json({
-      messages: deduped,
+      messages: await withReplyTo(supabase, deduped),
       hasMoreBefore,
       hasMoreAfter,
     })
@@ -116,7 +129,7 @@ export async function GET(request: Request) {
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
 
-  return NextResponse.json((messages ?? []).reverse())
+  return NextResponse.json(await withReplyTo(supabase, (messages ?? []).reverse()))
 }
 
 export async function POST(request: Request) {
@@ -202,7 +215,8 @@ export async function POST(request: Request) {
       .maybeSingle()
 
     if (existing) {
-      return NextResponse.json(existing, { status: 200 })
+      const [hydrated] = await withReplyTo(supabase, [existing])
+      return NextResponse.json(hydrated, { status: 200 })
     }
   }
 
@@ -519,7 +533,8 @@ export async function POST(request: Request) {
         .maybeSingle()
 
       if (existing) {
-        return NextResponse.json(existing, { status: 200 })
+        const [hydrated] = await withReplyTo(supabase, [existing])
+        return NextResponse.json(hydrated, { status: 200 })
       }
     }
 
@@ -596,5 +611,6 @@ export async function POST(request: Request) {
     excludeUserId: user.id,
   }).catch(() => {})
 
-  return NextResponse.json(message, { status: 201 })
+  const [hydratedMessage] = await withReplyTo(supabase, [message])
+  return NextResponse.json(hydratedMessage, { status: 201 })
 }

--- a/apps/web/app/channels/[serverId]/[channelId]/page.tsx
+++ b/apps/web/app/channels/[serverId]/[channelId]/page.tsx
@@ -38,13 +38,7 @@ export default async function ChannelPage({ params: paramsPromise }: Props) {
       .single(),
     supabase
       .from("messages")
-      .select(`
-        *,
-        author:users!messages_author_id_fkey(*),
-        attachments(*),
-        reactions(*),
-        reply_to:messages!messages_reply_to_id_fkey(*, author:users!messages_author_id_fkey(*))
-      `)
+      .select(`*, author:users!messages_author_id_fkey(*), attachments(*), reactions(*)`)
       .eq("channel_id", params.channelId)
       .is("deleted_at", null)
       .order("created_at", { ascending: false })
@@ -62,7 +56,18 @@ export default async function ChannelPage({ params: paramsPromise }: Props) {
   // Filter messages to only text-based channel types
   let messages: any[] = []
   if ((MESSAGE_CHANNEL_TYPES as readonly string[]).includes(channel.type)) {
-    messages = (messagesData ?? []).reverse()
+    const raw = (messagesData ?? []).reverse()
+    // Hydrate reply_to without relying on the self-referential FK join
+    const replyIds = [...new Set(raw.map((m: any) => m.reply_to_id).filter(Boolean))] as string[]
+    let replyMap = new Map<string, any>()
+    if (replyIds.length > 0) {
+      const { data: replyRows } = await supabase
+        .from("messages")
+        .select(`*, author:users!messages_author_id_fkey(*)`)
+        .in("id", replyIds)
+      for (const r of replyRows ?? []) replyMap.set(r.id, r)
+    }
+    messages = raw.map((m: any) => ({ ...m, reply_to: m.reply_to_id ? (replyMap.get(m.reply_to_id) ?? null) : null }))
   }
 
   // Voice and Stage channels use the WebRTC voice infrastructure

--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -43,7 +43,8 @@ function isDuplicateInsertError(error: { code?: string } | null): boolean {
   return error?.code === "23505"
 }
 
-const MESSAGE_SELECT = `*, author:users!messages_author_id_fkey(*), attachments(*), reactions(*), reply_to:messages!messages_reply_to_id_fkey(*, author:users!messages_author_id_fkey(*))`
+const MESSAGE_SELECT = `*, author:users!messages_author_id_fkey(*), attachments(*), reactions(*)`
+const REPLY_SELECT   = `*, author:users!messages_author_id_fkey(*)`
 
 function sortMessagesChronologically(items: MessageWithAuthor[]): MessageWithAuthor[] {
   const timestamps = new Map<string, number>()
@@ -266,7 +267,13 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     setAndPersistOutbox((current) => removeOutboxEntry(current, entry.id))
 
     if (data) {
-      upsertMessage(data as unknown as MessageWithAuthor)
+      const msg = data as any
+      let replyTo = null
+      if (msg.reply_to_id) {
+        const { data: parent } = await supabase.from("messages").select(REPLY_SELECT).eq("id", msg.reply_to_id).single()
+        replyTo = parent ?? null
+      }
+      upsertMessage({ ...msg, reply_to: replyTo } as MessageWithAuthor)
     }
   }, [persistOutboxAttachments, setAndPersistOutbox, supabase, upsertMessage])
 
@@ -894,7 +901,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
 
     setAndPersistOutbox((current) => removeOutboxEntry(current, messageId))
     if (message) {
-      upsertMessage(message as unknown as MessageWithAuthor)
+      upsertMessage({ ...message, reply_to: replyTo ?? null } as unknown as MessageWithAuthor)
     }
 
     setReplyTo(null)

--- a/apps/web/hooks/use-realtime-messages.ts
+++ b/apps/web/hooks/use-realtime-messages.ts
@@ -26,13 +26,24 @@ export function useRealtimeMessages(
           filter: `channel_id=eq.${channelId}`,
         },
         async (payload) => {
-          // Fetch full message with relations
+          // Fetch full message with relations (reply_to hydrated separately to
+          // avoid depending on the self-referential FK being in PostgREST cache)
           const { data } = await supabase
             .from("messages")
-            .select(`*, author:users!messages_author_id_fkey(*), attachments(*), reactions(*), reply_to:messages!messages_reply_to_id_fkey(*, author:users!messages_author_id_fkey(*))`)
+            .select(`*, author:users!messages_author_id_fkey(*), attachments(*), reactions(*)`)
             .eq("id", payload.new.id)
             .single()
-          if (data) onInsert(data as unknown as MessageWithAuthor)
+          if (!data) return
+          let replyTo = null
+          if (data.reply_to_id) {
+            const { data: parent } = await supabase
+              .from("messages")
+              .select(`*, author:users!messages_author_id_fkey(*)`)
+              .eq("id", data.reply_to_id)
+              .single()
+            replyTo = parent ?? null
+          }
+          onInsert({ ...data, reply_to: replyTo } as unknown as MessageWithAuthor)
         }
       )
       .on(


### PR DESCRIPTION
PostgREST returns 400 for `reply_to:messages!messages_reply_to_id_fkey` because the self-referential FK is not in its schema cache.  Rather than relying on the FK being present, fetch reply-to messages in a separate query and stitch them in at the application level.

Changes:
- route.ts: add withReplyTo() helper; call it after every message fetch (GET list, GET around, POST idempotency hit, POST insert)
- page.tsx: inline reply-to hydration after the SSR initial load
- use-realtime-messages.ts: secondary fetch for parent message on INSERT
- chat-area.tsx: update MESSAGE_SELECT; hydrate reply_to after outbox replay inserts; use the in-memory replyTo state for direct sends

The migration added in the previous commit (00029) still stands as a long-term fix so the FK embed can be used again once applied.

https://claude.ai/code/session_01KX8sBDg7ehcjNqM66BrgSi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal message data loading architecture to optimize database query efficiency and data handling across chat messaging features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->