### PR TITLE
Introduce semantic theme tokens and migrate UI to CSS variables

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -81,19 +81,19 @@ export default function LoginPage() {
   const showFallbacks = !policy.enforce_passkey
 
   return (
-    <div className="rounded-lg p-8 shadow-2xl" style={{ background: "#313338" }}>
+    <div className="rounded-lg p-8 shadow-2xl" style={{ background: "var(--theme-bg-primary)" }}>
       <div className="text-center mb-8">
-        <div className="flex justify-center mb-4"><div className="w-12 h-12 rounded-full flex items-center justify-center" style={{ background: "#5865f2" }}><Zap className="w-7 h-7 text-white" /></div></div>
+        <div className="flex justify-center mb-4"><div className="w-12 h-12 rounded-full flex items-center justify-center" style={{ background: "var(--theme-accent)" }}><Zap className="w-7 h-7 text-white" /></div></div>
         <h1 className="text-2xl font-bold text-white">{isNewUser ? "Verify your email" : "Welcome back!"}</h1>
-        <p style={{ color: "#b5bac1" }} className="text-sm mt-1">{isNewUser ? "Check your inbox for a verification link, then log in below." : "We’re so excited to see you again!"}</p>
+        <p style={{ color: "var(--theme-text-secondary)" }} className="text-sm mt-1">{isNewUser ? "Check your inbox for a verification link, then log in below." : "We’re so excited to see you again!"}</p>
       </div>
 
-      <div className="rounded-md p-3 mb-4 text-sm" style={{ background: "#2b2d31", border: "1px solid #1e1f22", color: "#b5bac1" }}>
+      <div className="rounded-md p-3 mb-4 text-sm" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)", color: "var(--theme-text-secondary)" }}>
         <p className="font-medium text-white flex items-center gap-2 mb-1"><ShieldCheck className="w-4 h-4" />Passkey-first security</p>
         <p>Use your device passkey for phishing-resistant sign in. If your policy allows it, password and magic link remain available as backups.</p>
       </div>
 
-      <Button type="button" disabled={passkeyLoading} onClick={handlePasskeyLogin} className="w-full h-11 font-medium mb-4" style={{ background: "#3ba55c" }}>
+      <Button type="button" disabled={passkeyLoading} onClick={handlePasskeyLogin} className="w-full h-11 font-medium mb-4" style={{ background: "var(--theme-positive)" }}>
         {passkeyLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Continue with Passkey
       </Button>
 
@@ -101,27 +101,27 @@ export default function LoginPage() {
         <>
           <form onSubmit={handleLogin} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="email" className="text-xs font-semibold uppercase tracking-wider" style={{ color: "#b5bac1" }}>Email <span className="text-red-500">*</span></Label>
-              <Input id="email" type="email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} required className="h-10" style={{ background: "#1e1f22", borderColor: "#1e1f22", color: "#f2f3f5" }} />
+              <Label htmlFor="email" className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-secondary)" }}>Email <span className="text-red-500">*</span></Label>
+              <Input id="email" type="email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} required className="h-10" style={{ background: "var(--theme-bg-tertiary)", borderColor: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)" }} />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="password" className="text-xs font-semibold uppercase tracking-wider" style={{ color: "#b5bac1" }}>Password <span className="text-red-500">*</span></Label>
-              <Input id="password" type="password" value={form.password} onChange={(e) => setForm({ ...form, password: e.target.value })} required className="h-10" style={{ background: "#1e1f22", borderColor: "#1e1f22", color: "#f2f3f5" }} />
+              <Label htmlFor="password" className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-secondary)" }}>Password <span className="text-red-500">*</span></Label>
+              <Input id="password" type="password" value={form.password} onChange={(e) => setForm({ ...form, password: e.target.value })} required className="h-10" style={{ background: "var(--theme-bg-tertiary)", borderColor: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)" }} />
             </div>
-            <Button type="submit" disabled={loading} className="w-full h-11 font-medium" style={{ background: "#5865f2" }}>
+            <Button type="submit" disabled={loading} className="w-full h-11 font-medium" style={{ background: "var(--theme-accent)" }}>
               {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Log In with Password
             </Button>
           </form>
 
-          <Button type="button" variant="outline" disabled={magicLinkLoading} onClick={handleMagicLink} className="w-full h-10 mt-4" style={{ borderColor: "#4e5058", color: "#b5bac1", background: "transparent" }}>
+          <Button type="button" variant="outline" disabled={magicLinkLoading} onClick={handleMagicLink} className="w-full h-10 mt-4" style={{ borderColor: "var(--theme-text-faint)", color: "var(--theme-text-secondary)", background: "transparent" }}>
             {magicLinkLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Send Magic Link
           </Button>
         </>
       )}
 
-      {!showFallbacks && <p className="text-xs mt-3" style={{ color: "#f0b132" }}>Your account policy requires passkey login. Contact an owner/admin if you need recovery help.</p>}
+      {!showFallbacks && <p className="text-xs mt-3" style={{ color: "var(--theme-warning)" }}>Your account policy requires passkey login. Contact an owner/admin if you need recovery help.</p>}
 
-      <p className="text-center text-sm mt-6" style={{ color: "#b5bac1" }}>Need an account? <Link href="/register" className="hover:underline" style={{ color: "#00a8fc" }}>Register</Link></p>
+      <p className="text-center text-sm mt-6" style={{ color: "var(--theme-text-secondary)" }}>Need an account? <Link href="/register" className="hover:underline" style={{ color: "var(--theme-link)" }}>Register</Link></p>
     </div>
   )
 }

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -78,22 +78,22 @@ export default function RegisterPage() {
   }
 
   return (
-    <div className="rounded-lg p-8 shadow-2xl" style={{ background: '#313338' }}>
+    <div className="rounded-lg p-8 shadow-2xl" style={{ background: 'var(--theme-bg-primary)' }}>
       <div className="text-center mb-8">
         <div className="flex justify-center mb-4">
-          <div className="w-12 h-12 rounded-full flex items-center justify-center" style={{ background: '#5865f2' }}>
+          <div className="w-12 h-12 rounded-full flex items-center justify-center" style={{ background: 'var(--theme-accent)' }}>
             <Zap className="w-7 h-7 text-white" />
           </div>
         </div>
         <h1 className="text-2xl font-bold text-white">Create an account</h1>
-        <p style={{ color: '#b5bac1' }} className="text-sm mt-1">
+        <p style={{ color: 'var(--theme-text-secondary)' }} className="text-sm mt-1">
           Join Vortex — then add a passkey in Security settings for passkey-first login.
         </p>
       </div>
 
       <form onSubmit={handleRegister} className="space-y-4">
         <div className="space-y-2">
-          <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+          <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
             Email <span className="text-red-500">*</span>
           </Label>
           <Input
@@ -102,12 +102,12 @@ export default function RegisterPage() {
             onChange={(e) => setForm({ ...form, email: e.target.value })}
             required
             className="h-10"
-            style={{ background: '#1e1f22', borderColor: '#1e1f22', color: '#f2f3f5' }}
+            style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)' }}
           />
         </div>
 
         <div className="space-y-2">
-          <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+          <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
             Username <span className="text-red-500">*</span>
           </Label>
           <Input
@@ -117,12 +117,12 @@ export default function RegisterPage() {
             placeholder="cooluser123"
             required
             className="h-10"
-            style={{ background: '#1e1f22', borderColor: '#1e1f22', color: '#f2f3f5' }}
+            style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)' }}
           />
         </div>
 
         <div className="space-y-2">
-          <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+          <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
             Display Name
           </Label>
           <Input
@@ -131,12 +131,12 @@ export default function RegisterPage() {
             onChange={(e) => setForm({ ...form, displayName: e.target.value })}
             placeholder="How others see you"
             className="h-10"
-            style={{ background: '#1e1f22', borderColor: '#1e1f22', color: '#f2f3f5' }}
+            style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)' }}
           />
         </div>
 
         <div className="space-y-2">
-          <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+          <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
             Password <span className="text-red-500">*</span>
           </Label>
           <Input
@@ -145,12 +145,12 @@ export default function RegisterPage() {
             onChange={(e) => setForm({ ...form, password: e.target.value })}
             required
             className="h-10"
-            style={{ background: '#1e1f22', borderColor: '#1e1f22', color: '#f2f3f5' }}
+            style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)' }}
           />
         </div>
 
         <div className="space-y-2">
-          <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+          <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
             Confirm Password <span className="text-red-500">*</span>
           </Label>
           <Input
@@ -159,7 +159,7 @@ export default function RegisterPage() {
             onChange={(e) => setForm({ ...form, confirmPassword: e.target.value })}
             required
             className="h-10"
-            style={{ background: '#1e1f22', borderColor: '#1e1f22', color: '#f2f3f5' }}
+            style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)' }}
           />
         </div>
 
@@ -167,21 +167,21 @@ export default function RegisterPage() {
           type="submit"
           disabled={loading}
           className="w-full h-11 font-medium mt-2"
-          style={{ background: '#5865f2' }}
+          style={{ background: 'var(--theme-accent)' }}
         >
           {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           Continue
         </Button>
       </form>
 
-      <p className="text-center text-sm mt-6" style={{ color: '#b5bac1' }}>
+      <p className="text-center text-sm mt-6" style={{ color: 'var(--theme-text-secondary)' }}>
         Already have an account?{" "}
-        <Link href="/login" className="hover:underline" style={{ color: '#00a8fc' }}>
+        <Link href="/login" className="hover:underline" style={{ color: 'var(--theme-link)' }}>
           Log In
         </Link>
       </p>
 
-      <p className="text-center text-xs mt-4" style={{ color: '#4e5058' }}>
+      <p className="text-center text-xs mt-4" style={{ color: 'var(--theme-text-faint)' }}>
         By registering, you agree to Vortex&apos;s terms of service. Keep password/magic link recovery enabled until you add a backup passkey on another device.
       </p>
     </div>

--- a/apps/web/app/channels/[serverId]/loading.tsx
+++ b/apps/web/app/channels/[serverId]/loading.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 export default function ServerLoading() {
   return (
     <div className="flex flex-1 overflow-hidden">
-      <aside className="w-60 flex-shrink-0 border-r px-3 py-4" style={{ background: "#2b2d31", borderColor: "#1e1f22" }}>
+      <aside className="w-60 flex-shrink-0 border-r px-3 py-4" style={{ background: "var(--theme-bg-secondary)", borderColor: "var(--theme-bg-tertiary)" }}>
         <Skeleton className="mb-4 h-8 w-full" />
         <div className="space-y-2">
           {Array.from({ length: 12 }).map((_, index) => (
@@ -12,7 +12,7 @@ export default function ServerLoading() {
         </div>
       </aside>
 
-      <main className="flex-1 border-r px-4 py-4" style={{ background: "#313338", borderColor: "#1e1f22" }}>
+      <main className="flex-1 border-r px-4 py-4" style={{ background: "var(--theme-bg-primary)", borderColor: "var(--theme-bg-tertiary)" }}>
         <Skeleton className="mb-4 h-10 w-full" />
         <div className="space-y-4">
           {Array.from({ length: 10 }).map((_, index) => (
@@ -27,7 +27,7 @@ export default function ServerLoading() {
         </div>
       </main>
 
-      <aside className="w-60 flex-shrink-0 px-3 py-4" style={{ background: "#2b2d31" }}>
+      <aside className="w-60 flex-shrink-0 px-3 py-4" style={{ background: "var(--theme-bg-secondary)" }}>
         <Skeleton className="mb-3 h-3 w-20" />
         <div className="space-y-3">
           {Array.from({ length: 10 }).map((_, index) => (

--- a/apps/web/app/channels/[serverId]/page.tsx
+++ b/apps/web/app/channels/[serverId]/page.tsx
@@ -24,12 +24,12 @@ export default async function ServerHomePage({ params: paramsPromise }: Props) {
   }
 
   return (
-    <div className="flex-1 flex items-center justify-center" style={{ background: '#313338' }}>
+    <div className="flex-1 flex items-center justify-center" style={{ background: 'var(--theme-bg-primary)' }}>
       <div className="text-center">
         <h2 className="text-xl font-semibold text-white mb-2">
           No channels yet
         </h2>
-        <p style={{ color: '#b5bac1' }} className="text-sm">
+        <p style={{ color: 'var(--theme-text-secondary)' }} className="text-sm">
           Create a channel to get started
         </p>
       </div>

--- a/apps/web/app/channels/me/page.tsx
+++ b/apps/web/app/channels/me/page.tsx
@@ -2,15 +2,15 @@ import { MessageSquare } from "lucide-react"
 
 export default function DirectMessagesHome() {
   return (
-    <div className="flex-1 flex items-center justify-center" style={{ background: '#313338' }}>
+    <div className="flex-1 flex items-center justify-center" style={{ background: 'var(--theme-bg-primary)' }}>
       <div className="text-center">
         <div className="flex justify-center mb-4">
-          <MessageSquare className="w-16 h-16" style={{ color: '#4e5058' }} />
+          <MessageSquare className="w-16 h-16" style={{ color: 'var(--theme-text-faint)' }} />
         </div>
         <h2 className="text-xl font-semibold text-white mb-2">
           No DM selected
         </h2>
-        <p style={{ color: '#b5bac1' }} className="text-sm">
+        <p style={{ color: 'var(--theme-text-secondary)' }} className="text-sm">
           Select a friend to start a conversation
         </p>
       </div>

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -20,17 +20,17 @@ export default function Error({
     <div
       role="alert"
       className="flex flex-col items-center justify-center min-h-screen gap-4"
-      style={{ background: "#313338", color: "#f2f3f5" }}
+      style={{ background: "var(--theme-bg-primary)", color: "var(--theme-text-primary)" }}
     >
       <h2 className="text-xl font-bold">Something went wrong</h2>
-      <p className="text-sm" style={{ color: "#b5bac1" }}>
+      <p className="text-sm" style={{ color: "var(--theme-text-secondary)" }}>
         An unexpected error occurred. Please try again.
       </p>
       <button
         type="button"
         onClick={reset}
         className="px-4 py-2 rounded text-sm font-medium text-white transition-colors hover:opacity-90"
-        style={{ background: "#5865f2" }}
+        style={{ background: "var(--theme-accent)" }}
       >
         Try Again
       </button>

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -18,7 +18,7 @@ export default function GlobalError({
 
   return (
     <html lang="en">
-      <body style={{ margin: 0, background: "#313338", color: "#f2f3f5", fontFamily: "system-ui, sans-serif" }}>
+      <body style={{ margin: 0, background: "var(--theme-bg-primary)", color: "var(--theme-text-primary)", fontFamily: "system-ui, sans-serif" }}>
         <div
           role="alert"
           style={{
@@ -31,7 +31,7 @@ export default function GlobalError({
           }}
         >
           <h2 style={{ fontSize: "20px", fontWeight: "bold", margin: 0 }}>Something went wrong</h2>
-          <p style={{ fontSize: "14px", color: "#b5bac1", margin: 0 }}>
+          <p style={{ fontSize: "14px", color: "var(--theme-text-secondary)", margin: 0 }}>
             An unexpected error occurred. Please try again.
           </p>
           <button
@@ -43,7 +43,7 @@ export default function GlobalError({
               fontSize: "14px",
               fontWeight: 500,
               color: "white",
-              background: "#5865f2",
+              background: "var(--theme-accent)",
               border: "none",
               cursor: "pointer",
             }}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -32,6 +32,27 @@
     --motion-ease-emphasized: cubic-bezier(0.16, 1, 0.3, 1);
     --app-bg-primary: #313338;
     --app-bg-secondary: #2b2d31;
+    --app-bg-tertiary: #1e1f22;
+    --app-accent-color: #5865f2;
+    /* Global semantic tokens for full custom themes */
+    --theme-bg-primary: #313338;
+    --theme-bg-secondary: #2b2d31;
+    --theme-bg-tertiary: #1e1f22;
+    --theme-surface-elevated: #3f4147;
+    --theme-surface-input: #383a40;
+    --theme-text-primary: #f2f3f5;
+    --theme-text-normal: #dcddde;
+    --theme-text-secondary: #b5bac1;
+    --theme-text-muted: #949ba4;
+    --theme-text-faint: #4e5058;
+    --theme-text-bright: #dbdee1;
+    --theme-accent: #5865f2;
+    --theme-link: #00a8fc;
+    --theme-success: #23a55a;
+    --theme-positive: #3ba55c;
+    --theme-warning: #f0b132;
+    --theme-danger: #f23f43;
+    --theme-presence-offline: #80848e;
   }
 }
 
@@ -56,12 +77,12 @@
   }
 
   ::-webkit-scrollbar-thumb {
-    background: #1a1b1e;
+    background: var(--theme-bg-tertiary);
     border-radius: 4px;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background: #111214;
+    background: color-mix(in srgb, var(--theme-bg-tertiary) 80%, black);
   }
 }
 
@@ -281,6 +302,24 @@
   --app-bg-secondary: #2b2d31;
   --app-bg-tertiary: #1e1f22;
   --app-accent-color: #5865f2;
+  --theme-bg-primary: #313338;
+  --theme-bg-secondary: #2b2d31;
+  --theme-bg-tertiary: #1e1f22;
+  --theme-surface-elevated: #3f4147;
+  --theme-surface-input: #383a40;
+  --theme-text-primary: #f2f3f5;
+  --theme-text-normal: #dcddde;
+  --theme-text-secondary: #b5bac1;
+  --theme-text-muted: #949ba4;
+  --theme-text-faint: #4e5058;
+  --theme-text-bright: #dbdee1;
+  --theme-accent: #5865f2;
+  --theme-link: #00a8fc;
+  --theme-success: #23a55a;
+  --theme-positive: #3ba55c;
+  --theme-warning: #f0b132;
+  --theme-danger: #f23f43;
+  --theme-presence-offline: #80848e;
 }
 
 [data-theme-preset="midnight-neon"] {
@@ -312,6 +351,24 @@
   --app-bg-secondary: #151829;
   --app-bg-tertiary: #0f1120;
   --app-accent-color: #00e5ff;
+  --theme-bg-primary: #1b1f31;
+  --theme-bg-secondary: #151829;
+  --theme-bg-tertiary: #0f1120;
+  --theme-surface-elevated: #252a42;
+  --theme-surface-input: #2a2f48;
+  --theme-text-primary: #e6ecff;
+  --theme-text-normal: #d6defc;
+  --theme-text-secondary: #b6c0dd;
+  --theme-text-muted: #8f9bbf;
+  --theme-text-faint: #6b7392;
+  --theme-text-bright: #f4f7ff;
+  --theme-accent: #00e5ff;
+  --theme-link: #6fd8ff;
+  --theme-success: #3ddc97;
+  --theme-positive: #6ee7b7;
+  --theme-warning: #ffb84d;
+  --theme-danger: #ff5d73;
+  --theme-presence-offline: #6f7898;
 }
 
 [data-theme-preset="synthwave"] {
@@ -343,6 +400,24 @@
   --app-bg-secondary: #23193b;
   --app-bg-tertiary: #1a1030;
   --app-accent-color: #f92aad;
+  --theme-bg-primary: #2a1e46;
+  --theme-bg-secondary: #23193b;
+  --theme-bg-tertiary: #1a1030;
+  --theme-surface-elevated: #35255a;
+  --theme-surface-input: #3f2d67;
+  --theme-text-primary: #f5edff;
+  --theme-text-normal: #e9dcff;
+  --theme-text-secondary: #cab7e8;
+  --theme-text-muted: #a990d0;
+  --theme-text-faint: #7f6aa8;
+  --theme-text-bright: #fff7ff;
+  --theme-accent: #f92aad;
+  --theme-link: #50e5ff;
+  --theme-success: #5ae6a9;
+  --theme-positive: #65d17a;
+  --theme-warning: #ffc266;
+  --theme-danger: #ff5f8c;
+  --theme-presence-offline: #8674a8;
 }
 
 [data-theme-preset="carbon"] {
@@ -374,6 +449,24 @@
   --app-bg-secondary: #191b1e;
   --app-bg-tertiary: #141618;
   --app-accent-color: #3ba55c;
+  --theme-bg-primary: #1f2124;
+  --theme-bg-secondary: #191b1e;
+  --theme-bg-tertiary: #141618;
+  --theme-surface-elevated: #2a2d31;
+  --theme-surface-input: #30343a;
+  --theme-text-primary: #e7eaee;
+  --theme-text-normal: #d5d9df;
+  --theme-text-secondary: #b5bcc6;
+  --theme-text-muted: #98a0ab;
+  --theme-text-faint: #6b737f;
+  --theme-text-bright: #f5f7fa;
+  --theme-accent: #3ba55c;
+  --theme-link: #5db3ff;
+  --theme-success: #3ba55c;
+  --theme-positive: #64c184;
+  --theme-warning: #d19c4c;
+  --theme-danger: #d65257;
+  --theme-presence-offline: #7d858f;
 }
 
 /* Font scale */

--- a/apps/web/components/channels/announcement-channel.tsx
+++ b/apps/web/components/channels/announcement-channel.tsx
@@ -133,18 +133,18 @@ export function AnnouncementChannel({ channel, initialMessages, currentUserId, s
   }
 
   return (
-    <div className="flex flex-col flex-1 overflow-hidden" style={{ background: '#313338' }}>
+    <div className="flex flex-col flex-1 overflow-hidden" style={{ background: 'var(--theme-bg-primary)' }}>
       {/* Channel header */}
       <div
         className="flex items-center gap-2 px-4 py-3 border-b flex-shrink-0"
-        style={{ borderColor: '#1e1f22' }}
+        style={{ borderColor: 'var(--theme-bg-tertiary)' }}
       >
-        <Megaphone className="w-5 h-5 flex-shrink-0" style={{ color: '#f0b132' }} />
+        <Megaphone className="w-5 h-5 flex-shrink-0" style={{ color: 'var(--theme-warning)' }} />
         <span className="font-semibold text-white">{channel.name}</span>
         {channel.topic && (
           <>
-            <span style={{ color: '#4e5058' }}>|</span>
-            <span className="text-sm truncate" style={{ color: '#949ba4' }}>{channel.topic}</span>
+            <span style={{ color: 'var(--theme-text-faint)' }}>|</span>
+            <span className="text-sm truncate" style={{ color: 'var(--theme-text-muted)' }}>{channel.topic}</span>
           </>
         )}
         <div className="ml-auto flex items-center">
@@ -153,7 +153,7 @@ export function AnnouncementChannel({ channel, initialMessages, currentUserId, s
             className="p-1.5 rounded hover:bg-white/10 transition-colors"
             title={memberListOpen ? "Hide Member List" : "Show Member List"}
           >
-            <Users className="w-5 h-5" style={{ color: memberListOpen ? '#f2f3f5' : '#949ba4' }} />
+            <Users className="w-5 h-5" style={{ color: memberListOpen ? 'var(--theme-text-primary)' : 'var(--theme-text-muted)' }} />
           </button>
         </div>
       </div>
@@ -161,7 +161,7 @@ export function AnnouncementChannel({ channel, initialMessages, currentUserId, s
       {/* Announcement banner */}
       <div
         className="mx-4 mt-3 px-3 py-2 rounded text-sm flex items-center gap-2"
-        style={{ background: 'rgba(240,177,50,0.1)', border: '1px solid rgba(240,177,50,0.3)', color: '#f0b132' }}
+        style={{ background: 'rgba(240,177,50,0.1)', border: '1px solid rgba(240,177,50,0.3)', color: 'var(--theme-warning)' }}
       >
         <Megaphone className="w-4 h-4 flex-shrink-0" />
         <span>This is an Announcement channel. Members can follow it to receive updates in their own servers.</span>
@@ -175,10 +175,10 @@ export function AnnouncementChannel({ channel, initialMessages, currentUserId, s
               className="w-16 h-16 rounded-full flex items-center justify-center mb-4"
               style={{ background: 'rgba(240,177,50,0.2)' }}
             >
-              <Megaphone className="w-8 h-8" style={{ color: '#f0b132' }} />
+              <Megaphone className="w-8 h-8" style={{ color: 'var(--theme-warning)' }} />
             </div>
             <h2 className="text-2xl font-bold text-white mb-2">Welcome to #{channel.name}!</h2>
-            <p style={{ color: '#b5bac1' }}>
+            <p style={{ color: 'var(--theme-text-secondary)' }}>
               This is the beginning of the #{channel.name} announcement channel.
               {channel.topic && ` ${channel.topic}`}
             </p>

--- a/apps/web/components/channels/forum-channel.tsx
+++ b/apps/web/components/channels/forum-channel.tsx
@@ -188,11 +188,11 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
 
   if (view === "thread" && activeThread) {
     return (
-      <div className="flex flex-col flex-1 overflow-hidden" style={{ background: '#313338' }}>
+      <div className="flex flex-col flex-1 overflow-hidden" style={{ background: 'var(--theme-bg-primary)' }}>
         {/* Thread header */}
         <div
           className="flex items-center gap-2 px-4 py-3 border-b flex-shrink-0"
-          style={{ borderColor: '#1e1f22' }}
+          style={{ borderColor: 'var(--theme-bg-tertiary)' }}
         >
           <button
             onClick={() => { setView("list"); setActiveThread(null) }}
@@ -200,20 +200,20 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
           >
             <ArrowLeft className="w-4 h-4 text-white" />
           </button>
-          <MessageSquare className="w-5 h-5 flex-shrink-0" style={{ color: '#949ba4' }} />
+          <MessageSquare className="w-5 h-5 flex-shrink-0" style={{ color: 'var(--theme-text-muted)' }} />
           <span className="font-semibold text-white truncate">
             {activeThread.content?.split("\n")[0].replace(/\*\*/g, "") ?? "Thread"}
           </span>
           <div className="ml-auto flex items-center">
             <button onClick={toggleMemberList} className="p-1.5 rounded hover:bg-white/10 transition-colors">
-              <Users className="w-5 h-5" style={{ color: memberListOpen ? '#f2f3f5' : '#949ba4' }} />
+              <Users className="w-5 h-5" style={{ color: memberListOpen ? 'var(--theme-text-primary)' : 'var(--theme-text-muted)' }} />
             </button>
           </div>
         </div>
 
         {/* Original post */}
         <div className="overflow-y-auto flex-1">
-          <div className="border-b pb-2" style={{ borderColor: '#1e1f22' }}>
+          <div className="border-b pb-2" style={{ borderColor: 'var(--theme-bg-tertiary)' }}>
             <MessageItem
               message={activeThread}
               isGrouped={false}
@@ -259,7 +259,7 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
           {/* Thread replies */}
           <div className="pb-4">
             {threadReplies.length === 0 && (
-              <p className="px-4 py-4 text-sm" style={{ color: '#949ba4' }}>No replies yet. Be the first to reply!</p>
+              <p className="px-4 py-4 text-sm" style={{ color: 'var(--theme-text-muted)' }}>No replies yet. Be the first to reply!</p>
             )}
             {threadReplies.map((reply, i) => {
               const prev = threadReplies[i - 1]
@@ -327,31 +327,31 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
 
   // Forum post list view
   return (
-    <div className="flex flex-col flex-1 overflow-hidden" style={{ background: '#313338' }}>
+    <div className="flex flex-col flex-1 overflow-hidden" style={{ background: 'var(--theme-bg-primary)' }}>
       {/* Forum header */}
       <div
         className="flex items-center gap-2 px-4 py-3 border-b flex-shrink-0"
-        style={{ borderColor: '#1e1f22' }}
+        style={{ borderColor: 'var(--theme-bg-tertiary)' }}
       >
-        <MessageSquare className="w-5 h-5 flex-shrink-0" style={{ color: '#949ba4' }} />
+        <MessageSquare className="w-5 h-5 flex-shrink-0" style={{ color: 'var(--theme-text-muted)' }} />
         <span className="font-semibold text-white">{channel.name}</span>
         {channel.topic && (
           <>
-            <span style={{ color: '#4e5058' }}>|</span>
-            <span className="text-sm truncate" style={{ color: '#949ba4' }}>{channel.topic}</span>
+            <span style={{ color: 'var(--theme-text-faint)' }}>|</span>
+            <span className="text-sm truncate" style={{ color: 'var(--theme-text-muted)' }}>{channel.topic}</span>
           </>
         )}
         <div className="ml-auto flex items-center gap-2">
           <button
             onClick={() => setShowNewPost(true)}
             className="flex items-center gap-1.5 px-3 py-1.5 rounded text-sm font-medium transition-colors"
-            style={{ background: '#5865f2', color: 'white' }}
+            style={{ background: 'var(--theme-accent)', color: 'white' }}
           >
             <Plus className="w-4 h-4" />
             New Post
           </button>
           <button onClick={toggleMemberList} className="p-1.5 rounded hover:bg-white/10 transition-colors">
-            <Users className="w-5 h-5" style={{ color: memberListOpen ? '#f2f3f5' : '#949ba4' }} />
+            <Users className="w-5 h-5" style={{ color: memberListOpen ? 'var(--theme-text-primary)' : 'var(--theme-text-muted)' }} />
           </button>
         </div>
       </div>
@@ -360,7 +360,7 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
       {channel.forum_guidelines && (
         <div
           className="mx-4 mt-3 px-3 py-2 rounded text-sm"
-          style={{ background: 'rgba(88,101,242,0.1)', border: '1px solid rgba(88,101,242,0.3)', color: '#b5bac1' }}
+          style={{ background: 'rgba(88,101,242,0.1)', border: '1px solid rgba(88,101,242,0.3)', color: 'var(--theme-text-secondary)' }}
         >
           <strong className="text-white">Guidelines: </strong>{channel.forum_guidelines}
         </div>
@@ -370,14 +370,14 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
       {showNewPost && (
         <div
           className="mx-4 mt-3 p-3 rounded border"
-          style={{ background: '#2b2d31', borderColor: '#1e1f22' }}
+          style={{ background: 'var(--theme-bg-secondary)', borderColor: 'var(--theme-bg-tertiary)' }}
         >
           <input
             value={newPostTitle}
             onChange={(e) => setNewPostTitle(e.target.value)}
             placeholder="Post title (optional)"
             className="w-full px-3 py-2 mb-2 rounded text-sm text-white focus:outline-none"
-            style={{ background: '#1e1f22' }}
+            style={{ background: 'var(--theme-bg-tertiary)' }}
           />
           <MessageInput
             channelName="new post content"
@@ -392,7 +392,7 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
           <button
             onClick={() => { setShowNewPost(false); setNewPostTitle(""); setNewPostDraft("") }}
             className="mt-1 text-xs"
-            style={{ color: '#949ba4' }}
+            style={{ color: 'var(--theme-text-muted)' }}
           >
             Cancel
           </button>
@@ -405,18 +405,18 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
           <div className="text-center py-12">
             <div
               className="w-16 h-16 rounded-full flex items-center justify-center mb-4 mx-auto"
-              style={{ background: '#4e5058' }}
+              style={{ background: 'var(--theme-text-faint)' }}
             >
               <MessageSquare className="w-8 h-8 text-white" />
             </div>
             <h2 className="text-xl font-bold text-white mb-2">No posts yet</h2>
-            <p className="mb-4" style={{ color: '#b5bac1' }}>
+            <p className="mb-4" style={{ color: 'var(--theme-text-secondary)' }}>
               {channel.forum_guidelines || "Be the first to start a discussion!"}
             </p>
             <button
               onClick={() => setShowNewPost(true)}
               className="px-4 py-2 rounded font-medium transition-colors"
-              style={{ background: '#5865f2', color: 'white' }}
+              style={{ background: 'var(--theme-accent)', color: 'white' }}
             >
               <Plus className="w-4 h-4 inline mr-1" />
               Create First Post
@@ -436,10 +436,10 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
               key={post.id}
               onClick={() => { setActiveThread(post); setView("thread") }}
               className="w-full text-left p-3 rounded border transition-colors hover:bg-white/5"
-              style={{ background: '#2b2d31', borderColor: '#1e1f22' }}
+              style={{ background: 'var(--theme-bg-secondary)', borderColor: 'var(--theme-bg-tertiary)' }}
             >
               <div className="flex items-start gap-3">
-                <MessageSquare className="w-4 h-4 flex-shrink-0 mt-0.5" style={{ color: '#949ba4' }} />
+                <MessageSquare className="w-4 h-4 flex-shrink-0 mt-0.5" style={{ color: 'var(--theme-text-muted)' }} />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
                     <span className="font-medium text-white text-sm truncate">
@@ -448,7 +448,7 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
                     </span>
                   </div>
                   {title && body && (
-                    <p className="text-xs truncate" style={{ color: '#949ba4' }}>
+                    <p className="text-xs truncate" style={{ color: 'var(--theme-text-muted)' }}>
                       {body.slice(0, 120)}{body.length > 120 ? "…" : ""}
                     </p>
                   )}

--- a/apps/web/components/channels/media-channel.tsx
+++ b/apps/web/components/channels/media-channel.tsx
@@ -130,18 +130,18 @@ export function MediaChannel({ channel, initialMessages, currentUserId, serverId
   const mediaMessages = messages.filter((m) => m.attachments.length > 0)
 
   return (
-    <div className="flex flex-col flex-1 overflow-hidden" style={{ background: '#313338' }}>
+    <div className="flex flex-col flex-1 overflow-hidden" style={{ background: 'var(--theme-bg-primary)' }}>
       {/* Channel header */}
       <div
         className="flex items-center gap-2 px-4 py-3 border-b flex-shrink-0"
-        style={{ borderColor: '#1e1f22' }}
+        style={{ borderColor: 'var(--theme-bg-tertiary)' }}
       >
-        <ImageIcon className="w-5 h-5 flex-shrink-0" style={{ color: '#949ba4' }} />
+        <ImageIcon className="w-5 h-5 flex-shrink-0" style={{ color: 'var(--theme-text-muted)' }} />
         <span className="font-semibold text-white">{channel.name}</span>
         {channel.topic && (
           <>
-            <span style={{ color: '#4e5058' }}>|</span>
-            <span className="text-sm truncate" style={{ color: '#949ba4' }}>{channel.topic}</span>
+            <span style={{ color: 'var(--theme-text-faint)' }}>|</span>
+            <span className="text-sm truncate" style={{ color: 'var(--theme-text-muted)' }}>{channel.topic}</span>
           </>
         )}
         <div className="ml-auto flex items-center">
@@ -150,7 +150,7 @@ export function MediaChannel({ channel, initialMessages, currentUserId, serverId
             className="p-1.5 rounded hover:bg-white/10 transition-colors"
             title={memberListOpen ? "Hide Member List" : "Show Member List"}
           >
-            <Users className="w-5 h-5" style={{ color: memberListOpen ? '#f2f3f5' : '#949ba4' }} />
+            <Users className="w-5 h-5" style={{ color: memberListOpen ? 'var(--theme-text-primary)' : 'var(--theme-text-muted)' }} />
           </button>
         </div>
       </div>
@@ -161,12 +161,12 @@ export function MediaChannel({ channel, initialMessages, currentUserId, serverId
           <div className="px-4 py-8">
             <div
               className="w-16 h-16 rounded-full flex items-center justify-center mb-4"
-              style={{ background: '#4e5058' }}
+              style={{ background: 'var(--theme-text-faint)' }}
             >
               <ImageIcon className="w-8 h-8 text-white" />
             </div>
             <h2 className="text-2xl font-bold text-white mb-2">Welcome to #{channel.name}!</h2>
-            <p style={{ color: '#b5bac1' }}>
+            <p style={{ color: 'var(--theme-text-secondary)' }}>
               Share images, videos, and files in this media channel.
               {channel.topic && ` ${channel.topic}`}
             </p>

--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -938,22 +938,22 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
 
   return (
     <div className="flex flex-1 overflow-hidden">
-      <div className="flex flex-col flex-1 overflow-hidden" style={{ background: '#313338' }}>
+      <div className="flex flex-col flex-1 overflow-hidden" style={{ background: 'var(--theme-bg-primary)' }}>
         <div
           className="flex items-center gap-2 px-4 py-2 border-b flex-shrink-0"
-          style={{ borderColor: '#1e1f22' }}
+          style={{ borderColor: 'var(--theme-bg-tertiary)' }}
         >
-          <Hash className="w-5 h-5 flex-shrink-0" style={{ color: '#949ba4' }} />
+          <Hash className="w-5 h-5 flex-shrink-0" style={{ color: 'var(--theme-text-muted)' }} />
           <span className="font-semibold text-white">{channel.name}</span>
           {!isOnline && (
-            <span className="text-xs px-2 py-0.5 rounded" style={{ background: "#f0b23222", color: "#f0b232" }}>
+            <span className="text-xs px-2 py-0.5 rounded" style={{ background: "color-mix(in srgb, var(--theme-warning) 13%, transparent)", color: "var(--theme-warning)" }}>
               Offline
             </span>
           )}
           {channel.topic && (
             <>
-              <span style={{ color: '#4e5058' }}>|</span>
-              <span className="text-sm truncate" style={{ color: '#949ba4' }}>
+              <span style={{ color: 'var(--theme-text-faint)' }}>|</span>
+              <span className="text-sm truncate" style={{ color: 'var(--theme-text-muted)' }}>
                 {channel.topic}
               </span>
             </>
@@ -968,7 +968,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
               title="Workspace"
               aria-label="Workspace"
             >
-              <Briefcase className="w-4 h-4" style={{ color: workspaceOpen ? "#5865f2" : "#b5bac1" }} />
+              <Briefcase className="w-4 h-4" style={{ color: workspaceOpen ? "var(--theme-accent)" : "var(--theme-text-secondary)" }} />
             </button>
 
             <button
@@ -977,7 +977,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
               title="Search messages"
               aria-label="Search messages"
             >
-              <Search className="w-4 h-4" style={{ color: "#b5bac1" }} />
+              <Search className="w-4 h-4" style={{ color: "var(--theme-text-secondary)" }} />
             </button>
 
             <button
@@ -986,7 +986,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
               title="Pinned messages"
               aria-label="Pinned messages"
             >
-              <Pin className="w-4 h-4" style={{ color: "#b5bac1" }} />
+              <Pin className="w-4 h-4" style={{ color: "var(--theme-text-secondary)" }} />
             </button>
 
             <button
@@ -995,7 +995,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
               title="Help"
               aria-label="Help"
             >
-              <CircleHelp className="w-4 h-4" style={{ color: "#b5bac1" }} />
+              <CircleHelp className="w-4 h-4" style={{ color: "var(--theme-text-secondary)" }} />
             </button>
 
             <button
@@ -1003,7 +1003,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
               className="motion-interactive motion-press p-1.5 rounded hover:bg-white/10"
               title={memberListOpen ? "Hide Member List" : "Show Member List"}
             >
-              <Users className="w-4 h-4" style={{ color: memberListOpen ? '#f2f3f5' : '#949ba4' }} />
+              <Users className="w-4 h-4" style={{ color: memberListOpen ? 'var(--theme-text-primary)' : 'var(--theme-text-muted)' }} />
             </button>
 
             <button
@@ -1011,7 +1011,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
               className="motion-interactive motion-press p-1.5 rounded hover:bg-white/10"
               title={threadPanelOpen ? "Hide Thread Panel" : "Show Thread Panel"}
             >
-              <MessageSquareText className="w-4 h-4" style={{ color: threadPanelOpen ? '#f2f3f5' : '#949ba4' }} />
+              <MessageSquareText className="w-4 h-4" style={{ color: threadPanelOpen ? 'var(--theme-text-primary)' : 'var(--theme-text-muted)' }} />
             </button>
           </div>
         </div>
@@ -1029,14 +1029,14 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
             <div className="px-4 py-8">
               <div
                 className="w-16 h-16 rounded-full flex items-center justify-center mb-4"
-                style={{ background: '#4e5058' }}
+                style={{ background: 'var(--theme-text-faint)' }}
               >
                 <Hash className="w-8 h-8 text-white" />
               </div>
               <h2 className="text-2xl font-bold text-white mb-2">
                 Welcome to #{channel.name}!
               </h2>
-              <p style={{ color: '#b5bac1' }}>
+              <p style={{ color: 'var(--theme-text-secondary)' }}>
                 This is the start of the #{channel.name} channel.
                 {channel.topic && ` ${channel.topic}`}
               </p>
@@ -1045,7 +1045,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
 
           <div className="pb-4">
             {isPaginating && (
-              <div className="px-4 py-2 text-[11px]" style={{ color: "#949ba4" }}>
+              <div className="px-4 py-2 text-[11px]" style={{ color: "var(--theme-text-muted)" }}>
                 Loading earlier messages…
               </div>
             )}
@@ -1061,14 +1061,14 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
                 <div key={message.id}>
                 {unreadDividerMessageId === message.id && (
                   <div className="px-4 py-2.5 flex items-center gap-2" role="separator" aria-label="New since last read">
-                    <div className="h-0.5 flex-1 rounded-full" style={{ background: "linear-gradient(90deg, #f23f43 0%, #f87171 100%)" }} />
+                    <div className="h-0.5 flex-1 rounded-full" style={{ background: "linear-gradient(90deg, var(--theme-danger) 0%, #f87171 100%)" }} />
                     <span
                       className="text-[11px] font-bold uppercase tracking-[0.08em] px-2 py-1 rounded-full"
-                      style={{ color: "#ffe3e3", background: "#f23f4333", border: "1px solid #f23f4399" }}
+                      style={{ color: "#ffe3e3", background: "color-mix(in srgb, var(--theme-danger) 20%, transparent)", border: "1px solid color-mix(in srgb, var(--theme-danger) 60%, transparent)" }}
                     >
                       New since last read
                     </span>
-                    <div className="h-0.5 flex-1 rounded-full" style={{ background: "linear-gradient(90deg, #f87171 0%, #f23f43 100%)" }} />
+                    <div className="h-0.5 flex-1 rounded-full" style={{ background: "linear-gradient(90deg, #f87171 0%, var(--theme-danger) 100%)" }} />
                   </div>
                 )}
                 <MessageItem
@@ -1148,7 +1148,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
               <button
                 onClick={jumpToLatest}
                 className="motion-interactive motion-press px-3 py-1.5 rounded-full text-xs font-semibold shadow-lg"
-                style={{ background: "#5865f2", color: "white" }}
+                style={{ background: "var(--theme-accent)", color: "white" }}
               >
                 Jump to present {pendingNewMessageCount > 0 ? `(${pendingNewMessageCount})` : ""}
               </button>
@@ -1160,7 +1160,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
               <button
                 onClick={returnToContext}
                 className="motion-interactive motion-press px-3 py-1.5 rounded-full text-xs font-semibold"
-                style={{ background: "#2b2d31", color: "#f2f3f5", border: "1px solid #1e1f22" }}
+                style={{ background: "var(--theme-bg-secondary)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-bg-tertiary)" }}
               >
                 Back to where you were
               </button>

--- a/apps/web/components/chat/link-embed.tsx
+++ b/apps/web/components/chat/link-embed.tsx
@@ -103,28 +103,28 @@ export function LinkEmbed({ url }: Props) {
       target="_blank"
       rel="noopener noreferrer"
       className="block mt-2 rounded overflow-hidden max-w-lg hover:brightness-110 transition-all"
-      style={{ background: "#2b2d31", border: "1px solid #1e1f22", borderLeft: "4px solid #5865f2", textDecoration: "none" }}
+      style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)", borderLeft: "4px solid var(--theme-accent)", textDecoration: "none" }}
     >
       <div className="p-3 flex gap-3">
         {/* Text side */}
         <div className="flex-1 min-w-0">
           {data.siteName && (
-            <div className="text-xs mb-0.5" style={{ color: "#949ba4" }}>{data.siteName}</div>
+            <div className="text-xs mb-0.5" style={{ color: "var(--theme-text-muted)" }}>{data.siteName}</div>
           )}
           {data.title && (
-            <div className="text-sm font-semibold truncate" style={{ color: "#00a8fc" }}>{data.title}</div>
+            <div className="text-sm font-semibold truncate" style={{ color: "var(--theme-link)" }}>{data.title}</div>
           )}
           {data.description && (
-            <div className="text-xs mt-1 line-clamp-2" style={{ color: "#b5bac1" }}>{data.description}</div>
+            <div className="text-xs mt-1 line-clamp-2" style={{ color: "var(--theme-text-secondary)" }}>{data.description}</div>
           )}
-          <div className="flex items-center gap-1 mt-1 text-xs" style={{ color: "#4e5058" }}>
+          <div className="flex items-center gap-1 mt-1 text-xs" style={{ color: "var(--theme-text-faint)" }}>
             <ExternalLink className="w-3 h-3" />
             {displayUrl}
           </div>
         </div>
         {/* Thumbnail */}
         {data.image && (
-          <div className="flex-shrink-0 w-20 h-16 rounded overflow-hidden" style={{ background: "#1e1f22" }}>
+          <div className="flex-shrink-0 w-20 h-16 rounded overflow-hidden" style={{ background: "var(--theme-bg-tertiary)" }}>
             <img
               src={data.image}
               alt=""

--- a/apps/web/components/chat/mention-suggestions.tsx
+++ b/apps/web/components/chat/mention-suggestions.tsx
@@ -42,8 +42,8 @@ export function MentionSuggestions({ members, selectedIndex, query, onSelect }: 
       aria-label="Mention suggestions"
       className="rounded-lg shadow-xl overflow-y-auto max-h-52 py-1"
       style={{
-        background: "#2b2d31",
-        border: "1px solid #1e1f22",
+        background: "var(--theme-bg-secondary)",
+        border: "1px solid var(--theme-bg-tertiary)",
       }}
     >
       {members.map((member, i) => {
@@ -52,7 +52,7 @@ export function MentionSuggestions({ members, selectedIndex, query, onSelect }: 
         const isSelected = i === selectedIndex
         const confidence = getMatchConfidence(member, query)
         const confidenceTone =
-          confidence === "Exact" ? "#3ba55d" : confidence === "Strong" ? "#5865f2" : "#faa81a"
+          confidence === "Exact" ? "#3ba55d" : confidence === "Strong" ? "var(--theme-accent)" : "#faa81a"
 
         return (
           <button
@@ -62,7 +62,7 @@ export function MentionSuggestions({ members, selectedIndex, query, onSelect }: 
             className="flex items-center gap-2 w-full px-3 py-1.5 text-left transition-colors"
             style={{
               background: isSelected ? "rgba(88,101,242,0.2)" : "transparent",
-              color: "#dcddde",
+              color: "var(--theme-text-normal)",
             }}
             onMouseDown={(e) => {
               e.preventDefault()
@@ -72,14 +72,14 @@ export function MentionSuggestions({ members, selectedIndex, query, onSelect }: 
             <Avatar className="w-6 h-6">
               {member.avatar_url && <AvatarImage src={member.avatar_url} />}
               <AvatarFallback
-                style={{ background: "#5865f2", color: "white", fontSize: "10px" }}
+                style={{ background: "var(--theme-accent)", color: "white", fontSize: "10px" }}
               >
                 {initials}
               </AvatarFallback>
             </Avatar>
             <span className="text-sm font-medium truncate">{displayName}</span>
             {displayName !== member.username && (
-              <span className="text-xs truncate" style={{ color: "#949ba4" }}>
+              <span className="text-xs truncate" style={{ color: "var(--theme-text-muted)" }}>
                 {member.username}
               </span>
             )}

--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -251,17 +251,17 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
       {replyTo && (
         <div
           className="flex items-center gap-2 px-3 py-2 rounded-t text-xs"
-          style={{ background: "#2b2d31", borderBottom: "1px solid #1e1f22" }}
+          style={{ background: "var(--theme-bg-secondary)", borderBottom: "1px solid var(--theme-bg-tertiary)" }}
         >
-          <Reply className="w-3 h-3 -scale-x-100" style={{ color: "#949ba4" }} />
-          <span style={{ color: "#949ba4" }}>Replying to</span>
+          <Reply className="w-3 h-3 -scale-x-100" style={{ color: "var(--theme-text-muted)" }} />
+          <span style={{ color: "var(--theme-text-muted)" }}>Replying to</span>
           <span className="font-semibold text-white">
             {replyTo.author?.display_name || replyTo.author?.username}
           </span>
-          <span className="truncate flex-1" style={{ color: "#949ba4" }}>
+          <span className="truncate flex-1" style={{ color: "var(--theme-text-muted)" }}>
             {replyTo.content}
           </span>
-          <button onClick={onCancelReply} style={{ color: "#949ba4" }}>
+          <button onClick={onCancelReply} style={{ color: "var(--theme-text-muted)" }}>
             <X className="w-3 h-3 hover:text-white" />
           </button>
         </div>
@@ -271,7 +271,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
       {files.length > 0 && (
         <div
           className="flex gap-2 p-2 flex-wrap rounded-t"
-          style={{ background: "#2b2d31", borderBottom: "1px solid #1e1f22" }}
+          style={{ background: "var(--theme-bg-secondary)", borderBottom: "1px solid var(--theme-bg-tertiary)" }}
         >
           {files.map((file, i) => (
             <div key={i} className="relative group w-24">
@@ -280,17 +280,17 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
                   src={getPreviewUrl(file)}
                   alt={file.name}
                   className="w-24 h-24 object-cover rounded-md border"
-                  style={{ borderColor: "#1e1f22" }}
+                  style={{ borderColor: "var(--theme-bg-tertiary)" }}
                 />
               ) : (
                 <div
                   className="w-24 h-24 rounded-md border flex items-center justify-center text-xs text-center p-2"
-                  style={{ background: "#1e1f22", color: "#b5bac1", borderColor: "#111214" }}
+                  style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-secondary)", borderColor: "#111214" }}
                 >
                   {file.name}
                 </div>
               )}
-              <div className="mt-1 text-[10px] truncate" style={{ color: "#949ba4" }} title={file.name}>
+              <div className="mt-1 text-[10px] truncate" style={{ color: "var(--theme-text-muted)" }} title={file.name}>
                 {file.name}
               </div>
               <button
@@ -301,7 +301,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
                   setFiles((prev) => prev.filter((_, j) => j !== i))
                 }}
                 className="motion-interactive absolute -top-1 -right-1 w-5 h-5 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100"
-                style={{ background: "#f23f43" }}
+                style={{ background: "var(--theme-danger)" }}
                 aria-label={`Remove ${file.name}`}
               >
                 <X className="w-3 h-3 text-white" />
@@ -317,13 +317,13 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
           "flex items-end gap-2 rounded-lg px-3 py-2",
           replyTo || files.length > 0 ? "rounded-t-none" : ""
         )}
-        style={{ background: "#383a40" }}
+        style={{ background: "var(--theme-surface-input)" }}
       >
         {/* Attach file */}
         <button
           onClick={() => fileRef.current?.click()}
           className="motion-interactive motion-press flex-shrink-0 mb-1 hover:text-white"
-          style={{ color: "#b5bac1" }}
+          style={{ color: "var(--theme-text-secondary)" }}
           title="Attach File"
         >
           <Plus className="w-5 h-5" />
@@ -366,7 +366,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
             }
             rows={1}
             className="w-full resize-none bg-transparent text-sm focus:outline-none py-1"
-            style={{ color: "#dcddde", maxHeight: "200px", lineHeight: "1.5" }}
+            style={{ color: "var(--theme-text-normal)", maxHeight: "200px", lineHeight: "1.5" }}
           />
         </div>
 
@@ -376,7 +376,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
             ref={emojiButtonRef}
             onClick={() => setShowEmojiPicker(!showEmojiPicker)}
             className="motion-interactive motion-press hover:text-white"
-            style={{ color: "#b5bac1" }}
+            style={{ color: "var(--theme-text-secondary)" }}
             title="Emoji"
           >
             <Smile className="w-5 h-5" />
@@ -387,20 +387,20 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
               ref={emojiPickerRef}
               data-state="open"
               className="panel-surface-motion absolute bottom-8 right-0 p-2 rounded-lg shadow-xl z-50"
-              style={{ background: "#2b2d31", border: "1px solid #1e1f22", width: "320px" }}
+              style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)", width: "320px" }}
             >
               <div className="mb-2 flex items-center gap-2">
                 <button
                   onClick={() => setPickerTab("emoji")}
                   className="px-2 py-1 rounded text-xs font-medium"
-                  style={{ background: pickerTab === "emoji" ? "#5865f2" : "transparent", color: "#f2f3f5" }}
+                  style={{ background: pickerTab === "emoji" ? "var(--theme-accent)" : "transparent", color: "var(--theme-text-primary)" }}
                 >
                   Emoji
                 </button>
                 <button
                   onClick={() => setPickerTab("gif")}
                   className="px-2 py-1 rounded text-xs font-medium"
-                  style={{ background: pickerTab === "gif" ? "#5865f2" : "transparent", color: "#f2f3f5" }}
+                  style={{ background: pickerTab === "gif" ? "var(--theme-accent)" : "transparent", color: "var(--theme-text-primary)" }}
                 >
                   GIFs
                 </button>
@@ -410,7 +410,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
                 <div className="max-h-72 overflow-y-auto pr-1 space-y-2">
                   {Object.entries(EMOJI_CATEGORIES).map(([category, emojis]) => (
                     <div key={category}>
-                      <p className="text-[10px] font-semibold uppercase mb-1" style={{ color: "#949ba4" }}>{category}</p>
+                      <p className="text-[10px] font-semibold uppercase mb-1" style={{ color: "var(--theme-text-muted)" }}>{category}</p>
                       <div className="grid grid-cols-8 gap-1">
                         {emojis.map((emoji) => (
                           <button
@@ -439,14 +439,14 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
                     onChange={(e) => setGifQuery(e.target.value)}
                     placeholder="Search GIFs"
                     className="w-full px-2 py-1.5 rounded text-xs focus:outline-none"
-                    style={{ background: "#1e1f22", color: "#dcddde" }}
+                    style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-normal)" }}
                   />
                   {!process.env.NEXT_PUBLIC_GIPHY_API_KEY ? (
-                    <p className="text-xs" style={{ color: "#949ba4" }}>
+                    <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>
                       Add NEXT_PUBLIC_GIPHY_API_KEY to enable GIF search.
                     </p>
                   ) : gifLoading ? (
-                    <p className="text-xs" style={{ color: "#949ba4" }}>Loading GIFs…</p>
+                    <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>Loading GIFs…</p>
                   ) : (
                     <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
                       {gifResults.map((gif) => (
@@ -465,7 +465,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
                           title={gif.title}
                         >
                           <img src={gif.previewUrl} alt={gif.title} className="w-full h-16 object-cover" />
-                          <span className="block px-1 py-0.5 text-[10px] truncate text-left" style={{ color: "#b5bac1", background: "#1e1f22" }}>{gif.title || "GIF"}</span>
+                          <span className="block px-1 py-0.5 text-[10px] truncate text-left" style={{ color: "var(--theme-text-secondary)", background: "var(--theme-bg-tertiary)" }}>{gif.title || "GIF"}</span>
                         </button>
                       ))}
                     </div>
@@ -482,7 +482,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
             onClick={handleSend}
             disabled={sending}
             className="motion-interactive motion-press flex-shrink-0 mb-1 hover:text-white"
-            style={{ color: "#5865f2" }}
+            style={{ color: "var(--theme-accent)" }}
             title="Send Message"
           >
             <Send className="w-5 h-5" />
@@ -491,7 +491,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
       </div>
       <div
         className="mt-1 px-1 flex items-center justify-between text-[11px]"
-        style={{ color: "#949ba4" }}
+        style={{ color: "var(--theme-text-muted)" }}
       >
         <div className="flex items-center gap-1.5">
           <Keyboard className="w-3 h-3" />

--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -115,7 +115,7 @@ export const MessageItem = memo(function MessageItem({
       if (match.index > lastIndex) parts.push(text.slice(lastIndex, match.index))
       const full = match[0]
       if (/^https?:\/\//.test(full)) {
-        parts.push(<a key={key++} href={full} target="_blank" rel="noopener noreferrer" className="hover:underline" style={{ color: "#00a8fc" }}>{full}</a>)
+        parts.push(<a key={key++} href={full} target="_blank" rel="noopener noreferrer" className="hover:underline" style={{ color: "var(--theme-link)" }}>{full}</a>)
       } else if (match[2] !== undefined) {
         parts.push(<strong key={key++}>{match[2]}</strong>)
       } else if (match[3] !== undefined) {
@@ -127,7 +127,7 @@ export const MessageItem = memo(function MessageItem({
       } else if (match[6] !== undefined) {
         parts.push(<code key={key++} className="px-1 py-0.5 rounded text-sm" style={{ background: "rgba(0,0,0,0.3)", fontFamily: "monospace" }}>{match[6]}</code>)
       } else if (match[7] !== undefined) {
-        parts.push(<span key={key++} className="px-0.5 rounded" style={{ color: "#5865f2", background: "rgba(88,101,242,0.1)" }}>@{match[7]}</span>)
+        parts.push(<span key={key++} className="px-0.5 rounded" style={{ color: "var(--theme-accent)", background: "rgba(88,101,242,0.1)" }}>@{match[7]}</span>)
       } else if (match[8] !== undefined) {
         parts.push(<SpoilerSpan key={key++}>{match[8]}</SpoilerSpan>)
       } else if (match[9] !== undefined) {
@@ -153,7 +153,7 @@ export const MessageItem = memo(function MessageItem({
           i++
         }
         result.push(
-          <blockquote key={`bq-${key++}`} className="pl-3 my-1" style={{ borderLeft: "4px solid #4e5058", color: "#b5bac1" }}>
+          <blockquote key={`bq-${key++}`} className="pl-3 my-1" style={{ borderLeft: "4px solid var(--theme-text-faint)", color: "var(--theme-text-secondary)" }}>
             {quoteLines.map((ql, qi) => <div key={qi}>{renderInline(ql, key + qi * 100)}</div>)}
           </blockquote>
         )
@@ -186,8 +186,8 @@ export const MessageItem = memo(function MessageItem({
       const lang = cbMatch[1] || ""
       const code = cbMatch[2]
       segments.push(
-        <pre key={`cb-${keyCounter++}`} className="my-1 p-3 rounded overflow-x-auto text-sm" style={{ background: "#1e1f22", fontFamily: "monospace", color: "#dcddde", border: "1px solid #232428" }}>
-          {lang && <div className="text-xs mb-1" style={{ color: "#5865f2", fontFamily: "sans-serif" }}>{lang}</div>}
+        <pre key={`cb-${keyCounter++}`} className="my-1 p-3 rounded overflow-x-auto text-sm" style={{ background: "var(--theme-bg-tertiary)", fontFamily: "monospace", color: "var(--theme-text-normal)", border: "1px solid #232428" }}>
+          {lang && <div className="text-xs mb-1" style={{ color: "var(--theme-accent)", fontFamily: "sans-serif" }}>{lang}</div>}
           <code>{code}</code>
         </pre>
       )
@@ -208,7 +208,7 @@ export const MessageItem = memo(function MessageItem({
           id={containerId}
           className={cn(
             "relative group px-4 message-hover motion-interactive",
-            highlighted && "bg-[#5865f233]",
+            highlighted && "mention-highlight",
             isGrouped ? "py-0.5" : "pt-4 pb-0.5"
           )}
           onMouseEnter={() => setShowActions(true)}
@@ -225,7 +225,7 @@ export const MessageItem = memo(function MessageItem({
           {message.reply_to_id && message.reply_to && (
             <div className="flex items-center gap-2 mb-1 ml-10 text-xs tertiary-metadata">
               <Reply className="w-3 h-3 -scale-x-100" />
-              <span className="font-medium" style={{ color: '#b5bac1' }}>
+              <span className="font-medium" style={{ color: 'var(--theme-text-secondary)' }}>
                 {message.reply_to.author?.display_name || message.reply_to.author?.username}
               </span>
               <span className="truncate">{message.reply_to.content}</span>
@@ -251,7 +251,7 @@ export const MessageItem = memo(function MessageItem({
                         <AvatarImage src={message.author.avatar_url} />
                       )}
                       <AvatarFallback
-                        style={{ background: "#5865f2", color: "white", fontSize: "14px" }}
+                        style={{ background: "var(--theme-accent)", color: "white", fontSize: "14px" }}
                       >
                         {initials}
                       </AvatarFallback>
@@ -268,13 +268,13 @@ export const MessageItem = memo(function MessageItem({
                     {format(timestamp, "HH:mm")}
                   </span>
                   {sendState === "queued" && (
-                    <Clock3 className="w-3 h-3" style={{ color: "#f0b232" }} />
+                    <Clock3 className="w-3 h-3" style={{ color: "var(--theme-warning)" }} />
                   )}
                   {sendState === "sending" && (
-                    <Loader2 className="w-3 h-3 animate-spin" style={{ color: "#949ba4" }} />
+                    <Loader2 className="w-3 h-3 animate-spin" style={{ color: "var(--theme-text-muted)" }} />
                   )}
                   {sendState === "failed" && (
-                    <AlertCircle className="w-3 h-3" style={{ color: "#f23f43" }} />
+                    <AlertCircle className="w-3 h-3" style={{ color: "var(--theme-danger)" }} />
                   )}
                 </div>
               )}
@@ -301,17 +301,17 @@ export const MessageItem = memo(function MessageItem({
                     {format(timestamp, "MM/dd/yyyy h:mm a")}
                   </span>
                   {sendState === "queued" && (
-                    <span className="text-xs flex items-center gap-1" style={{ color: "#f0b232" }}>
+                    <span className="text-xs flex items-center gap-1" style={{ color: "var(--theme-warning)" }}>
                       <Clock3 className="w-3 h-3" /> queued
                     </span>
                   )}
                   {sendState === "sending" && (
-                    <span className="text-xs flex items-center gap-1" style={{ color: "#949ba4" }}>
+                    <span className="text-xs flex items-center gap-1" style={{ color: "var(--theme-text-muted)" }}>
                       <Loader2 className="w-3 h-3 animate-spin" /> sending
                     </span>
                   )}
                   {sendState === "failed" && (
-                    <span className="text-xs flex items-center gap-1" style={{ color: "#f23f43" }}>
+                    <span className="text-xs flex items-center gap-1" style={{ color: "var(--theme-danger)" }}>
                       <AlertCircle className="w-3 h-3" /> failed
                     </span>
                   )}
@@ -340,9 +340,9 @@ export const MessageItem = memo(function MessageItem({
                     }}
                     className="w-full rounded px-3 py-2 text-sm resize-none focus:outline-none"
                     style={{
-                      background: "#1e1f22",
-                      color: "#f2f3f5",
-                      border: "1px solid #5865f2",
+                      background: "var(--theme-bg-tertiary)",
+                      color: "var(--theme-text-primary)",
+                      border: "1px solid var(--theme-accent)",
                     }}
                     rows={3}
                     autoFocus
@@ -353,7 +353,7 @@ export const MessageItem = memo(function MessageItem({
                     <button
                       onClick={handleEditSubmit}
                       className="focus-ring rounded"
-                      style={{ color: "#00a8fc" }}
+                      style={{ color: "var(--theme-link)" }}
                     >
                       Enter to save
                     </button>
@@ -364,7 +364,7 @@ export const MessageItem = memo(function MessageItem({
                   {renderedContent && (
                     <p
                       className="text-sm leading-relaxed message-content break-words"
-                      style={{ color: "#dcddde" }}
+                      style={{ color: "var(--theme-text-normal)" }}
                     >
                       {renderContent(renderedContent)}
                     </p>
@@ -375,7 +375,7 @@ export const MessageItem = memo(function MessageItem({
                       src={embeddableGiphyUrl}
                       alt="GIF"
                       className="mt-2 max-w-sm w-full rounded-md border"
-                      style={{ borderColor: "#1e1f22", background: "#1e1f22" }}
+                      style={{ borderColor: "var(--theme-bg-tertiary)", background: "var(--theme-bg-tertiary)" }}
                     />
                   )}
 
@@ -417,8 +417,8 @@ export const MessageItem = memo(function MessageItem({
                             background: hasOwn
                               ? "rgba(88,101,242,0.3)"
                               : "rgba(255,255,255,0.06)",
-                            border: `1px solid ${hasOwn ? "#5865f2" : "transparent"}`,
-                            color: "#dcddde",
+                            border: `1px solid ${hasOwn ? "var(--theme-accent)" : "transparent"}`,
+                            color: "var(--theme-text-normal)",
                           }}
                         >
                           {emoji} {count}
@@ -440,7 +440,7 @@ export const MessageItem = memo(function MessageItem({
                 "action-rail-motion absolute right-4 -top-4 flex items-center rounded shadow-lg overflow-hidden",
                 showActions ? "opacity-100 translate-y-0" : "pointer-events-none opacity-0 -translate-y-1"
               )}
-              style={{ background: "#2b2d31", border: "1px solid #1e1f22" }}
+              style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}
             >
               {/* Quick reactions */}
               {showEmojiPicker && (
@@ -462,7 +462,7 @@ export const MessageItem = memo(function MessageItem({
               <button
                 onClick={() => setShowEmojiPicker(!showEmojiPicker)}
                 className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-white/10 focus-ring"
-                style={{ color: "#b5bac1" }}
+                style={{ color: "var(--theme-text-secondary)" }}
                 title="Add Reaction"
                 aria-label="Add reaction"
                 aria-describedby={messageMetaId}
@@ -474,7 +474,7 @@ export const MessageItem = memo(function MessageItem({
               <button
                 onClick={onReply}
                 className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-white/10 focus-ring"
-                style={{ color: "#b5bac1" }}
+                style={{ color: "var(--theme-text-secondary)" }}
                 title="Reply"
                 aria-label="Reply to message"
                 aria-describedby={messageMetaId}
@@ -487,7 +487,7 @@ export const MessageItem = memo(function MessageItem({
                 <button
                   onClick={() => setShowCreateThread(true)}
                   className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-white/10 focus-ring"
-                  style={{ color: "#b5bac1" }}
+                  style={{ color: "var(--theme-text-secondary)" }}
                   title="Create Thread"
                   aria-label="Create thread from message"
                   aria-describedby={messageMetaId}
@@ -501,7 +501,7 @@ export const MessageItem = memo(function MessageItem({
                 <button
                   onClick={() => setIsEditing(true)}
                   className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-white/10 focus-ring"
-                  style={{ color: "#b5bac1" }}
+                  style={{ color: "var(--theme-text-secondary)" }}
                   title="Edit"
                   aria-label="Edit message"
                   aria-describedby={messageMetaId}
@@ -515,7 +515,7 @@ export const MessageItem = memo(function MessageItem({
                 <button
                   onClick={onRetry}
                   className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-white/10 focus-ring"
-                  style={{ color: "#f0b232" }}
+                  style={{ color: "var(--theme-warning)" }}
                   title="Retry send"
                   aria-label="Retry sending message"
                   aria-describedby={messageMetaId}
@@ -529,7 +529,7 @@ export const MessageItem = memo(function MessageItem({
                 <button
                   onClick={() => setShowDeleteDialog(true)}
                   className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-red-500/20 focus-ring"
-                  style={{ color: "#f23f43" }}
+                  style={{ color: "var(--theme-danger)" }}
                   title="Delete"
                   aria-label="Delete message"
                   aria-describedby={messageMetaId}
@@ -607,10 +607,10 @@ export const MessageItem = memo(function MessageItem({
     )}
 
     <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-      <DialogContent style={{ background: "#313338", borderColor: "#1e1f22", color: "#f2f3f5" }}>
+      <DialogContent style={{ background: "var(--theme-bg-primary)", borderColor: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)" }}>
         <DialogHeader>
           <DialogTitle>Delete message?</DialogTitle>
-          <DialogDescription style={{ color: "#b5bac1" }}>
+          <DialogDescription style={{ color: "var(--theme-text-secondary)" }}>
             This action is irreversible. This message will be permanently removed for everyone in this channel.
           </DialogDescription>
         </DialogHeader>
@@ -656,7 +656,7 @@ function AttachmentGallery({ attachments }: { attachments: AttachmentRow[] }) {
       <Dialog open={lightboxIndex !== null} onOpenChange={(open) => { if (!open) closeImage() }}>
         <DialogContent
           className="max-w-5xl border"
-          style={{ background: "#1e1f22", borderColor: "#2b2d31", color: "#f2f3f5" }}
+          style={{ background: "var(--theme-bg-tertiary)", borderColor: "var(--theme-bg-secondary)", color: "var(--theme-text-primary)" }}
           onKeyDown={(event) => {
             if (event.key === "ArrowRight") {
               event.preventDefault()
@@ -670,7 +670,7 @@ function AttachmentGallery({ attachments }: { attachments: AttachmentRow[] }) {
           {currentAttachment && (
             <div className="space-y-3">
               <img src={currentAttachment.url} alt={currentAttachment.filename} className="w-full max-h-[75vh] object-contain rounded" />
-              <div className="flex items-center justify-between text-xs" style={{ color: "#b5bac1" }}>
+              <div className="flex items-center justify-between text-xs" style={{ color: "var(--theme-text-secondary)" }}>
                 <span>{currentAttachment.filename}</span>
                 {imageIndexes.length > 1 && (
                   <span>
@@ -697,7 +697,7 @@ function AttachmentDisplay({ attachment, onOpenImage }: { attachment: Attachment
           src={attachment.url}
           alt={attachment.filename}
           className="rounded max-h-80 object-contain"
-          style={{ background: "#1e1f22" }}
+          style={{ background: "var(--theme-bg-tertiary)" }}
         />
       </button>
     )
@@ -709,11 +709,11 @@ function AttachmentDisplay({ attachment, onOpenImage }: { attachment: Attachment
       target="_blank"
       rel="noopener noreferrer"
       className="motion-interactive flex items-center gap-3 p-3 rounded max-w-sm hover:bg-white/5"
-      style={{ background: "#2b2d31", border: "1px solid #1e1f22" }}
+      style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}
     >
       <div
         className="w-10 h-10 rounded flex items-center justify-center flex-shrink-0"
-        style={{ background: "#5865f2" }}
+        style={{ background: "var(--theme-accent)" }}
       >
         <span className="text-white text-xs font-bold">
           {attachment.filename.split(".").pop()?.toUpperCase().slice(0, 4)}
@@ -723,7 +723,7 @@ function AttachmentDisplay({ attachment, onOpenImage }: { attachment: Attachment
         <div className="text-sm font-medium text-white truncate">
           {attachment.filename}
         </div>
-        <div className="text-xs" style={{ color: "#949ba4" }}>
+        <div className="text-xs" style={{ color: "var(--theme-text-muted)" }}>
           {(attachment.size / 1024).toFixed(1)} KB
         </div>
       </div>
@@ -738,8 +738,8 @@ function SpoilerSpan({ children }: { children: React.ReactNode }) {
       onClick={() => setRevealed(true)}
       className="rounded px-0.5 cursor-pointer select-none"
       style={{
-        background: revealed ? "rgba(255,255,255,0.1)" : "#2b2d31",
-        color: revealed ? "#dcddde" : "transparent",
+        background: revealed ? "rgba(255,255,255,0.1)" : "var(--theme-bg-secondary)",
+        color: revealed ? "var(--theme-text-normal)" : "transparent",
         transition: "color 0.1s",
       }}
       title={revealed ? undefined : "Click to reveal spoiler"}

--- a/apps/web/components/chat/thread-list.tsx
+++ b/apps/web/components/chat/thread-list.tsx
@@ -103,13 +103,13 @@ export function ThreadList({ channelId, activeThreadId, filter, onSelectThread }
   return (
     <div
       className="border-t mx-0"
-      style={{ borderColor: "#1e1f22" }}
+      style={{ borderColor: "var(--theme-bg-tertiary)" }}
     >
       {/* Section header */}
       <button
         onClick={() => setExpanded((e) => !e)}
         className="flex items-center gap-1.5 w-full px-4 py-2 text-xs font-semibold uppercase tracking-wide hover:bg-white/5 transition-colors"
-        style={{ color: "#949ba4" }}
+        style={{ color: "var(--theme-text-muted)" }}
       >
         {expanded ? (
           <ChevronDown className="w-3 h-3" />
@@ -120,7 +120,7 @@ export function ThreadList({ channelId, activeThreadId, filter, onSelectThread }
         Channel threads
         <span
           className="ml-auto rounded-full px-1.5 py-0.5 text-xs"
-          style={{ background: "#4e5058", color: "#dcddde" }}
+          style={{ background: "var(--theme-text-faint)", color: "var(--theme-text-normal)" }}
         >
           {threads.length}
         </span>
@@ -195,18 +195,18 @@ function ThreadListItem({
       )}
       style={{ maxWidth: "calc(100% - 8px)" }}
     >
-      <MessageSquare className="w-3.5 h-3.5 flex-shrink-0" style={{ color: "#949ba4" }} />
+      <MessageSquare className="w-3.5 h-3.5 flex-shrink-0" style={{ color: "var(--theme-text-muted)" }} />
       <span
         className="truncate flex-1"
-        style={{ color: isActive ? "#f2f3f5" : "#b5bac1" }}
+        style={{ color: isActive ? "var(--theme-text-primary)" : "var(--theme-text-secondary)" }}
       >
         {thread.name}
       </span>
-      {thread.locked && <Lock className="w-3 h-3 flex-shrink-0" style={{ color: "#f23f43" }} />}
+      {thread.locked && <Lock className="w-3 h-3 flex-shrink-0" style={{ color: "var(--theme-danger)" }} />}
       {thread.archived && <Archive className="w-3 h-3 flex-shrink-0" style={{ color: "#ed9c28" }} />}
       <span
         className="text-xs flex-shrink-0 ml-auto"
-        style={{ color: "#4e5058" }}
+        style={{ color: "var(--theme-text-faint)" }}
         title={format(new Date(thread.updated_at), "PPpp")}
       >
         {formatDistanceToNow(new Date(thread.updated_at), { addSuffix: false })}

--- a/apps/web/components/chat/thread-panel.tsx
+++ b/apps/web/components/chat/thread-panel.tsx
@@ -228,14 +228,14 @@ export function ThreadPanel({ thread, currentUserId, onClose, onThreadUpdate, fo
   return (
     <div
       className="flex flex-col w-80 flex-shrink-0 border-l"
-      style={{ background: "#313338", borderColor: "#1e1f22" }}
+      style={{ background: "var(--theme-bg-primary)", borderColor: "var(--theme-bg-tertiary)" }}
     >
       {/* Header */}
       <div
         className="flex items-center gap-2 px-3 py-3 border-b flex-shrink-0"
-        style={{ borderColor: "#1e1f22" }}
+        style={{ borderColor: "var(--theme-bg-tertiary)" }}
       >
-        <Hash className="w-4 h-4 flex-shrink-0" style={{ color: "#949ba4" }} />
+        <Hash className="w-4 h-4 flex-shrink-0" style={{ color: "var(--theme-text-muted)" }} />
         <span className="font-semibold text-white text-sm truncate flex-1">{thread.name}</span>
         <div className="flex items-center gap-1 ml-auto">
           {thread.owner_id === currentUserId && (
@@ -243,7 +243,7 @@ export function ThreadPanel({ thread, currentUserId, onClose, onThreadUpdate, fo
               <button
                 onClick={handleArchive}
                 className="w-7 h-7 flex items-center justify-center rounded hover:bg-white/10 transition-colors"
-                style={{ color: "#949ba4" }}
+                style={{ color: "var(--theme-text-muted)" }}
                 title={thread.archived ? "Unarchive thread" : "Archive thread"}
               >
                 {thread.archived ? (
@@ -255,7 +255,7 @@ export function ThreadPanel({ thread, currentUserId, onClose, onThreadUpdate, fo
               <button
                 onClick={handleLock}
                 className="w-7 h-7 flex items-center justify-center rounded hover:bg-white/10 transition-colors"
-                style={{ color: thread.locked ? "#f23f43" : "#949ba4" }}
+                style={{ color: thread.locked ? "var(--theme-danger)" : "var(--theme-text-muted)" }}
                 title={thread.locked ? "Unlock thread" : "Lock thread"}
               >
                 <Lock className="w-4 h-4" />
@@ -265,7 +265,7 @@ export function ThreadPanel({ thread, currentUserId, onClose, onThreadUpdate, fo
           <button
             onClick={isMember ? handleLeave : handleJoin}
             className="w-7 h-7 flex items-center justify-center rounded hover:bg-white/10 transition-colors"
-            style={{ color: isMember ? "#5865f2" : "#949ba4" }}
+            style={{ color: isMember ? "var(--theme-accent)" : "var(--theme-text-muted)" }}
             title={isMember ? "Leave thread" : "Join thread"}
           >
             <Users className="w-4 h-4" />
@@ -273,7 +273,7 @@ export function ThreadPanel({ thread, currentUserId, onClose, onThreadUpdate, fo
           <button
             onClick={onClose}
             className="w-7 h-7 flex items-center justify-center rounded hover:bg-white/10 transition-colors"
-            style={{ color: "#949ba4" }}
+            style={{ color: "var(--theme-text-muted)" }}
             title="Close thread"
           >
             <X className="w-4 h-4" />
@@ -283,7 +283,7 @@ export function ThreadPanel({ thread, currentUserId, onClose, onThreadUpdate, fo
 
       {/* Status badges */}
       {(thread.archived || thread.locked) && (
-        <div className="flex items-center gap-2 px-3 py-2" style={{ background: "#2b2d31" }}>
+        <div className="flex items-center gap-2 px-3 py-2" style={{ background: "var(--theme-bg-secondary)" }}>
           {thread.archived && (
             <span
               className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full"
@@ -295,7 +295,7 @@ export function ThreadPanel({ thread, currentUserId, onClose, onThreadUpdate, fo
           {thread.locked && (
             <span
               className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full"
-              style={{ background: "#f23f43", color: "#fff" }}
+              style={{ background: "var(--theme-danger)", color: "#fff" }}
             >
               <Lock className="w-3 h-3" /> Locked
             </span>
@@ -318,7 +318,7 @@ export function ThreadPanel({ thread, currentUserId, onClose, onThreadUpdate, fo
             ))}
           </div>
         ) : messages.length === 0 ? (
-          <div className="px-4 py-6 text-sm text-center" style={{ color: "#949ba4" }}>
+          <div className="px-4 py-6 text-sm text-center" style={{ color: "var(--theme-text-muted)" }}>
             No messages yet. Start the conversation!
           </div>
         ) : (
@@ -409,7 +409,7 @@ export function ThreadPanel({ thread, currentUserId, onClose, onThreadUpdate, fo
       ) : (
         <div
           className="px-4 py-3 text-sm text-center flex-shrink-0"
-          style={{ color: "#949ba4", background: "#2b2d31", borderTop: "1px solid #1e1f22" }}
+          style={{ color: "var(--theme-text-muted)", background: "var(--theme-bg-secondary)", borderTop: "1px solid var(--theme-bg-tertiary)" }}
         >
           {thread.locked ? "This thread is locked." : "This thread is archived."}
         </div>

--- a/apps/web/components/chat/workspace-reference-embed.tsx
+++ b/apps/web/components/chat/workspace-reference-embed.tsx
@@ -22,7 +22,7 @@ export function WorkspaceReferenceEmbed({ type, id }: { type: "task" | "doc"; id
   if (!data) return null
 
   return (
-    <div className="mt-2 rounded border border-[#1e1f22] bg-[#2b2d31] p-2 text-xs text-zinc-200">
+    <div className="mt-2 rounded border border-[var(--theme-bg-tertiary)] bg-[var(--theme-bg-secondary)] p-2 text-xs text-zinc-200">
       <div className="mb-1 flex items-center gap-1 font-medium text-white">
         {type === "task" ? <CheckSquare className="h-3.5 w-3.5" /> : <FileText className="h-3.5 w-3.5" />}
         {type.toUpperCase()} • {data.title}

--- a/apps/web/components/dm/dm-area.tsx
+++ b/apps/web/components/dm/dm-area.tsx
@@ -90,18 +90,18 @@ export function DMArea({ partner, currentUserId, initialMessages }: Props) {
       {/* Header */}
       <div
         className="flex items-center gap-3 px-4 py-3 border-b flex-shrink-0"
-        style={{ borderColor: "#1e1f22" }}
+        style={{ borderColor: "var(--theme-bg-tertiary)" }}
       >
         <Avatar className="w-8 h-8">
           {partner.avatar_url && <AvatarImage src={partner.avatar_url} />}
-          <AvatarFallback style={{ background: "#5865f2", color: "white", fontSize: "12px" }}>
+          <AvatarFallback style={{ background: "var(--theme-accent)", color: "white", fontSize: "12px" }}>
             {partnerInitials}
           </AvatarFallback>
         </Avatar>
         <div>
           <span className="font-semibold text-white">{partnerName}</span>
           {partner.status_message && (
-            <div className="text-xs" style={{ color: "#949ba4" }}>{partner.status_message}</div>
+            <div className="text-xs" style={{ color: "var(--theme-text-muted)" }}>{partner.status_message}</div>
           )}
         </div>
       </div>
@@ -112,12 +112,12 @@ export function DMArea({ partner, currentUserId, initialMessages }: Props) {
           <div className="text-center py-16">
             <Avatar className="w-20 h-20 mx-auto mb-4">
               {partner.avatar_url && <AvatarImage src={partner.avatar_url} />}
-              <AvatarFallback style={{ background: "#5865f2", color: "white", fontSize: "28px" }}>
+              <AvatarFallback style={{ background: "var(--theme-accent)", color: "white", fontSize: "28px" }}>
                 {partnerInitials}
               </AvatarFallback>
             </Avatar>
             <h2 className="text-2xl font-bold text-white mb-1">{partnerName}</h2>
-            <p style={{ color: "#b5bac1" }} className="text-sm">
+            <p style={{ color: "var(--theme-text-secondary)" }} className="text-sm">
               This is the beginning of your direct message history with <strong>{partnerName}</strong>.
             </p>
           </div>
@@ -134,7 +134,7 @@ export function DMArea({ partner, currentUserId, initialMessages }: Props) {
               {!isGrouped && (
                 <Avatar className="w-8 h-8 flex-shrink-0 mt-0.5">
                   {isOwn ? null : (partner.avatar_url && <AvatarImage src={partner.avatar_url} />)}
-                  <AvatarFallback style={{ background: isOwn ? "#5865f2" : "#36393f", color: "white", fontSize: "12px" }}>
+                  <AvatarFallback style={{ background: isOwn ? "var(--theme-accent)" : "#36393f", color: "white", fontSize: "12px" }}>
                     {isOwn ? "ME" : partnerInitials}
                   </AvatarFallback>
                 </Avatar>
@@ -145,16 +145,16 @@ export function DMArea({ partner, currentUserId, initialMessages }: Props) {
                     <span className="text-sm font-semibold text-white">
                       {isOwn ? "You" : partnerName}
                     </span>
-                    <span className="text-xs" style={{ color: "#4e5058" }}>
+                    <span className="text-xs" style={{ color: "var(--theme-text-faint)" }}>
                       {format(new Date(msg.created_at), "h:mm a")}
                     </span>
                   </div>
                 )}
-                <p className="text-sm break-words" style={{ color: "#dcddde" }}>
+                <p className="text-sm break-words" style={{ color: "var(--theme-text-normal)" }}>
                   {msg.content}
                 </p>
                 {msg.edited_at && (
-                  <span className="text-xs" style={{ color: "#4e5058" }}> (edited)</span>
+                  <span className="text-xs" style={{ color: "var(--theme-text-faint)" }}> (edited)</span>
                 )}
               </div>
             </div>
@@ -165,7 +165,7 @@ export function DMArea({ partner, currentUserId, initialMessages }: Props) {
 
       {/* Input */}
       <div className="px-4 pb-4 flex-shrink-0">
-        <div className="flex items-center gap-2 rounded-lg px-3 py-2" style={{ background: "#383a40" }}>
+        <div className="flex items-center gap-2 rounded-lg px-3 py-2" style={{ background: "var(--theme-surface-input)" }}>
           <input
             type="text"
             value={content}
@@ -173,13 +173,13 @@ export function DMArea({ partner, currentUserId, initialMessages }: Props) {
             onKeyDown={(e) => e.key === "Enter" && !e.shiftKey && handleSend()}
             placeholder={`Message @${partnerName}`}
             className="flex-1 bg-transparent text-sm focus:outline-none"
-            style={{ color: "#dcddde" }}
+            style={{ color: "var(--theme-text-normal)" }}
           />
           {content.trim() && (
             <button
               onClick={handleSend}
               disabled={sending}
-              style={{ color: "#5865f2" }}
+              style={{ color: "var(--theme-accent)" }}
             >
               <Send className="w-5 h-5" />
             </button>

--- a/apps/web/components/dm/dm-call.tsx
+++ b/apps/web/components/dm/dm-call.tsx
@@ -159,7 +159,7 @@ export function DMCallScreen({ channelId, currentUserId, partner, withVideo, onH
   const initials = partnerName.slice(0, 2).toUpperCase()
 
   return (
-    <div className="flex flex-col items-center justify-between flex-1 p-6" style={{ background: "#1e1f22" }}>
+    <div className="flex flex-col items-center justify-between flex-1 p-6" style={{ background: "var(--theme-bg-tertiary)" }}>
       {/* Remote video / avatar */}
       <div className="flex-1 flex items-center justify-center w-full relative">
         <video
@@ -174,10 +174,10 @@ export function DMCallScreen({ channelId, currentUserId, partner, withVideo, onH
           <div className="flex flex-col items-center gap-4">
             <Avatar className="w-24 h-24">
               {partner.avatar_url && <AvatarImage src={partner.avatar_url} />}
-              <AvatarFallback style={{ background: "#5865f2", color: "white", fontSize: "32px" }}>{initials}</AvatarFallback>
+              <AvatarFallback style={{ background: "var(--theme-accent)", color: "white", fontSize: "32px" }}>{initials}</AvatarFallback>
             </Avatar>
             <div className="text-white font-semibold text-lg">{partnerName}</div>
-            <div className="flex items-center gap-2 text-sm" style={{ color: "#b5bac1" }}>
+            <div className="flex items-center gap-2 text-sm" style={{ color: "var(--theme-text-secondary)" }}>
               <Loader2 className="w-4 h-4 animate-spin" /> Connecting…
             </div>
           </div>
@@ -191,7 +191,7 @@ export function DMCallScreen({ channelId, currentUserId, partner, withVideo, onH
             playsInline
             muted
             className="absolute bottom-3 right-3 w-32 h-24 rounded-lg object-cover border-2"
-            style={{ borderColor: "#5865f2", background: "#000", transform: "scaleX(-1)" }}
+            style={{ borderColor: "var(--theme-accent)", background: "#000", transform: "scaleX(-1)" }}
           />
         )}
       </div>
@@ -201,7 +201,7 @@ export function DMCallScreen({ channelId, currentUserId, partner, withVideo, onH
         <button
           onClick={toggleMute}
           className="w-14 h-14 rounded-full flex items-center justify-center transition-colors"
-          style={{ background: muted ? "#f23f43" : "#4e5058" }}
+          style={{ background: muted ? "var(--theme-danger)" : "var(--theme-text-faint)" }}
           title={muted ? "Unmute" : "Mute"}
         >
           {muted ? <MicOff className="w-6 h-6 text-white" /> : <Mic className="w-6 h-6 text-white" />}
@@ -211,7 +211,7 @@ export function DMCallScreen({ channelId, currentUserId, partner, withVideo, onH
           <button
             onClick={toggleVideo}
             className="w-14 h-14 rounded-full flex items-center justify-center transition-colors"
-            style={{ background: videoOff ? "#f23f43" : "#4e5058" }}
+            style={{ background: videoOff ? "var(--theme-danger)" : "var(--theme-text-faint)" }}
             title={videoOff ? "Turn on camera" : "Turn off camera"}
           >
             {videoOff ? <VideoOff className="w-6 h-6 text-white" /> : <Video className="w-6 h-6 text-white" />}
@@ -221,7 +221,7 @@ export function DMCallScreen({ channelId, currentUserId, partner, withVideo, onH
         <button
           onClick={handleHangUp}
           className="w-14 h-14 rounded-full flex items-center justify-center"
-          style={{ background: "#f23f43" }}
+          style={{ background: "var(--theme-danger)" }}
           title="Hang up"
         >
           <PhoneOff className="w-6 h-6 text-white" />
@@ -244,18 +244,18 @@ export function IncomingCallToast({ call, onAccept, onDecline }: IncomingCallToa
   return (
     <div
       className="fixed bottom-6 right-6 z-50 rounded-xl shadow-2xl p-4 flex items-center gap-4 min-w-72"
-      style={{ background: "#2b2d31", border: "1px solid #1e1f22" }}
+      style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}
     >
       {call.callerAvatar ? (
         <img src={call.callerAvatar} alt="" className="w-12 h-12 rounded-full object-cover" />
       ) : (
-        <div className="w-12 h-12 rounded-full flex items-center justify-center text-white font-bold" style={{ background: "#5865f2" }}>
+        <div className="w-12 h-12 rounded-full flex items-center justify-center text-white font-bold" style={{ background: "var(--theme-accent)" }}>
           {call.callerName.slice(0, 2).toUpperCase()}
         </div>
       )}
       <div className="flex-1 min-w-0">
         <div className="text-white font-semibold truncate">{call.callerName}</div>
-        <div className="text-sm" style={{ color: "#b5bac1" }}>
+        <div className="text-sm" style={{ color: "var(--theme-text-secondary)" }}>
           {call.withVideo ? "Incoming video call…" : "Incoming voice call…"}
         </div>
       </div>
@@ -263,7 +263,7 @@ export function IncomingCallToast({ call, onAccept, onDecline }: IncomingCallToa
         <button
           onClick={() => onAccept(false)}
           className="w-9 h-9 rounded-full flex items-center justify-center transition-colors"
-          style={{ background: "#23a55a" }}
+          style={{ background: "var(--theme-success)" }}
           title="Accept (voice)"
         >
           <Phone className="w-4 h-4 text-white" />
@@ -272,7 +272,7 @@ export function IncomingCallToast({ call, onAccept, onDecline }: IncomingCallToa
           <button
             onClick={() => onAccept(true)}
             className="w-9 h-9 rounded-full flex items-center justify-center transition-colors"
-            style={{ background: "#5865f2" }}
+            style={{ background: "var(--theme-accent)" }}
             title="Accept (video)"
           >
             <Video className="w-4 h-4 text-white" />
@@ -281,7 +281,7 @@ export function IncomingCallToast({ call, onAccept, onDecline }: IncomingCallToa
         <button
           onClick={onDecline}
           className="w-9 h-9 rounded-full flex items-center justify-center transition-colors"
-          style={{ background: "#f23f43" }}
+          style={{ background: "var(--theme-danger)" }}
           title="Decline"
         >
           <PhoneOff className="w-4 h-4 text-white" />

--- a/apps/web/components/dm/dm-channel-area.tsx
+++ b/apps/web/components/dm/dm-channel-area.tsx
@@ -264,11 +264,11 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
   if (loadError) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-3" style={{ background: "var(--app-bg-primary)" }}>
-        <p className="text-sm" style={{ color: "#949ba4" }}>Failed to load conversation.</p>
+        <p className="text-sm" style={{ color: "var(--theme-text-muted)" }}>Failed to load conversation.</p>
         <button
           onClick={() => loadMessages()}
           className="px-4 py-2 rounded text-sm font-medium"
-          style={{ background: "#5865f2", color: "white" }}
+          style={{ background: "var(--theme-accent)", color: "white" }}
         >
           Retry
         </button>
@@ -279,7 +279,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
   if (!channel) {
     return (
       <div className="flex-1 flex items-center justify-center" style={{ background: "var(--app-bg-primary)" }}>
-        <div className="w-5 h-5 border-2 border-t-transparent rounded-full animate-spin" style={{ borderColor: "#5865f2", borderTopColor: "transparent" }} />
+        <div className="w-5 h-5 border-2 border-t-transparent rounded-full animate-spin" style={{ borderColor: "var(--theme-accent)", borderTopColor: "transparent" }} />
       </div>
     )
   }
@@ -292,16 +292,16 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
   return (
     <div className="flex flex-col flex-1 overflow-hidden" style={{ background: "var(--app-bg-primary)" }}>
       {/* Header */}
-      <div className="flex items-center gap-3 px-4 py-3 border-b flex-shrink-0" style={{ borderColor: "#1e1f22" }}>
+      <div className="flex items-center gap-3 px-4 py-3 border-b flex-shrink-0" style={{ borderColor: "var(--theme-bg-tertiary)" }}>
         <MobileMenuButton />
         {channel.is_group ? (
-          <div className="w-8 h-8 rounded-full flex items-center justify-center" style={{ background: "#5865f2" }}>
+          <div className="w-8 h-8 rounded-full flex items-center justify-center" style={{ background: "var(--theme-accent)" }}>
             <Users className="w-4 h-4 text-white" />
           </div>
         ) : (
           <Avatar className="w-8 h-8">
             {channel.partner?.avatar_url && <AvatarImage src={channel.partner.avatar_url} />}
-            <AvatarFallback style={{ background: "#5865f2", color: "white", fontSize: "12px" }}>
+            <AvatarFallback style={{ background: "var(--theme-accent)", color: "white", fontSize: "12px" }}>
               {partnerInitials}
             </AvatarFallback>
           </Avatar>
@@ -310,7 +310,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
 
         <button
           className="w-8 h-8 flex items-center justify-center rounded hover:bg-white/10 transition-colors"
-          style={{ color: "#b5bac1" }}
+          style={{ color: "var(--theme-text-secondary)" }}
           title="Search in conversation"
           aria-label="Search in conversation"
           type="button"
@@ -320,7 +320,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
         </button>
         <button
           className="w-8 h-8 flex items-center justify-center rounded hover:bg-white/10 transition-colors"
-          style={{ color: "#b5bac1" }}
+          style={{ color: "var(--theme-text-secondary)" }}
           title="Pinned messages"
           aria-label="Pinned messages"
           type="button"
@@ -335,7 +335,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
             <button
               onClick={startVoiceCall}
               className="w-8 h-8 flex items-center justify-center rounded hover:bg-white/10 transition-colors"
-              style={{ color: (inCall && !callWithVideo) ? "#23a55a" : "#b5bac1" }}
+              style={{ color: (inCall && !callWithVideo) ? "var(--theme-success)" : "var(--theme-text-secondary)" }}
               title="Start voice call"
               disabled={inCall}
             >
@@ -344,7 +344,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
             <button
               onClick={startVideoCall}
               className="w-8 h-8 flex items-center justify-center rounded hover:bg-white/10 transition-colors"
-              style={{ color: (inCall && callWithVideo) ? "#23a55a" : "#b5bac1" }}
+              style={{ color: (inCall && callWithVideo) ? "var(--theme-success)" : "var(--theme-text-secondary)" }}
               title="Start video call"
               disabled={inCall}
             >
@@ -375,7 +375,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
               onClick={loadMore}
               disabled={loadingMore}
               className="text-xs px-3 py-1 rounded transition-colors hover:bg-white/10"
-              style={{ color: "#949ba4" }}
+              style={{ color: "var(--theme-text-muted)" }}
             >
               {loadingMore ? "Loading…" : "Load older messages"}
             </button>
@@ -387,19 +387,19 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
         {!hasMore && messages.length === 0 && (
           <div className="text-center py-16">
             {channel.is_group ? (
-              <div className="w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-4" style={{ background: "#5865f2" }}>
+              <div className="w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-4" style={{ background: "var(--theme-accent)" }}>
                 <Users className="w-10 h-10 text-white" />
               </div>
             ) : (
               <Avatar className="w-20 h-20 mx-auto mb-4">
                 {channel.partner?.avatar_url && <AvatarImage src={channel.partner.avatar_url} />}
-                <AvatarFallback style={{ background: "#5865f2", color: "white", fontSize: "28px" }}>
+                <AvatarFallback style={{ background: "var(--theme-accent)", color: "white", fontSize: "28px" }}>
                   {partnerInitials}
                 </AvatarFallback>
               </Avatar>
             )}
             <h2 className="text-2xl font-bold text-white mb-1">{displayName}</h2>
-            <p style={{ color: "#b5bac1" }} className="text-sm">
+            <p style={{ color: "var(--theme-text-secondary)" }} className="text-sm">
               {channel.is_group
                 ? `Welcome to your group DM with ${channel.members.length} members.`
                 : `This is the beginning of your DM with ${displayName}.`}
@@ -425,7 +425,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
               {!isGrouped && (
                 <Avatar className="w-8 h-8 flex-shrink-0 mt-0.5">
                   {msg.sender?.avatar_url && <AvatarImage src={msg.sender.avatar_url} />}
-                  <AvatarFallback style={{ background: "#5865f2", color: "white", fontSize: "12px" }}>
+                  <AvatarFallback style={{ background: "var(--theme-accent)", color: "white", fontSize: "12px" }}>
                     {senderInitials}
                   </AvatarFallback>
                 </Avatar>
@@ -436,7 +436,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
                     <span className="text-sm font-semibold" style={{ color: isOwn ? "#00b0f4" : "white" }}>
                       {isOwn ? "You" : senderName}
                     </span>
-                    <span className="text-xs" style={{ color: "#4e5058" }}>
+                    <span className="text-xs" style={{ color: "var(--theme-text-faint)" }}>
                       {format(new Date(msg.created_at), "h:mm a")}
                     </span>
                   </div>
@@ -452,10 +452,10 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
                         if (e.key === "Escape") setEditingId(null)
                       }}
                       className="flex-1 bg-transparent border-b text-sm focus:outline-none"
-                      style={{ color: "#dcddde", borderColor: "#5865f2" }}
+                      style={{ color: "var(--theme-text-normal)", borderColor: "var(--theme-accent)" }}
                     />
-                    <button onClick={() => handleEditSave(msg.id)} className="text-xs px-2 py-0.5 rounded" style={{ background: "#5865f2", color: "white" }}>Save</button>
-                    <button onClick={() => setEditingId(null)} className="text-xs" style={{ color: "#949ba4" }}>Cancel</button>
+                    <button onClick={() => handleEditSave(msg.id)} className="text-xs px-2 py-0.5 rounded" style={{ background: "var(--theme-accent)", color: "white" }}>Save</button>
+                    <button onClick={() => setEditingId(null)} className="text-xs" style={{ color: "var(--theme-text-muted)" }}>Cancel</button>
                   </div>
                 ) : imageMatch ? (
                   <div className="mt-1">
@@ -467,15 +467,15 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
                         onError={(e) => { (e.target as HTMLImageElement).style.display = "none" }}
                       />
                     </a>
-                    <span className="text-xs" style={{ color: "#949ba4" }}>{imageMatch[1]}</span>
+                    <span className="text-xs" style={{ color: "var(--theme-text-muted)" }}>{imageMatch[1]}</span>
                   </div>
                 ) : (
-                  <p className="text-sm break-words" style={{ color: "#dcddde" }}>
+                  <p className="text-sm break-words" style={{ color: "var(--theme-text-normal)" }}>
                     {msg.content}
                   </p>
                 )}
                 {msg.edited_at && !isEditing && (
-                  <span className="text-xs" style={{ color: "#4e5058" }}> (edited)</span>
+                  <span className="text-xs" style={{ color: "var(--theme-text-faint)" }}> (edited)</span>
                 )}
               </div>
               {/* Hover actions — own messages only */}
@@ -484,7 +484,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
                   <button
                     onClick={() => { setEditingId(msg.id); setEditContent(msg.content) }}
                     className="w-7 h-7 flex items-center justify-center rounded hover:bg-white/10"
-                    style={{ color: "#949ba4" }}
+                    style={{ color: "var(--theme-text-muted)" }}
                     title="Edit"
                   >
                     <Pencil className="w-3.5 h-3.5" />
@@ -492,7 +492,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
                   <button
                     onClick={() => handleDelete(msg.id)}
                     className="w-7 h-7 flex items-center justify-center rounded hover:bg-red-500/20"
-                    style={{ color: "#949ba4" }}
+                    style={{ color: "var(--theme-text-muted)" }}
                     title="Delete"
                   >
                     <Trash2 className="w-3.5 h-3.5" />
@@ -510,17 +510,17 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
 
       {/* Input */}
       <div className="px-4 pb-4 flex-shrink-0">
-        <div className="flex items-center gap-2 rounded-lg px-3 py-2" style={{ background: "#383a40" }}>
+        <div className="flex items-center gap-2 rounded-lg px-3 py-2" style={{ background: "var(--theme-surface-input)" }}>
           {/* File upload */}
           <button
             onClick={() => fileInputRef.current?.click()}
             disabled={uploadingFile}
             className="flex-shrink-0 transition-colors hover:text-white"
-            style={{ color: "#949ba4" }}
+            style={{ color: "var(--theme-text-muted)" }}
             title="Attach file"
           >
             {uploadingFile
-              ? <div className="w-5 h-5 border-2 border-t-transparent rounded-full animate-spin" style={{ borderColor: "#5865f2", borderTopColor: "transparent" }} />
+              ? <div className="w-5 h-5 border-2 border-t-transparent rounded-full animate-spin" style={{ borderColor: "var(--theme-accent)", borderTopColor: "transparent" }} />
               : <Paperclip className="w-5 h-5" />}
           </button>
           <input
@@ -538,18 +538,18 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
             onKeyDown={(e) => e.key === "Enter" && !e.shiftKey && handleSend()}
             placeholder={`Message ${channel.is_group ? displayName : `@${displayName}`}`}
             className="flex-1 bg-transparent text-sm focus:outline-none"
-            style={{ color: "#dcddde" }}
+            style={{ color: "var(--theme-text-normal)" }}
           />
           <button
             className="w-8 h-8 flex items-center justify-center rounded hover:bg-white/10 transition-colors"
-            style={{ color: "#949ba4" }}
+            style={{ color: "var(--theme-text-muted)" }}
             title="Open emoji picker"
             type="button"
           >
             <SmilePlus className="w-4 h-4" />
           </button>
           {content.trim() && (
-            <button onClick={handleSend} disabled={sending} style={{ color: "#5865f2" }}>
+            <button onClick={handleSend} disabled={sending} style={{ color: "var(--theme-accent)" }}>
               <Send className="w-5 h-5" />
             </button>
           )}
@@ -585,7 +585,7 @@ function DMCallView({ channelId, currentUserId, partner, displayName, withVideo,
     connecting: {
       label: "Connecting",
       detail: withVideo ? `Setting up video with ${displayName}` : `Reaching ${displayName}`,
-      tone: "#b5bac1",
+      tone: "var(--theme-text-secondary)",
       bg: "rgba(181,186,193,0.18)",
     },
     connected: {
@@ -721,7 +721,7 @@ function DMCallView({ channelId, currentUserId, partner, displayName, withVideo,
   }
 
   return (
-    <div className="absolute inset-0 z-40 flex flex-col items-center justify-center" style={{ background: "#1e1f22" }}>
+    <div className="absolute inset-0 z-40 flex flex-col items-center justify-center" style={{ background: "var(--theme-bg-tertiary)" }}>
       <audio ref={remoteAudioRef} autoPlay playsInline />
 
       {/* Video area (video calls only) */}
@@ -734,18 +734,18 @@ function DMCallView({ channelId, currentUserId, partner, displayName, withVideo,
             playsInline
             muted
             className="absolute bottom-3 right-3 w-32 rounded-lg border-2 object-cover"
-            style={{ borderColor: "#5865f2", transform: "scaleX(-1)" }}
+            style={{ borderColor: "var(--theme-accent)", transform: "scaleX(-1)" }}
           />
           {status === "connecting" && (
             <div className="absolute inset-0 flex flex-col items-center justify-center gap-3" style={{ background: "rgba(0,0,0,0.6)" }}>
-              <div className="w-6 h-6 border-2 border-t-transparent rounded-full animate-spin" style={{ borderColor: "#5865f2", borderTopColor: "transparent" }} />
+              <div className="w-6 h-6 border-2 border-t-transparent rounded-full animate-spin" style={{ borderColor: "var(--theme-accent)", borderTopColor: "transparent" }} />
               <p className="text-white text-sm">{statusMeta.connecting.detail}…</p>
             </div>
           )}
           {status === "failed" && (
             <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4" style={{ background: "rgba(0,0,0,0.7)" }}>
               <p className="text-white font-medium">{statusMeta.failed.label}</p>
-              <p className="text-sm text-center" style={{ color: "#b5bac1" }}>{statusMeta.failed.detail}</p>
+              <p className="text-sm text-center" style={{ color: "var(--theme-text-secondary)" }}>{statusMeta.failed.detail}</p>
             </div>
           )}
         </div>
@@ -755,9 +755,9 @@ function DMCallView({ channelId, currentUserId, partner, displayName, withVideo,
           <div
             className={cn(
               "w-32 h-32 rounded-full flex items-center justify-center overflow-hidden",
-              status === "connected" ? "ring-4 ring-green-500/80" : "ring-2 ring-[#4e5058]/60"
+              status === "connected" ? "ring-4 ring-green-500/80" : "ring-2 ring-[var(--theme-text-faint)]/60"
             )}
-            style={{ background: "#5865f2", transition: "box-shadow 240ms ease" }}
+            style={{ background: "var(--theme-accent)", transition: "box-shadow 240ms ease" }}
           >
             {partner?.avatar_url ? (
               <img src={partner.avatar_url} alt="" className="w-full h-full object-cover" />
@@ -771,8 +771,8 @@ function DMCallView({ channelId, currentUserId, partner, displayName, withVideo,
             <span className="ml-2" style={{ color: "#c9ccd1" }}>{statusMeta[status].detail}</span>
           </div>
           {status === "connecting" && (
-            <div className="flex items-center gap-2 text-xs" style={{ color: "#949ba4" }}>
-              <div className="w-3.5 h-3.5 border-2 border-t-transparent rounded-full animate-spin" style={{ borderColor: "#5865f2", borderTopColor: "transparent" }} />
+            <div className="flex items-center gap-2 text-xs" style={{ color: "var(--theme-text-muted)" }}>
+              <div className="w-3.5 h-3.5 border-2 border-t-transparent rounded-full animate-spin" style={{ borderColor: "var(--theme-accent)", borderTopColor: "transparent" }} />
               Establishing secure media link…
             </div>
           )}
@@ -784,7 +784,7 @@ function DMCallView({ channelId, currentUserId, partner, displayName, withVideo,
         <button
           onClick={toggleMute}
           className="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-          style={{ background: muted ? "#f23f43" : "#4e5058" }}
+          style={{ background: muted ? "var(--theme-danger)" : "var(--theme-text-faint)" }}
           title={muted ? "Unmute" : "Mute"}
         >
           {muted ? <MicOff className="w-5 h-5 text-white" /> : <Mic className="w-5 h-5 text-white" />}
@@ -793,7 +793,7 @@ function DMCallView({ channelId, currentUserId, partner, displayName, withVideo,
           <button
             onClick={toggleVideo}
             className="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-            style={{ background: videoOff ? "#f23f43" : "#4e5058" }}
+            style={{ background: videoOff ? "var(--theme-danger)" : "var(--theme-text-faint)" }}
             title={videoOff ? "Turn on camera" : "Turn off camera"}
           >
             {videoOff ? <VideoOff className="w-5 h-5 text-white" /> : <Video className="w-5 h-5 text-white" />}
@@ -802,7 +802,7 @@ function DMCallView({ channelId, currentUserId, partner, displayName, withVideo,
         <button
           onClick={hangup}
           className="w-12 h-12 rounded-full flex items-center justify-center"
-          style={{ background: "#f23f43" }}
+          style={{ background: "var(--theme-danger)" }}
           title="Hang up"
         >
           <PhoneOff className="w-5 h-5 text-white" />

--- a/apps/web/components/dm/dm-list.tsx
+++ b/apps/web/components/dm/dm-list.tsx
@@ -40,16 +40,16 @@ function formatTime(ts: string) {
 
 function StatusDot({ status }: { status: string }) {
   const colors: Record<string, string> = {
-    online: "#23a55a",
-    idle: "#f0b132",
-    dnd: "#f23f43",
-    offline: "#80848e",
-    invisible: "#80848e",
+    online: "var(--theme-success)",
+    idle: "var(--theme-warning)",
+    dnd: "var(--theme-danger)",
+    offline: "var(--theme-presence-offline)",
+    invisible: "var(--theme-presence-offline)",
   }
   return (
     <span
       className="absolute bottom-0 right-0 w-3 h-3 rounded-full border-2"
-      style={{ background: colors[status] ?? "#80848e", borderColor: "#2b2d31" }}
+      style={{ background: colors[status] ?? "var(--theme-presence-offline)", borderColor: "var(--theme-bg-secondary)" }}
     />
   )
 }
@@ -125,12 +125,12 @@ export function DMList({ onNavigate }: { onNavigate?: () => void } = {}) {
     <div className="flex flex-col h-full">
       {/* Header */}
       <div className="px-4 py-3 flex items-center justify-between">
-        <span className="text-xs font-semibold uppercase tracking-wide" style={{ color: "#949ba4" }}>
+        <span className="text-xs font-semibold uppercase tracking-wide" style={{ color: "var(--theme-text-muted)" }}>
           Direct Messages
         </span>
         <button
           className="w-4 h-4 hover:text-white transition-colors"
-          style={{ color: "#949ba4" }}
+          style={{ color: "var(--theme-text-muted)" }}
           title="New DM"
         >
           <Plus className="w-4 h-4" />
@@ -172,14 +172,14 @@ export function DMList({ onNavigate }: { onNavigate?: () => void } = {}) {
                 {ch.is_group ? (
                   <div
                     className="w-8 h-8 rounded-full flex items-center justify-center"
-                    style={{ background: "#5865f2" }}
+                    style={{ background: "var(--theme-accent)" }}
                   >
                     <Users className="w-4 h-4 text-white" />
                   </div>
                 ) : (
                   <Avatar className="w-8 h-8">
                     {ch.partner?.avatar_url && <AvatarImage src={ch.partner.avatar_url} />}
-                    <AvatarFallback style={{ background: "#5865f2", color: "white", fontSize: "11px" }}>
+                    <AvatarFallback style={{ background: "var(--theme-accent)", color: "white", fontSize: "11px" }}>
                       {initials}
                     </AvatarFallback>
                   </Avatar>
@@ -198,13 +198,13 @@ export function DMList({ onNavigate }: { onNavigate?: () => void } = {}) {
                     {displayName}
                   </span>
                   {ch.latest_message && (
-                    <span className="text-xs flex-shrink-0" style={{ color: "#4e5058" }}>
+                    <span className="text-xs flex-shrink-0" style={{ color: "var(--theme-text-faint)" }}>
                       {formatTime(ch.latest_message.created_at)}
                     </span>
                   )}
                 </div>
                 {ch.latest_message && (
-                  <p className="text-xs truncate" style={{ color: "#949ba4" }}>
+                  <p className="text-xs truncate" style={{ color: "var(--theme-text-muted)" }}>
                     {ch.latest_message.content}
                   </p>
                 )}

--- a/apps/web/components/dm/friends-sidebar.tsx
+++ b/apps/web/components/dm/friends-sidebar.tsx
@@ -16,18 +16,18 @@ interface FriendsData {
 
 function StatusDot({ status }: { status: string }) {
   const colors: Record<string, string> = {
-    online: "#23a55a",
-    idle: "#f0b232",
-    dnd: "#f23f43",
-    invisible: "#80848e",
-    offline: "#80848e",
+    online: "var(--theme-success)",
+    idle: "var(--theme-warning)",
+    dnd: "var(--theme-danger)",
+    invisible: "var(--theme-presence-offline)",
+    offline: "var(--theme-presence-offline)",
   }
   return (
     <span
       className="w-3 h-3 rounded-full border-2 flex-shrink-0"
       style={{
-        background: colors[status] ?? "#80848e",
-        borderColor: "#2b2d31",
+        background: colors[status] ?? "var(--theme-presence-offline)",
+        borderColor: "var(--theme-bg-secondary)",
       }}
     />
   )
@@ -51,25 +51,25 @@ function FriendEntry({
       <div className="relative flex-shrink-0">
         <Avatar className="w-9 h-9">
           {friend.avatar_url && <AvatarImage src={friend.avatar_url} />}
-          <AvatarFallback style={{ background: "#5865f2", color: "white", fontSize: "13px" }}>
+          <AvatarFallback style={{ background: "var(--theme-accent)", color: "white", fontSize: "13px" }}>
             {initials}
           </AvatarFallback>
         </Avatar>
         <span
           className="absolute bottom-0 right-0 w-3 h-3 rounded-full border-2"
           style={{
-            background: friend.status === "online" ? "#23a55a"
-              : friend.status === "idle" ? "#f0b232"
-              : friend.status === "dnd" ? "#f23f43"
-              : "#80848e",
-            borderColor: "#2b2d31",
+            background: friend.status === "online" ? "var(--theme-success)"
+              : friend.status === "idle" ? "var(--theme-warning)"
+              : friend.status === "dnd" ? "var(--theme-danger)"
+              : "var(--theme-presence-offline)",
+            borderColor: "var(--theme-bg-secondary)",
           }}
         />
       </div>
 
       <div className="flex-1 min-w-0">
         <div className="text-sm font-semibold text-white truncate">{displayName}</div>
-        <div className="text-xs truncate capitalize" style={{ color: "#949ba4" }}>
+        <div className="text-xs truncate capitalize" style={{ color: "var(--theme-text-muted)" }}>
           {friend.username !== displayName ? `@${friend.username} · ` : ""}
           {friend.status_message || friend.status || "Offline"}
         </div>
@@ -100,7 +100,7 @@ function IconButton({
       className="w-8 h-8 rounded-full flex items-center justify-center transition-colors"
       style={{
         background: danger ? "rgba(242,63,67,0.15)" : "rgba(255,255,255,0.08)",
-        color: danger ? "#f23f43" : "#b5bac1",
+        color: danger ? "var(--theme-danger)" : "var(--theme-text-secondary)",
       }}
     >
       {children}
@@ -219,9 +219,9 @@ export function FriendsSidebar() {
       {/* Header */}
       <div
         className="flex items-center gap-2 px-4 py-3 border-b flex-shrink-0"
-        style={{ borderColor: "#1e1f22" }}
+        style={{ borderColor: "var(--theme-bg-tertiary)" }}
       >
-        <UserPlus className="w-5 h-5 flex-shrink-0" style={{ color: "#b5bac1" }} />
+        <UserPlus className="w-5 h-5 flex-shrink-0" style={{ color: "var(--theme-text-secondary)" }} />
         <span className="font-semibold text-white">Friends</span>
       </div>
 
@@ -235,16 +235,16 @@ export function FriendsSidebar() {
             placeholder="Add friend by username…"
             className="flex-1 px-3 py-2 rounded text-sm focus:outline-none"
             style={{
-              background: "#1e1f22",
-              color: "#f2f3f5",
-              border: "1px solid #3f4147",
+              background: "var(--theme-bg-tertiary)",
+              color: "var(--theme-text-primary)",
+              border: "1px solid var(--theme-surface-elevated)",
             }}
           />
           <button
             type="submit"
             disabled={addLoading || !addUsername.trim()}
             className="px-3 py-2 rounded text-sm font-semibold transition-colors disabled:opacity-50"
-            style={{ background: "#5865f2", color: "white" }}
+            style={{ background: "var(--theme-accent)", color: "white" }}
           >
             {addLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Send"}
           </button>
@@ -252,7 +252,7 @@ export function FriendsSidebar() {
         {addStatus && (
           <p
             className="mt-1 text-xs px-1"
-            style={{ color: addStatus.type === "success" ? "#23a55a" : "#f23f43" }}
+            style={{ color: addStatus.type === "success" ? "var(--theme-success)" : "var(--theme-danger)" }}
           >
             {addStatus.msg}
           </p>
@@ -262,7 +262,7 @@ export function FriendsSidebar() {
       {/* Tabs */}
       <div
         className="flex gap-1 px-4 pb-2 flex-shrink-0 border-b"
-        style={{ borderColor: "#1e1f22" }}
+        style={{ borderColor: "var(--theme-bg-tertiary)" }}
       >
         {tabs.map((t) => (
           <button
@@ -271,14 +271,14 @@ export function FriendsSidebar() {
             className="flex items-center gap-1.5 px-3 py-1.5 rounded text-sm font-medium transition-colors"
             style={{
               background: tab === t.id ? "#404249" : "transparent",
-              color: tab === t.id ? "#f2f3f5" : "#949ba4",
+              color: tab === t.id ? "var(--theme-text-primary)" : "var(--theme-text-muted)",
             }}
           >
             {t.label}
             {t.count && t.count > 0 ? (
               <span
                 className="px-1.5 py-0.5 rounded-full text-xs font-bold"
-                style={{ background: "#f23f43", color: "white" }}
+                style={{ background: "var(--theme-danger)", color: "white" }}
               >
                 {t.count}
               </span>
@@ -291,14 +291,14 @@ export function FriendsSidebar() {
       <div className="flex-1 overflow-y-auto px-2 py-2">
         {loading ? (
           <div className="flex items-center justify-center py-8">
-            <Loader2 className="w-6 h-6 animate-spin" style={{ color: "#949ba4" }} />
+            <Loader2 className="w-6 h-6 animate-spin" style={{ color: "var(--theme-text-muted)" }} />
           </div>
         ) : (
           <>
             {/* Pending received */}
             {pendingReceivedList.length > 0 && (
               <div className="mb-4">
-                <p className="text-xs font-semibold uppercase px-1 mb-1" style={{ color: "#949ba4" }}>
+                <p className="text-xs font-semibold uppercase px-1 mb-1" style={{ color: "var(--theme-text-muted)" }}>
                   Incoming — {pendingReceivedList.length}
                 </p>
                 {pendingReceivedList.map((entry) => (
@@ -323,7 +323,7 @@ export function FriendsSidebar() {
             {/* Pending sent */}
             {pendingSentList.length > 0 && (
               <div className="mb-4">
-                <p className="text-xs font-semibold uppercase px-1 mb-1" style={{ color: "#949ba4" }}>
+                <p className="text-xs font-semibold uppercase px-1 mb-1" style={{ color: "var(--theme-text-muted)" }}>
                   Outgoing — {pendingSentList.length}
                 </p>
                 {pendingSentList.map((entry) => (
@@ -343,7 +343,7 @@ export function FriendsSidebar() {
             {/* Main list */}
             {displayList.length > 0 && (
               <div>
-                <p className="text-xs font-semibold uppercase px-1 mb-1" style={{ color: "#949ba4" }}>
+                <p className="text-xs font-semibold uppercase px-1 mb-1" style={{ color: "var(--theme-text-muted)" }}>
                   {tab === "online"
                     ? `Online — ${displayList.length}`
                     : tab === "all"
@@ -377,12 +377,12 @@ export function FriendsSidebar() {
 
             {/* Empty states */}
             {tab === "pending" && pendingReceivedList.length === 0 && pendingSentList.length === 0 && (
-              <p className="text-center py-8 text-sm" style={{ color: "#949ba4" }}>
+              <p className="text-center py-8 text-sm" style={{ color: "var(--theme-text-muted)" }}>
                 No pending friend requests
               </p>
             )}
             {tab !== "pending" && displayList.length === 0 && (
-              <p className="text-center py-8 text-sm" style={{ color: "#949ba4" }}>
+              <p className="text-center py-8 text-sm" style={{ color: "var(--theme-text-muted)" }}>
                 {tab === "online"
                   ? "No friends online"
                   : tab === "all"

--- a/apps/web/components/layout/channel-sidebar.tsx
+++ b/apps/web/components/layout/channel-sidebar.tsx
@@ -564,13 +564,13 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
     <TooltipProvider delayDuration={200}>
       <div
         className="w-60 flex flex-col flex-shrink-0"
-        style={{ background: '#2b2d31' }}
+        style={{ background: 'var(--theme-bg-secondary)' }}
       >
         {/* Server header */}
         <button
           onClick={() => setShowServerSettings(true)}
           className="flex items-center justify-between px-4 py-3 border-b cursor-pointer hover:bg-white/5 motion-interactive motion-press group focus-ring" aria-label="Open server settings"
-          style={{ borderColor: '#1e1f22' }}
+          style={{ borderColor: 'var(--theme-bg-tertiary)' }}
         >
           <span className="font-semibold text-white truncate text-sm">{server.name}</span>
           <ChevronDown className="w-4 h-4 flex-shrink-0 text-gray-400 group-hover:text-white motion-interactive" />
@@ -671,7 +671,7 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
               {activeChannel ? (
                 <div
                   className="flex items-center gap-2 px-2 py-1.5 rounded text-sm text-white shadow-lg opacity-90"
-                  style={{ background: '#313338', width: '208px' }}
+                  style={{ background: 'var(--theme-bg-primary)', width: '208px' }}
                 >
                   <ChannelIcon channel={activeChannel} isVoiceActive={false} />
                   <span className="truncate">{activeChannel.name}</span>
@@ -679,7 +679,7 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
               ) : activeCategory ? (
                 <div
                   className="flex items-center gap-2 px-2 py-1.5 rounded text-sm text-white shadow-lg opacity-90"
-                  style={{ background: '#313338', width: '208px' }}
+                  style={{ background: 'var(--theme-bg-primary)', width: '208px' }}
                 >
                   <ChevronDown className="w-3 h-3 tertiary-metadata" />
                   <span className="truncate uppercase text-xs font-semibold tracking-wider">{activeCategory.name}</span>
@@ -741,10 +741,10 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
 
         {/* Delete channel confirmation dialog */}
         <Dialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>
-          <DialogContent style={{ background: '#313338', borderColor: '#1e1f22' }}>
+          <DialogContent style={{ background: 'var(--theme-bg-primary)', borderColor: 'var(--theme-bg-tertiary)' }}>
             <DialogHeader>
               <DialogTitle className="text-white">Delete Channel</DialogTitle>
-              <DialogDescription style={{ color: '#b5bac1' }}>
+              <DialogDescription style={{ color: 'var(--theme-text-secondary)' }}>
                 Are you sure you want to delete{" "}
                 <span className="font-semibold text-white">#{deleteTarget?.name}</span>?
                 {" "}This cannot be undone.
@@ -754,7 +754,7 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
               <button
                 onClick={() => setDeleteTarget(null)}
                 className="px-4 py-2 rounded text-sm font-medium motion-interactive motion-press hover:bg-white/10 focus-ring"
-                style={{ color: '#b5bac1' }}
+                style={{ color: 'var(--theme-text-secondary)' }}
               >
                 Cancel
               </button>
@@ -787,7 +787,7 @@ function formatTimeRemaining(expiresAt: string): string {
 }
 
 function ChannelIcon({ channel, isVoiceActive }: { channel: ChannelRow; isVoiceActive: boolean }) {
-  const iconStyle = { color: isVoiceActive ? '#23a55a' : undefined }
+  const iconStyle = { color: isVoiceActive ? 'var(--theme-success)' : undefined }
   switch (channel.type) {
     case "voice":        return <Volume2 className="w-4 h-4 flex-shrink-0" style={iconStyle} />
     case "forum":        return <MessageSquare className="w-4 h-4 flex-shrink-0 tertiary-metadata" />
@@ -997,12 +997,12 @@ function SortableChannelItem({
               {showBadge && (mentionCount ?? 0) > 0 ? (
                 <span
                   className="min-w-[18px] h-[18px] rounded-full flex items-center justify-center text-[11px] font-bold text-white px-1"
-                  style={{ background: "#f23f43" }}
+                  style={{ background: "var(--theme-danger)" }}
                 >
                   {(mentionCount ?? 0) > 99 ? "99+" : mentionCount}
                 </span>
               ) : showBadge ? (
-                <span className="w-2 h-2 rounded-full" style={{ background: "#f2f3f5" }} />
+                <span className="w-2 h-2 rounded-full" style={{ background: "var(--theme-text-primary)" }} />
               ) : null}
               {(activeThreadCount ?? 0) > 0 && (
                 <span
@@ -1046,24 +1046,24 @@ function SortableChannelItem({
               <div
                 key={participant.user_id}
                 className="flex items-center gap-2 px-2 py-1 rounded text-xs hover:bg-white/5"
-                style={{ color: "#b5bac1" }}
+                style={{ color: "var(--theme-text-secondary)" }}
               >
                 <Avatar className="w-5 h-5 flex-shrink-0">
                   {participant.user?.avatar_url && (
                     <AvatarImage src={participant.user.avatar_url} />
                   )}
                   <AvatarFallback
-                    style={{ background: "#5865f2", color: "white", fontSize: "8px" }}
+                    style={{ background: "var(--theme-accent)", color: "white", fontSize: "8px" }}
                   >
                     {initials}
                   </AvatarFallback>
                 </Avatar>
                 <span className="truncate">{name}</span>
                 {participant.muted && (
-                  <MicOff className="w-3 h-3 flex-shrink-0" style={{ color: "#f23f43" }} />
+                  <MicOff className="w-3 h-3 flex-shrink-0" style={{ color: "var(--theme-danger)" }} />
                 )}
                 {participant.deafened && (
-                  <Headphones className="w-3 h-3 flex-shrink-0" style={{ color: "#f23f43" }} />
+                  <Headphones className="w-3 h-3 flex-shrink-0" style={{ color: "var(--theme-danger)" }} />
                 )}
               </div>
             )

--- a/apps/web/components/layout/member-list.tsx
+++ b/apps/web/components/layout/member-list.tsx
@@ -45,10 +45,10 @@ interface MemberData {
 
 function getStatusColor(status?: string) {
   switch (status) {
-    case "online": return "#23a55a"
-    case "idle": return "#f0b132"
-    case "dnd": return "#f23f43"
-    default: return "#80848e"
+    case "online": return "var(--theme-success)"
+    case "idle": return "var(--theme-warning)"
+    case "dnd": return "var(--theme-danger)"
+    default: return "var(--theme-presence-offline)"
   }
 }
 
@@ -215,7 +215,7 @@ export function MemberList({ serverId }: Props) {
           <div className="mb-2">
             <div
               className="px-4 py-1 text-xs font-semibold uppercase tracking-wider mb-1"
-              style={{ color: "#949ba4" }}
+              style={{ color: "var(--theme-text-muted)" }}
             >
               Online — {onlineMembers.length}
             </div>
@@ -236,7 +236,7 @@ export function MemberList({ serverId }: Props) {
           <div>
             <div
               className="px-4 py-1 text-xs font-semibold uppercase tracking-wider mb-1"
-              style={{ color: "#949ba4" }}
+              style={{ color: "var(--theme-text-muted)" }}
             >
               Offline — {offlineMembers.length}
             </div>
@@ -345,7 +345,7 @@ function MemberItem({
                 {member.user?.avatar_url && <AvatarImage src={member.user.avatar_url} />}
                 <AvatarFallback
                   style={{
-                    background: "#5865f2",
+                    background: "var(--theme-accent)",
                     color: "white",
                     fontSize: "12px",
                     opacity: offline ? 0.5 : 1,
@@ -358,7 +358,7 @@ function MemberItem({
                 className="absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-2"
                 style={{
                   background: getStatusColor(presence?.status),
-                  borderColor: "#2b2d31",
+                  borderColor: "var(--theme-bg-secondary)",
                 }}
               />
             </div>
@@ -367,13 +367,13 @@ function MemberItem({
               <div
                 className="text-sm font-medium truncate"
                 style={{
-                  color: roleColor ?? (offline ? "#4e5058" : "#dcddde"),
+                  color: roleColor ?? (offline ? "var(--theme-text-faint)" : "var(--theme-text-normal)"),
                 }}
               >
                 {displayName}
               </div>
               {member.user?.status_message && !offline && (
-                <div className="text-xs truncate" style={{ color: "#949ba4" }}>
+                <div className="text-xs truncate" style={{ color: "var(--theme-text-muted)" }}>
                   {member.user.status_message}
                 </div>
               )}

--- a/apps/web/components/layout/mobile-nav.tsx
+++ b/apps/web/components/layout/mobile-nav.tsx
@@ -32,7 +32,7 @@ export function MobileMenuButton() {
   return (
     <button
       className="md:hidden w-8 h-8 flex items-center justify-center rounded transition-colors hover:bg-white/10"
-      style={{ color: "#b5bac1" }}
+      style={{ color: "var(--theme-text-secondary)" }}
       onClick={() => setSidebarOpen(!sidebarOpen)}
       aria-label="Toggle sidebar"
     >

--- a/apps/web/components/layout/server-sidebar.tsx
+++ b/apps/web/components/layout/server-sidebar.tsx
@@ -75,7 +75,7 @@ export function ServerSidebar() {
     <TooltipProvider delayDuration={200}>
       <div
         className="flex flex-col items-center w-[72px] py-3 gap-2 flex-shrink-0 overflow-y-auto no-scrollbar"
-        style={{ background: '#1e1f22' }}
+        style={{ background: 'var(--theme-bg-tertiary)' }}
       >
         {/* DMs / Home */}
         <Tooltip>
@@ -90,19 +90,19 @@ export function ServerSidebar() {
                   : "hover:rounded-2xl"
               )}
               style={{
-                background: activeServerId === null ? '#5865f2' : '#313338',
+                background: activeServerId === null ? 'var(--theme-accent)' : 'var(--theme-bg-primary)',
               }}
             >
               <MessageSquare
                 className="w-6 h-6 transition-colors"
-                style={{ color: activeServerId === null ? 'white' : '#949ba4' }}
+                style={{ color: activeServerId === null ? 'white' : 'var(--theme-text-muted)' }}
               />
             </Link>
           </TooltipTrigger>
           <TooltipContent side="right">Direct Messages</TooltipContent>
         </Tooltip>
 
-        <Separator className="w-8 my-1" style={{ background: '#3f4147' }} />
+        <Separator className="w-8 my-1" style={{ background: 'var(--theme-surface-elevated)' }} />
 
         {/* Server list */}
         {servers.map((server) => (
@@ -116,7 +116,7 @@ export function ServerSidebar() {
           />
         ))}
 
-        <Separator className="w-8 my-1" style={{ background: '#3f4147' }} />
+        <Separator className="w-8 my-1" style={{ background: 'var(--theme-surface-elevated)' }} />
 
         {/* Add server */}
         <Tooltip>
@@ -124,9 +124,9 @@ export function ServerSidebar() {
             <button
               onClick={() => setShowCreateServer(true)}
               className="w-12 h-12 rounded-full hover:rounded-2xl flex items-center justify-center cursor-pointer transition-all duration-200 group"
-              style={{ background: '#313338' }}
+              style={{ background: 'var(--theme-bg-primary)' }}
             >
-              <Plus className="w-6 h-6 transition-colors" style={{ color: '#23a55a' }} />
+              <Plus className="w-6 h-6 transition-colors" style={{ color: 'var(--theme-success)' }} />
             </button>
           </TooltipTrigger>
           <TooltipContent side="right">Add a Server</TooltipContent>
@@ -137,9 +137,9 @@ export function ServerSidebar() {
           <TooltipTrigger asChild>
             <button
               className="w-12 h-12 rounded-full hover:rounded-2xl flex items-center justify-center cursor-pointer transition-all duration-200"
-              style={{ background: '#313338' }}
+              style={{ background: 'var(--theme-bg-primary)' }}
             >
-              <Compass className="w-6 h-6" style={{ color: '#23a55a' }} />
+              <Compass className="w-6 h-6" style={{ color: 'var(--theme-success)' }} />
             </button>
           </TooltipTrigger>
           <TooltipContent side="right">Explore Public Servers</TooltipContent>
@@ -189,7 +189,7 @@ function ServerIcon({
                     ? "h-10 -left-3"
                     : "h-5 -left-3 opacity-0 group-hover:opacity-100 group-hover:h-5"
                 )}
-                style={{ background: '#f2f3f5' }}
+                style={{ background: 'var(--theme-text-primary)' }}
               />
               <div
                 className={cn(

--- a/apps/web/components/layout/user-panel.tsx
+++ b/apps/web/components/layout/user-panel.tsx
@@ -14,14 +14,14 @@ import { createClientSupabaseClient } from "@/lib/supabase/client"
 import type { UserRow } from "@/types/database"
 
 const STATUS_OPTIONS: { value: UserRow["status"]; label: string; color: string }[] = [
-  { value: "online", label: "Online", color: "#23a55a" },
-  { value: "idle", label: "Idle", color: "#f0b132" },
-  { value: "dnd", label: "Do Not Disturb", color: "#f23f43" },
-  { value: "invisible", label: "Invisible", color: "#80848e" },
+  { value: "online", label: "Online", color: "var(--theme-success)" },
+  { value: "idle", label: "Idle", color: "var(--theme-warning)" },
+  { value: "dnd", label: "Do Not Disturb", color: "var(--theme-danger)" },
+  { value: "invisible", label: "Invisible", color: "var(--theme-presence-offline)" },
 ]
 
 function getStatusColor(status: string) {
-  return STATUS_OPTIONS.find((o) => o.value === status)?.color ?? "#80848e"
+  return STATUS_OPTIONS.find((o) => o.value === status)?.color ?? "var(--theme-presence-offline)"
 }
 
 /** Bottom-bar user panel with avatar, status selector, mute/deafen/disconnect controls, and settings shortcut. */
@@ -59,7 +59,7 @@ export function UserPanel() {
   return (
     <div
       className="flex items-center gap-2 p-2 border-t"
-      style={{ background: '#232428', borderColor: '#1e1f22' }}
+      style={{ background: '#232428', borderColor: 'var(--theme-bg-tertiary)' }}
     >
       <ContextMenu>
         <ContextMenuTrigger asChild>
@@ -68,7 +68,7 @@ export function UserPanel() {
             <div className="relative flex-shrink-0">
               <Avatar className="w-8 h-8">
                 {currentUser.avatar_url && <AvatarImage src={currentUser.avatar_url} />}
-                <AvatarFallback style={{ background: '#5865f2', color: 'white', fontSize: '12px' }}>
+                <AvatarFallback style={{ background: 'var(--theme-accent)', color: 'white', fontSize: '12px' }}>
                   {initials}
                 </AvatarFallback>
               </Avatar>
@@ -85,11 +85,11 @@ export function UserPanel() {
             <div className="min-w-0">
               <div className="text-xs font-semibold text-white truncate">{displayName}</div>
               {currentUser.status_message ? (
-                <div className="text-xs truncate" style={{ color: '#949ba4' }}>
+                <div className="text-xs truncate" style={{ color: 'var(--theme-text-muted)' }}>
                   {currentUser.status_message}
                 </div>
               ) : (
-                <div className="text-xs" style={{ color: '#949ba4' }}>
+                <div className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>
                   #{currentUser.username}
                 </div>
               )}
@@ -107,7 +107,7 @@ export function UserPanel() {
                 <ContextMenuItem key={value} onClick={() => handleSetStatus(value)}>
                   <Circle className="w-3 h-3 mr-2 fill-current" style={{ color }} />
                   {label}
-                  {currentUser.status === value && <span className="ml-auto text-xs" style={{ color: '#949ba4' }}>&#10003;</span>}
+                  {currentUser.status === value && <span className="ml-auto text-xs" style={{ color: 'var(--theme-text-muted)' }}>&#10003;</span>}
                 </ContextMenuItem>
               ))}
             </ContextMenuSubContent>
@@ -154,7 +154,7 @@ export function UserPanel() {
                   }
                 }}
                 className="w-7 h-7 rounded flex items-center justify-center hover:bg-red-500/20 transition-colors"
-                style={{ color: '#f23f43' }}
+                style={{ color: 'var(--theme-danger)' }}
               >
                 <PhoneOff className="w-4 h-4" />
               </button>
@@ -168,7 +168,7 @@ export function UserPanel() {
             <button
               onClick={() => setMuted(!muted)}
               className="w-7 h-7 rounded flex items-center justify-center hover:bg-white/10 transition-colors"
-              style={{ color: muted ? '#f23f43' : '#949ba4' }}
+              style={{ color: muted ? 'var(--theme-danger)' : 'var(--theme-text-muted)' }}
             >
               {muted ? <MicOff className="w-4 h-4" /> : <Mic className="w-4 h-4" />}
             </button>
@@ -181,7 +181,7 @@ export function UserPanel() {
             <button
               onClick={() => setDeafened(!deafened)}
               className="w-7 h-7 rounded flex items-center justify-center hover:bg-white/10 transition-colors"
-              style={{ color: deafened ? '#f23f43' : '#949ba4' }}
+              style={{ color: deafened ? 'var(--theme-danger)' : 'var(--theme-text-muted)' }}
             >
               <Headphones className="w-4 h-4" />
             </button>
@@ -194,7 +194,7 @@ export function UserPanel() {
             <button
               onClick={() => setShowProfileSettings(true)}
               className="w-7 h-7 rounded flex items-center justify-center hover:bg-white/10 transition-colors"
-              style={{ color: '#949ba4' }}
+              style={{ color: 'var(--theme-text-muted)' }}
             >
               <Settings className="w-4 h-4" />
             </button>

--- a/apps/web/components/modals/audit-log-viewer.tsx
+++ b/apps/web/components/modals/audit-log-viewer.tsx
@@ -16,9 +16,9 @@ interface AuditEntry {
 }
 
 const ACTION_ICONS: Record<string, React.ReactNode> = {
-  kick: <UserX className="w-4 h-4" style={{ color: "#f0b132" }} />,
-  ban: <Ban className="w-4 h-4" style={{ color: "#f23f43" }} />,
-  unban: <Shield className="w-4 h-4" style={{ color: "#23a55a" }} />,
+  kick: <UserX className="w-4 h-4" style={{ color: "var(--theme-warning)" }} />,
+  ban: <Ban className="w-4 h-4" style={{ color: "var(--theme-danger)" }} />,
+  unban: <Shield className="w-4 h-4" style={{ color: "var(--theme-success)" }} />,
 }
 
 const ACTION_LABELS: Record<string, string> = {
@@ -58,12 +58,12 @@ export function AuditLogViewer({ serverId }: { serverId: string }) {
   }
 
   if (loading) {
-    return <div className="flex justify-center py-8"><Loader2 className="animate-spin" style={{ color: "#949ba4" }} /></div>
+    return <div className="flex justify-center py-8"><Loader2 className="animate-spin" style={{ color: "var(--theme-text-muted)" }} /></div>
   }
 
   if (entries.length === 0) {
     return (
-      <div className="text-center py-8" style={{ color: "#949ba4" }}>
+      <div className="text-center py-8" style={{ color: "var(--theme-text-muted)" }}>
         <Shield className="w-10 h-10 mx-auto mb-2 opacity-30" />
         <p className="text-sm">No audit log entries yet.</p>
       </div>
@@ -81,10 +81,10 @@ export function AuditLogViewer({ serverId }: { serverId: string }) {
           <div
             key={entry.id}
             className="flex items-start gap-3 px-3 py-2.5 rounded"
-            style={{ background: "#2b2d31" }}
+            style={{ background: "var(--theme-bg-secondary)" }}
           >
             <div className="flex-shrink-0 mt-0.5">
-              {ACTION_ICONS[entry.action] ?? <Shield className="w-4 h-4" style={{ color: "#949ba4" }} />}
+              {ACTION_ICONS[entry.action] ?? <Shield className="w-4 h-4" style={{ color: "var(--theme-text-muted)" }} />}
             </div>
             <div className="flex-1 min-w-0">
               <p className="text-sm text-white">
@@ -93,10 +93,10 @@ export function AuditLogViewer({ serverId }: { serverId: string }) {
                 <span className="font-semibold text-white">{targetName}</span>
               </p>
               {entry.reason && (
-                <p className="text-xs mt-0.5" style={{ color: "#949ba4" }}>Reason: {entry.reason}</p>
+                <p className="text-xs mt-0.5" style={{ color: "var(--theme-text-muted)" }}>Reason: {entry.reason}</p>
               )}
             </div>
-            <span className="text-xs flex-shrink-0 mt-0.5" style={{ color: "#4e5058" }}>
+            <span className="text-xs flex-shrink-0 mt-0.5" style={{ color: "var(--theme-text-faint)" }}>
               {format(new Date(entry.created_at), "MMM d, h:mm a")}
             </span>
           </div>
@@ -108,7 +108,7 @@ export function AuditLogViewer({ serverId }: { serverId: string }) {
           onClick={loadMore}
           disabled={loadingMore}
           className="w-full text-center text-sm py-2 rounded transition-colors hover:bg-white/5"
-          style={{ color: "#949ba4" }}
+          style={{ color: "var(--theme-text-muted)" }}
         >
           {loadingMore ? <Loader2 className="w-4 h-4 animate-spin mx-auto" /> : "Load more"}
         </button>

--- a/apps/web/components/modals/channel-permissions-editor.tsx
+++ b/apps/web/components/modals/channel-permissions-editor.tsx
@@ -95,36 +95,36 @@ export function ChannelPermissionsEditor({ channelId, serverId }: { channelId: s
 
   const unusedRoles = roles.filter((r) => !perms.find((p) => p.role_id === r.id))
 
-  if (loading) return <div className="flex justify-center py-4"><Loader2 className="animate-spin" style={{ color: "#949ba4" }} /></div>
+  if (loading) return <div className="flex justify-center py-4"><Loader2 className="animate-spin" style={{ color: "var(--theme-text-muted)" }} /></div>
 
   return (
     <div className="flex gap-3 h-72">
       {/* Role list */}
       <div className="w-40 flex-shrink-0 space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: "#949ba4" }}>Roles</p>
+        <p className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: "var(--theme-text-muted)" }}>Roles</p>
         {perms.map((p) => (
           <button
             key={p.role_id}
             onClick={() => setSelected(p)}
             className="w-full flex items-center gap-2 px-2 py-1.5 rounded text-sm text-left"
-            style={{ background: selected?.role_id === p.role_id ? "rgba(255,255,255,0.1)" : "transparent", color: "#f2f3f5" }}
+            style={{ background: selected?.role_id === p.role_id ? "rgba(255,255,255,0.1)" : "transparent", color: "var(--theme-text-primary)" }}
           >
             <span className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ background: p.role.color }} />
             <span className="truncate flex-1">{p.role.name}</span>
-            <button onClick={(e) => { e.stopPropagation(); remove(p.role_id) }} style={{ color: "#f23f43" }}>
+            <button onClick={(e) => { e.stopPropagation(); remove(p.role_id) }} style={{ color: "var(--theme-danger)" }}>
               <Trash2 className="w-3 h-3" />
             </button>
           </button>
         ))}
         {unusedRoles.length > 0 && (
-          <div className="pt-2 border-t" style={{ borderColor: "#3f4147" }}>
-            <p className="text-xs mb-1" style={{ color: "#4e5058" }}>Add override</p>
+          <div className="pt-2 border-t" style={{ borderColor: "var(--theme-surface-elevated)" }}>
+            <p className="text-xs mb-1" style={{ color: "var(--theme-text-faint)" }}>Add override</p>
             {unusedRoles.map((r) => (
               <button
                 key={r.id}
                 onClick={() => addRole(r)}
                 className="w-full flex items-center gap-2 px-2 py-1 rounded text-xs text-left hover:bg-white/5"
-                style={{ color: "#b5bac1" }}
+                style={{ color: "var(--theme-text-secondary)" }}
               >
                 <Plus className="w-3 h-3" />
                 <span className="truncate">{r.name}</span>
@@ -137,13 +137,13 @@ export function ChannelPermissionsEditor({ channelId, serverId }: { channelId: s
       {/* Permission editor */}
       {selected ? (
         <div className="flex-1 overflow-y-auto space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: "#949ba4" }}>
+          <p className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: "var(--theme-text-muted)" }}>
             Permissions for <span style={{ color: selected.role.color }}>{selected.role.name}</span>
           </p>
           <div className="grid grid-cols-[1fr_auto_auto] gap-x-4 gap-y-2 items-center">
-            <span className="text-xs font-medium" style={{ color: "#b5bac1" }}>Permission</span>
-            <span className="text-xs text-center" style={{ color: "#23a55a" }}>Allow</span>
-            <span className="text-xs text-center" style={{ color: "#f23f43" }}>Deny</span>
+            <span className="text-xs font-medium" style={{ color: "var(--theme-text-secondary)" }}>Permission</span>
+            <span className="text-xs text-center" style={{ color: "var(--theme-success)" }}>Allow</span>
+            <span className="text-xs text-center" style={{ color: "var(--theme-danger)" }}>Deny</span>
             {PERM_LIST.map(({ key, label }) => (
               <>
                 <span key={`${key}-label`} className="text-sm text-white">{label}</span>
@@ -164,13 +164,13 @@ export function ChannelPermissionsEditor({ channelId, serverId }: { channelId: s
             onClick={save}
             disabled={saving}
             className="mt-3 px-3 py-1.5 rounded text-sm font-semibold"
-            style={{ background: "#5865f2", color: "white" }}
+            style={{ background: "var(--theme-accent)", color: "white" }}
           >
             {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : "Save"}
           </button>
         </div>
       ) : (
-        <div className="flex-1 flex items-center justify-center text-sm" style={{ color: "#4e5058" }}>
+        <div className="flex-1 flex items-center justify-center text-sm" style={{ color: "var(--theme-text-faint)" }}>
           Select a role to edit permissions
         </div>
       )}

--- a/apps/web/components/modals/create-channel-modal.tsx
+++ b/apps/web/components/modals/create-channel-modal.tsx
@@ -153,28 +153,28 @@ export function CreateChannelModal({ open, onClose, serverId, categoryId }: Prop
 
   function getInputIcon() {
     switch (type) {
-      case "voice": return <Volume2 className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: '#949ba4' }} />
-      case "forum": return <MessageSquare className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: '#949ba4' }} />
-      case "announcement": return <Megaphone className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: '#949ba4' }} />
-      case "media": return <Image className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: '#949ba4' }} />
-      case "stage": return <Mic2 className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: '#949ba4' }} />
-      default: return <Hash className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: '#949ba4' }} />
+      case "voice": return <Volume2 className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: 'var(--theme-text-muted)' }} />
+      case "forum": return <MessageSquare className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: 'var(--theme-text-muted)' }} />
+      case "announcement": return <Megaphone className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: 'var(--theme-text-muted)' }} />
+      case "media": return <Image className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: 'var(--theme-text-muted)' }} />
+      case "stage": return <Mic2 className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: 'var(--theme-text-muted)' }} />
+      default: return <Hash className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: 'var(--theme-text-muted)' }} />
     }
   }
 
   return (
     <Dialog open={open} onOpenChange={resetForm}>
-      <DialogContent style={{ background: '#313338', borderColor: '#1e1f22', maxWidth: '460px' }}>
+      <DialogContent style={{ background: 'var(--theme-bg-primary)', borderColor: 'var(--theme-bg-tertiary)', maxWidth: '460px' }}>
         <DialogHeader>
           <DialogTitle className="text-white">Create Channel</DialogTitle>
           {categoryId && (
-            <p className="text-sm" style={{ color: '#b5bac1' }}>in a category</p>
+            <p className="text-sm" style={{ color: 'var(--theme-text-secondary)' }}>in a category</p>
           )}
         </DialogHeader>
 
         <div className="space-y-4">
           <div>
-            <Label className="text-xs font-semibold uppercase tracking-wider mb-3 block" style={{ color: '#b5bac1' }}>
+            <Label className="text-xs font-semibold uppercase tracking-wider mb-3 block" style={{ color: 'var(--theme-text-secondary)' }}>
               Channel Type
             </Label>
             <div className="space-y-2">
@@ -184,14 +184,14 @@ export function CreateChannelModal({ open, onClose, serverId, categoryId }: Prop
                   onClick={() => setType(t)}
                   className="w-full flex items-center gap-3 p-3 rounded cursor-pointer transition-colors text-left"
                   style={{
-                    background: type === t ? '#5865f2' : '#2b2d31',
-                    border: `1px solid ${type === t ? '#5865f2' : 'transparent'}`,
+                    background: type === t ? 'var(--theme-accent)' : 'var(--theme-bg-secondary)',
+                    border: `1px solid ${type === t ? 'var(--theme-accent)' : 'transparent'}`,
                   }}
                 >
-                  <span style={{ color: type === t ? 'white' : '#949ba4' }}>{icon}</span>
+                  <span style={{ color: type === t ? 'white' : 'var(--theme-text-muted)' }}>{icon}</span>
                   <div>
                     <div className="font-medium text-white text-sm">{label}</div>
-                    <div className="text-xs" style={{ color: type === t ? 'rgba(255,255,255,0.7)' : '#949ba4' }}>
+                    <div className="text-xs" style={{ color: type === t ? 'rgba(255,255,255,0.7)' : 'var(--theme-text-muted)' }}>
                       {description}
                     </div>
                   </div>
@@ -201,7 +201,7 @@ export function CreateChannelModal({ open, onClose, serverId, categoryId }: Prop
           </div>
 
           <div className="space-y-2">
-            <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+            <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
               Channel Name <span className="text-red-500">*</span>
             </Label>
             <div className="relative">
@@ -220,7 +220,7 @@ export function CreateChannelModal({ open, onClose, serverId, categoryId }: Prop
                 }
                 onKeyDown={(e) => e.key === "Enter" && handleCreate()}
                 className={type !== "category" ? "pl-8" : ""}
-                style={{ background: '#1e1f22', borderColor: '#1e1f22', color: '#f2f3f5' }}
+                style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)' }}
               />
             </div>
           </div>
@@ -230,12 +230,12 @@ export function CreateChannelModal({ open, onClose, serverId, categoryId }: Prop
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                  <Clock className="w-4 h-4" style={{ color: '#949ba4' }} />
+                  <Clock className="w-4 h-4" style={{ color: 'var(--theme-text-muted)' }} />
                   <div>
                     <Label className="text-sm font-medium text-white cursor-pointer" htmlFor="temporary-toggle">
                       Temporary Channel
                     </Label>
-                    <p className="text-xs" style={{ color: '#949ba4' }}>
+                    <p className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>
                       Auto-delete this channel after a set time
                     </p>
                   </div>
@@ -249,7 +249,7 @@ export function CreateChannelModal({ open, onClose, serverId, categoryId }: Prop
 
               {isTemporary && (
                 <div>
-                  <Label className="text-xs font-semibold uppercase tracking-wider mb-2 block" style={{ color: '#b5bac1' }}>
+                  <Label className="text-xs font-semibold uppercase tracking-wider mb-2 block" style={{ color: 'var(--theme-text-secondary)' }}>
                     Delete after
                   </Label>
                   <div className="grid grid-cols-3 gap-2">
@@ -259,9 +259,9 @@ export function CreateChannelModal({ open, onClose, serverId, categoryId }: Prop
                         onClick={() => setExpirySeconds(seconds)}
                         className="py-1.5 px-2 rounded text-sm font-medium transition-colors"
                         style={{
-                          background: expirySeconds === seconds ? '#5865f2' : '#2b2d31',
-                          color: expirySeconds === seconds ? 'white' : '#949ba4',
-                          border: `1px solid ${expirySeconds === seconds ? '#5865f2' : 'transparent'}`,
+                          background: expirySeconds === seconds ? 'var(--theme-accent)' : 'var(--theme-bg-secondary)',
+                          color: expirySeconds === seconds ? 'white' : 'var(--theme-text-muted)',
+                          border: `1px solid ${expirySeconds === seconds ? 'var(--theme-accent)' : 'transparent'}`,
                         }}
                       >
                         {label}
@@ -278,7 +278,7 @@ export function CreateChannelModal({ open, onClose, serverId, categoryId }: Prop
               variant="ghost"
               onClick={resetForm}
               className="flex-1"
-              style={{ color: '#b5bac1' }}
+              style={{ color: 'var(--theme-text-secondary)' }}
             >
               Cancel
             </Button>
@@ -286,7 +286,7 @@ export function CreateChannelModal({ open, onClose, serverId, categoryId }: Prop
               onClick={handleCreate}
               disabled={loading || !name.trim()}
               className="flex-1"
-              style={{ background: '#5865f2' }}
+              style={{ background: 'var(--theme-accent)' }}
             >
               {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Create Channel

--- a/apps/web/components/modals/create-server-modal.tsx
+++ b/apps/web/components/modals/create-server-modal.tsx
@@ -149,12 +149,12 @@ export function CreateServerModal({ open, onClose }: Props) {
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent style={{ background: '#313338', borderColor: '#1e1f22', maxWidth: '440px' }}>
+      <DialogContent style={{ background: 'var(--theme-bg-primary)', borderColor: 'var(--theme-bg-tertiary)', maxWidth: '440px' }}>
         <DialogHeader>
           <DialogTitle className="text-white text-center text-xl">
             {mode === "create" ? "Customize Your Server" : "Join a Server"}
           </DialogTitle>
-          <p className="text-center text-sm" style={{ color: '#b5bac1' }}>
+          <p className="text-center text-sm" style={{ color: 'var(--theme-text-secondary)' }}>
             {mode === "create"
               ? "Give your server a personality with a name and icon."
               : "Enter an invite code to join an existing server."}
@@ -165,21 +165,21 @@ export function CreateServerModal({ open, onClose }: Props) {
           <button
             onClick={() => setMode("create")}
             className={`flex-1 py-2 rounded text-sm font-medium transition-colors ${mode === "create" ? "text-white" : "text-gray-400 hover:text-gray-200"}`}
-            style={{ background: mode === "create" ? '#5865f2' : '#2b2d31' }}
+            style={{ background: mode === "create" ? 'var(--theme-accent)' : 'var(--theme-bg-secondary)' }}
           >
             Create New
           </button>
           <button
             onClick={() => setMode("join")}
             className={`flex-1 py-2 rounded text-sm font-medium transition-colors ${mode === "join" ? "text-white" : "text-gray-400 hover:text-gray-200"}`}
-            style={{ background: mode === "join" ? '#5865f2' : '#2b2d31' }}
+            style={{ background: mode === "join" ? 'var(--theme-accent)' : 'var(--theme-bg-secondary)' }}
           >
             Join Existing
           </button>
           <button
             onClick={() => setMode("template")}
             className={`flex-1 py-2 rounded text-sm font-medium transition-colors ${mode === "template" ? "text-white" : "text-gray-400 hover:text-gray-200"}`}
-            style={{ background: mode === "template" ? '#5865f2' : '#2b2d31' }}
+            style={{ background: mode === "template" ? 'var(--theme-accent)' : 'var(--theme-bg-secondary)' }}
           >
             Import Template
           </button>
@@ -192,14 +192,14 @@ export function CreateServerModal({ open, onClose }: Props) {
               <div
                 onClick={() => fileRef.current?.click()}
                 className="w-20 h-20 rounded-full border-2 border-dashed flex items-center justify-center cursor-pointer hover:border-white/50 transition-colors overflow-hidden"
-                style={{ borderColor: '#4e5058' }}
+                style={{ borderColor: 'var(--theme-text-faint)' }}
               >
                 {iconPreview ? (
                   <img src={iconPreview} alt="" className="w-full h-full object-cover" />
                 ) : (
                   <div className="text-center">
-                    <Upload className="w-5 h-5 mx-auto mb-1" style={{ color: '#949ba4' }} />
-                    <span className="text-xs" style={{ color: '#949ba4' }}>UPLOAD</span>
+                    <Upload className="w-5 h-5 mx-auto mb-1" style={{ color: 'var(--theme-text-muted)' }} />
+                    <span className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>UPLOAD</span>
                   </div>
                 )}
               </div>
@@ -207,7 +207,7 @@ export function CreateServerModal({ open, onClose }: Props) {
             </div>
 
             <div className="space-y-2">
-              <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+              <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
                 Server Name <span className="text-red-500">*</span>
               </Label>
               <Input
@@ -215,7 +215,7 @@ export function CreateServerModal({ open, onClose }: Props) {
                 onChange={(e) => setName(e.target.value)}
                 placeholder="My Awesome Server"
                 onKeyDown={(e) => e.key === "Enter" && handleCreate()}
-                style={{ background: '#1e1f22', borderColor: '#1e1f22', color: '#f2f3f5' }}
+                style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)' }}
               />
             </div>
 
@@ -223,7 +223,7 @@ export function CreateServerModal({ open, onClose }: Props) {
               onClick={handleCreate}
               disabled={loading || !name.trim()}
               className="w-full"
-              style={{ background: '#5865f2' }}
+              style={{ background: 'var(--theme-accent)' }}
             >
               {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Create Server
@@ -232,7 +232,7 @@ export function CreateServerModal({ open, onClose }: Props) {
         ) : mode === "join" ? (
           <div className="space-y-4">
             <div className="space-y-2">
-              <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+              <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
                 Invite Code
               </Label>
               <Input
@@ -240,7 +240,7 @@ export function CreateServerModal({ open, onClose }: Props) {
                 onChange={(e) => setJoinCode(e.target.value)}
                 placeholder="e.g. abc123def456"
                 onKeyDown={(e) => e.key === "Enter" && handleJoin()}
-                style={{ background: '#1e1f22', borderColor: '#1e1f22', color: '#f2f3f5' }}
+                style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)' }}
               />
             </div>
 
@@ -248,7 +248,7 @@ export function CreateServerModal({ open, onClose }: Props) {
               onClick={handleJoin}
               disabled={loading || !joinCode.trim()}
               className="w-full"
-              style={{ background: '#5865f2' }}
+              style={{ background: 'var(--theme-accent)' }}
             >
               {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Join Server
@@ -257,14 +257,14 @@ export function CreateServerModal({ open, onClose }: Props) {
         ) : (
           <div className="space-y-3">
             <div className="space-y-2">
-              <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+              <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
                 Server Name <span className="text-red-500">*</span>
               </Label>
               <Input
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Template Powered Server"
-                style={{ background: '#1e1f22', borderColor: '#1e1f22', color: '#f2f3f5' }}
+                style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)' }}
               />
             </div>
             <TemplateManager

--- a/apps/web/components/modals/create-thread-modal.tsx
+++ b/apps/web/components/modals/create-thread-modal.tsx
@@ -46,17 +46,17 @@ export function CreateThreadModal({ open, onClose, messageId, onCreated }: Props
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent style={{ background: "#313338", border: "1px solid #1e1f22", color: "white" }}>
+      <DialogContent style={{ background: "var(--theme-bg-primary)", border: "1px solid var(--theme-bg-tertiary)", color: "white" }}>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-white">
-            <MessageSquare className="w-5 h-5" style={{ color: "#5865f2" }} />
+            <MessageSquare className="w-5 h-5" style={{ color: "var(--theme-accent)" }} />
             Create Thread
           </DialogTitle>
         </DialogHeader>
 
         <div className="space-y-4 pt-2">
           <div className="space-y-2">
-            <Label style={{ color: "#b5bac1" }}>Thread Name</Label>
+            <Label style={{ color: "var(--theme-text-secondary)" }}>Thread Name</Label>
             <Input
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -65,7 +65,7 @@ export function CreateThreadModal({ open, onClose, messageId, onCreated }: Props
               }}
               placeholder="e.g. Discussion about this"
               autoFocus
-              style={{ background: "#1e1f22", border: "1px solid #4e5058", color: "white" }}
+              style={{ background: "var(--theme-bg-tertiary)", border: "1px solid var(--theme-text-faint)", color: "white" }}
             />
           </div>
 
@@ -73,14 +73,14 @@ export function CreateThreadModal({ open, onClose, messageId, onCreated }: Props
             <Button
               variant="ghost"
               onClick={onClose}
-              style={{ color: "#b5bac1" }}
+              style={{ color: "var(--theme-text-secondary)" }}
             >
               Cancel
             </Button>
             <Button
               onClick={handleCreate}
               disabled={!name.trim() || loading}
-              style={{ background: "#5865f2", color: "white" }}
+              style={{ background: "var(--theme-accent)", color: "white" }}
             >
               {loading && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
               Create Thread

--- a/apps/web/components/modals/invite-modal.tsx
+++ b/apps/web/components/modals/invite-modal.tsx
@@ -54,7 +54,7 @@ function CopyButton({ text }: { text: string }) {
       onClick={handleCopy}
       className="w-7 h-7 flex items-center justify-center rounded transition-colors hover:bg-white/10"
       title={copied ? "Copied!" : "Copy link"}
-      style={{ color: copied ? "#23a55a" : "#b5bac1" }}
+      style={{ color: copied ? "var(--theme-success)" : "var(--theme-text-secondary)" }}
     >
       {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
     </button>
@@ -109,33 +109,33 @@ export function InviteModal({ serverId, serverName, onClose }: Props) {
     >
       <div
         className="w-full max-w-lg rounded-xl shadow-2xl overflow-hidden flex flex-col"
-        style={{ background: "#2b2d31", maxHeight: "80vh" }}
+        style={{ background: "var(--theme-bg-secondary)", maxHeight: "80vh" }}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b" style={{ borderColor: "#1e1f22" }}>
+        <div className="flex items-center justify-between px-5 py-4 border-b" style={{ borderColor: "var(--theme-bg-tertiary)" }}>
           <div>
             <h2 className="text-lg font-bold text-white">Invite people to {serverName}</h2>
-            <p className="text-xs mt-0.5" style={{ color: "#949ba4" }}>
+            <p className="text-xs mt-0.5" style={{ color: "var(--theme-text-muted)" }}>
               Share an invite link to let others join
             </p>
           </div>
-          <button onClick={onClose} style={{ color: "#949ba4" }} className="hover:text-white">
+          <button onClick={onClose} style={{ color: "var(--theme-text-muted)" }} className="hover:text-white">
             <X className="w-5 h-5" />
           </button>
         </div>
 
         {/* Create invite */}
-        <div className="px-5 py-4 border-b" style={{ borderColor: "#1e1f22" }}>
+        <div className="px-5 py-4 border-b" style={{ borderColor: "var(--theme-bg-tertiary)" }}>
           <div className="flex gap-3 items-end">
             <div className="flex-1">
-              <label className="text-xs font-semibold uppercase mb-1 block" style={{ color: "#949ba4" }}>
+              <label className="text-xs font-semibold uppercase mb-1 block" style={{ color: "var(--theme-text-muted)" }}>
                 Expire after
               </label>
               <select
                 value={expiresIn ?? ""}
                 onChange={(e) => setExpiresIn(e.target.value ? Number(e.target.value) : null)}
                 className="w-full rounded px-2 py-1.5 text-sm focus:outline-none"
-                style={{ background: "#1e1f22", color: "#f2f3f5", border: "1px solid #3f4147" }}
+                style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-surface-elevated)" }}
               >
                 {EXPIRE_OPTIONS.map((o) => (
                   <option key={o.label} value={o.value ?? ""}>{o.label}</option>
@@ -143,14 +143,14 @@ export function InviteModal({ serverId, serverName, onClose }: Props) {
               </select>
             </div>
             <div className="flex-1">
-              <label className="text-xs font-semibold uppercase mb-1 block" style={{ color: "#949ba4" }}>
+              <label className="text-xs font-semibold uppercase mb-1 block" style={{ color: "var(--theme-text-muted)" }}>
                 Max uses
               </label>
               <select
                 value={maxUses ?? ""}
                 onChange={(e) => setMaxUses(e.target.value ? Number(e.target.value) : null)}
                 className="w-full rounded px-2 py-1.5 text-sm focus:outline-none"
-                style={{ background: "#1e1f22", color: "#f2f3f5", border: "1px solid #3f4147" }}
+                style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-surface-elevated)" }}
               >
                 {USE_OPTIONS.map((o) => (
                   <option key={o.label} value={o.value ?? ""}>{o.label}</option>
@@ -161,7 +161,7 @@ export function InviteModal({ serverId, serverName, onClose }: Props) {
               onClick={handleCreate}
               disabled={creating}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded text-sm font-semibold disabled:opacity-50 transition-colors"
-              style={{ background: "#5865f2", color: "white" }}
+              style={{ background: "var(--theme-accent)", color: "white" }}
             >
               {creating ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
               Create
@@ -173,12 +173,12 @@ export function InviteModal({ serverId, serverName, onClose }: Props) {
         <div className="flex-1 overflow-y-auto px-5 py-3">
           {loading ? (
             <div className="flex items-center justify-center py-8">
-              <Loader2 className="w-5 h-5 animate-spin" style={{ color: "#949ba4" }} />
+              <Loader2 className="w-5 h-5 animate-spin" style={{ color: "var(--theme-text-muted)" }} />
             </div>
           ) : invites.length === 0 ? (
             <div className="text-center py-8">
-              <Link className="w-8 h-8 mx-auto mb-2" style={{ color: "#4e5058" }} />
-              <p className="text-sm" style={{ color: "#949ba4" }}>No invite links yet</p>
+              <Link className="w-8 h-8 mx-auto mb-2" style={{ color: "var(--theme-text-faint)" }} />
+              <p className="text-sm" style={{ color: "var(--theme-text-muted)" }}>No invite links yet</p>
             </div>
           ) : (
             <div className="space-y-2">
@@ -191,7 +191,7 @@ export function InviteModal({ serverId, serverName, onClose }: Props) {
                     key={invite.code}
                     className="flex items-center gap-3 p-3 rounded-lg"
                     style={{
-                      background: "#1e1f22",
+                      background: "var(--theme-bg-tertiary)",
                       opacity: isExpired || isExhausted ? 0.5 : 1,
                     }}
                   >
@@ -199,12 +199,12 @@ export function InviteModal({ serverId, serverName, onClose }: Props) {
                       <div className="flex items-center gap-2">
                         <code className="text-sm font-mono text-white">{invite.code}</code>
                         {(isExpired || isExhausted) && (
-                          <span className="text-xs px-1 rounded" style={{ background: "#f23f43", color: "white" }}>
+                          <span className="text-xs px-1 rounded" style={{ background: "var(--theme-danger)", color: "white" }}>
                             {isExpired ? "Expired" : "Exhausted"}
                           </span>
                         )}
                       </div>
-                      <div className="text-xs mt-0.5 flex gap-2" style={{ color: "#949ba4" }}>
+                      <div className="text-xs mt-0.5 flex gap-2" style={{ color: "var(--theme-text-muted)" }}>
                         <span>{invite.uses}{invite.max_uses ? `/${invite.max_uses}` : ""} uses</span>
                         {invite.expires_at && (
                           <span>· Expires {format(new Date(invite.expires_at), "MMM d, h:mm a")}</span>
@@ -218,7 +218,7 @@ export function InviteModal({ serverId, serverName, onClose }: Props) {
                     <button
                       onClick={() => handleRevoke(invite.code)}
                       className="w-7 h-7 flex items-center justify-center rounded transition-colors hover:bg-red-500/20"
-                      style={{ color: "#f23f43" }}
+                      style={{ color: "var(--theme-danger)" }}
                       title="Revoke"
                     >
                       <Trash2 className="w-4 h-4" />

--- a/apps/web/components/modals/notification-settings-modal.tsx
+++ b/apps/web/components/modals/notification-settings-modal.tsx
@@ -47,14 +47,14 @@ export function NotificationSettingsModal({ open, onClose, serverId, channelId, 
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent style={{ background: "#313338", borderColor: "#1e1f22" }} className="max-w-sm">
+      <DialogContent style={{ background: "var(--theme-bg-primary)", borderColor: "var(--theme-bg-tertiary)" }} className="max-w-sm">
         <DialogHeader>
           <DialogTitle className="text-white">Notification Settings</DialogTitle>
-          <p className="text-sm" style={{ color: "#949ba4" }}>{label}</p>
+          <p className="text-sm" style={{ color: "var(--theme-text-muted)" }}>{label}</p>
         </DialogHeader>
 
         {loading ? (
-          <div className="flex justify-center py-6"><Loader2 className="animate-spin" style={{ color: "#949ba4" }} /></div>
+          <div className="flex justify-center py-6"><Loader2 className="animate-spin" style={{ color: "var(--theme-text-muted)" }} /></div>
         ) : (
           <div className="space-y-2 pt-2">
             {OPTIONS.map((opt) => (
@@ -63,16 +63,16 @@ export function NotificationSettingsModal({ open, onClose, serverId, channelId, 
                 onClick={() => save(opt.mode)}
                 className="w-full flex items-center gap-3 px-4 py-3 rounded-lg text-left transition-colors"
                 style={{
-                  background: mode === opt.mode ? "rgba(88,101,242,0.15)" : "#2b2d31",
-                  border: mode === opt.mode ? "1px solid #5865f2" : "1px solid transparent",
+                  background: mode === opt.mode ? "rgba(88,101,242,0.15)" : "var(--theme-bg-secondary)",
+                  border: mode === opt.mode ? "1px solid var(--theme-accent)" : "1px solid transparent",
                 }}
               >
-                <span style={{ color: mode === opt.mode ? "#5865f2" : "#949ba4" }}>{opt.icon}</span>
+                <span style={{ color: mode === opt.mode ? "var(--theme-accent)" : "var(--theme-text-muted)" }}>{opt.icon}</span>
                 <div>
                   <p className="text-sm font-medium text-white">{opt.label}</p>
-                  <p className="text-xs" style={{ color: "#949ba4" }}>{opt.description}</p>
+                  <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>{opt.description}</p>
                 </div>
-                {saving && mode === opt.mode && <Loader2 className="w-4 h-4 animate-spin ml-auto" style={{ color: "#5865f2" }} />}
+                {saving && mode === opt.mode && <Loader2 className="w-4 h-4 animate-spin ml-auto" style={{ color: "var(--theme-accent)" }} />}
               </button>
             ))}
           </div>

--- a/apps/web/components/modals/profile-settings-modal.tsx
+++ b/apps/web/components/modals/profile-settings-modal.tsx
@@ -24,10 +24,10 @@ interface Props {
 }
 
 const STATUS_OPTIONS = [
-  { value: "online", label: "Online", color: "#23a55a" },
-  { value: "idle", label: "Idle", color: "#f0b132" },
-  { value: "dnd", label: "Do Not Disturb", color: "#f23f43" },
-  { value: "invisible", label: "Invisible", color: "#80848e" },
+  { value: "online", label: "Online", color: "var(--theme-success)" },
+  { value: "idle", label: "Idle", color: "var(--theme-warning)" },
+  { value: "dnd", label: "Do Not Disturb", color: "var(--theme-danger)" },
+  { value: "invisible", label: "Invisible", color: "var(--theme-presence-offline)" },
 ] as const
 
 const BANNER_PRESETS = [
@@ -39,37 +39,64 @@ const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp
 const MAX_AVATAR_SIZE = 5 * 1024 * 1024 // 5MB
 
 const CSS_TEMPLATE = `/**
- * Vortex Custom Theme – BetterDiscord-compatible
+ * Vortex full custom theme template
  *
- * Paste any BetterDiscord / Vencord theme here.
- * @import and url() are supported for HTTPS fonts & images.
- *
- * Example: import a Google Font
- * @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
+ * Override any variable below. Everything in the app reads from these tokens.
  */
 
 :root {
-  /* Override app surface colors */
-  --app-bg-primary: #1e1e2e;
-  --app-bg-secondary: #181825;
-  --app-bg-tertiary: #11111b;
+  /* App shell */
+  --app-bg-primary: #313338;
+  --app-bg-secondary: #2b2d31;
+  --app-bg-tertiary: #1e1f22;
+  --app-accent-color: #5865f2;
 
-  /* Override Tailwind design tokens (HSL without hsl() wrapper) */
-  --background: 240 21% 15%;
-  --card: 240 21% 12%;
-  --popover: 240 24% 10%;
-  --foreground: 226 64% 88%;
-  --muted: 240 14% 28%;
-  --muted-foreground: 228 20% 70%;
-  --border: 240 14% 22%;
-  --input: 240 14% 18%;
-  --primary: 267 84% 81%;
-  --accent: 316 73% 69%;
-  --ring: 267 84% 81%;
+  /* Semantic theme tokens */
+  --theme-bg-primary: #313338;
+  --theme-bg-secondary: #2b2d31;
+  --theme-bg-tertiary: #1e1f22;
+  --theme-surface-elevated: #3f4147;
+  --theme-surface-input: #383a40;
+
+  --theme-text-primary: #f2f3f5;
+  --theme-text-normal: #dcddde;
+  --theme-text-secondary: #b5bac1;
+  --theme-text-muted: #949ba4;
+  --theme-text-faint: #4e5058;
+  --theme-text-bright: #dbdee1;
+
+  --theme-accent: #5865f2;
+  --theme-link: #00a8fc;
+  --theme-success: #23a55a;
+  --theme-positive: #3ba55c;
+  --theme-warning: #f0b132;
+  --theme-danger: #f23f43;
+  --theme-presence-offline: #80848e;
+
+  /* Tailwind tokens (HSL values, no hsl() wrapper) */
+  --background: 223 7% 20%;
+  --foreground: 220 9% 95%;
+  --card: 220 7% 18%;
+  --card-foreground: 220 9% 95%;
+  --popover: 220 7% 14%;
+  --popover-foreground: 220 9% 95%;
+  --primary: 235 86% 65%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 220 6% 18%;
+  --secondary-foreground: 215 8% 73%;
+  --accent: 235 86% 65%;
+  --accent-foreground: 0 0% 100%;
+  --muted: 220 5% 30%;
+  --muted-foreground: 215 8% 60%;
+  --border: 220 6% 25%;
+  --input: 220 6% 18%;
+  --ring: 235 86% 65%;
+  --destructive: 359 87% 57%;
+  --destructive-foreground: 0 0% 100%;
 }
 
-/* Optional: style specific elements */
-.message-content a { color: #89b4fa; }
+/* Optional element-level overrides */
+.message-content a { color: var(--theme-link); }
 `
 
 /** Tabbed user settings dialog covering profile editing, account security (2FA, passkeys, sessions), and appearance preferences. */
@@ -210,23 +237,23 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent
         className="max-w-2xl max-h-[90vh] overflow-hidden p-0"
-        style={{ background: "#313338", borderColor: "#1e1f22" }}
+        style={{ background: "var(--theme-bg-primary)", borderColor: "var(--theme-bg-tertiary)" }}
       >
         <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as "profile" | "security" | "appearance")} orientation="vertical" className="flex h-[80vh]">
           {/* Settings nav */}
-          <div className="w-52 flex-shrink-0 p-4 flex flex-col" style={{ background: "#2b2d31" }}>
-            <h3 className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: "#949ba4" }}>
+          <div className="w-52 flex-shrink-0 p-4 flex flex-col" style={{ background: "var(--theme-bg-secondary)" }}>
+            <h3 className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: "var(--theme-text-muted)" }}>
               User Settings
             </h3>
 
             <TabsList className="flex flex-col h-auto bg-transparent gap-0.5 w-full">
-              <TabsTrigger value="profile" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: "#b5bac1" }}>
+              <TabsTrigger value="profile" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: "var(--theme-text-secondary)" }}>
                 My Account
               </TabsTrigger>
-                <TabsTrigger value="security" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: "#b5bac1" }}>
+                <TabsTrigger value="security" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: "var(--theme-text-secondary)" }}>
                 Security
               </TabsTrigger>
-              <TabsTrigger value="appearance" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: "#b5bac1" }}>
+              <TabsTrigger value="appearance" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: "var(--theme-text-secondary)" }}>
                 Appearance
               </TabsTrigger>
             </TabsList>
@@ -236,16 +263,16 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
           <div className="flex-1 overflow-y-auto p-6">
                 <DialogHeader className="mb-6 space-y-1">
                   <DialogTitle className="text-2xl font-semibold leading-tight text-white">{tabMeta[activeTab].title}</DialogTitle>
-                  <p className="text-sm" style={{ color: "#949ba4" }}>{tabMeta[activeTab].subtitle}</p>
+                  <p className="text-sm" style={{ color: "var(--theme-text-muted)" }}>{tabMeta[activeTab].subtitle}</p>
                 </DialogHeader>
 
                 <TabsContent value="profile" className="mt-0 space-y-8">
                   {/* Profile preview card */}
-                  <div className="rounded-lg overflow-hidden" style={{ border: "1px solid #1e1f22" }}>
+                  <div className="rounded-lg overflow-hidden" style={{ border: "1px solid var(--theme-bg-tertiary)" }}>
                     {/* Banner */}
                     <div
                       className="h-20 relative"
-                      style={{ background: /^#[0-9a-f]{6}$/i.test(bannerColor) ? bannerColor : "#5865f2" }}
+                      style={{ background: /^#[0-9a-f]{6}$/i.test(bannerColor) ? bannerColor : "var(--theme-accent)" }}
                     />
 
                     {/* Avatar */}
@@ -258,7 +285,7 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
                           <Avatar className="w-20 h-20 ring-4" style={{ "--tw-ring-color": "#232428" } as React.CSSProperties}>
                             {avatarPreview && <AvatarImage src={avatarPreview} />}
                             <AvatarFallback
-                              style={{ background: "#5865f2", color: "white", fontSize: "24px" }}
+                              style={{ background: "var(--theme-accent)", color: "white", fontSize: "24px" }}
                             >
                               {displayNamePreview.slice(0, 2).toUpperCase()}
                             </AvatarFallback>
@@ -276,9 +303,9 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
                         />
                       </div>
                       <div className="font-bold text-white">{displayNamePreview}</div>
-                      <div className="text-sm" style={{ color: "#b5bac1" }}>#{user.username}</div>
+                      <div className="text-sm" style={{ color: "var(--theme-text-secondary)" }}>#{user.username}</div>
                       {user.custom_tag && (
-                        <div className="text-xs mt-1" style={{ color: "#949ba4" }}>{user.custom_tag}</div>
+                        <div className="text-xs mt-1" style={{ color: "var(--theme-text-muted)" }}>{user.custom_tag}</div>
                       )}
                     </div>
                   </div>
@@ -286,42 +313,42 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
                   {/* Form fields */}
                   <div className="space-y-5">
                     <div className="space-y-2">
-                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "#b5bac1" }}>
+                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-secondary)" }}>
                         Display Name
                       </Label>
                       <Input
                         value={displayName}
                         onChange={(e) => setDisplayName(e.target.value)}
                         placeholder={user.username}
-                        style={{ background: "#1e1f22", borderColor: "#1e1f22", color: "#f2f3f5" }}
+                        style={{ background: "var(--theme-bg-tertiary)", borderColor: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)" }}
                       />
                     </div>
 
                     <div className="space-y-2">
-                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "#b5bac1" }}>
+                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-secondary)" }}>
                         Username
                       </Label>
                       <Input
                         value={username}
                         onChange={(e) => setUsername(e.target.value)}
-                        style={{ background: "#1e1f22", borderColor: "#1e1f22", color: "#f2f3f5" }}
+                        style={{ background: "var(--theme-bg-tertiary)", borderColor: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)" }}
                       />
                     </div>
 
                     <div className="space-y-2">
-                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "#b5bac1" }}>
+                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-secondary)" }}>
                         Custom Tag / Subtitle
                       </Label>
                       <Input
                         value={customTag}
                         onChange={(e) => setCustomTag(e.target.value)}
                         placeholder="e.g. Game Dev | Coffee Addict"
-                        style={{ background: "#1e1f22", borderColor: "#1e1f22", color: "#f2f3f5" }}
+                        style={{ background: "var(--theme-bg-tertiary)", borderColor: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)" }}
                       />
                     </div>
 
                     <div className="space-y-2">
-                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "#b5bac1" }}>
+                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-secondary)" }}>
                         About Me
                       </Label>
                       <textarea
@@ -331,15 +358,15 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
                         rows={3}
                         maxLength={190}
                         className="w-full rounded px-3 py-2 text-sm resize-none focus:outline-none"
-                        style={{ background: "#1e1f22", color: "#f2f3f5", border: "1px solid #1e1f22" }}
+                        style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-bg-tertiary)" }}
                       />
-                      <div className="text-right text-xs" style={{ color: "#4e5058" }}>
+                      <div className="text-right text-xs" style={{ color: "var(--theme-text-faint)" }}>
                         {bio.length}/190
                       </div>
                     </div>
 
                     <div className="space-y-2">
-                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "#b5bac1" }}>
+                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-secondary)" }}>
                         Status
                       </Label>
                       <div className="grid grid-cols-2 gap-2">
@@ -349,9 +376,9 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
                             onClick={() => setStatus(value)}
                             className="flex items-center gap-2 px-3 py-2 rounded text-sm transition-colors text-left"
                             style={{
-                              background: status === value ? "rgba(255,255,255,0.1)" : "#1e1f22",
-                              border: `1px solid ${status === value ? "#5865f2" : "transparent"}`,
-                              color: "#f2f3f5",
+                              background: status === value ? "rgba(255,255,255,0.1)" : "var(--theme-bg-tertiary)",
+                              border: `1px solid ${status === value ? "var(--theme-accent)" : "transparent"}`,
+                              color: "var(--theme-text-primary)",
                             }}
                           >
                             <span className="w-3 h-3 rounded-full flex-shrink-0" style={{ background: color }} />
@@ -362,7 +389,7 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
                     </div>
 
                     <div className="space-y-2">
-                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "#b5bac1" }}>
+                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-secondary)" }}>
                         Custom Status
                       </Label>
                       <Input
@@ -370,12 +397,12 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
                         onChange={(e) => setStatusMessage(e.target.value)}
                         placeholder="What are you up to?"
                         maxLength={128}
-                        style={{ background: "#1e1f22", borderColor: "#1e1f22", color: "#f2f3f5" }}
+                        style={{ background: "var(--theme-bg-tertiary)", borderColor: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)" }}
                       />
                     </div>
 
                     <div className="space-y-2">
-                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "#b5bac1" }}>
+                      <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-secondary)" }}>
                         Banner Color
                       </Label>
                       <div className="flex flex-wrap gap-2">
@@ -432,18 +459,18 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
                       variant="ghost"
                       onClick={handleLogout}
                       className="w-fit"
-                      style={{ color: "#f23f43", background: "rgba(242,63,67,0.12)" }}
+                      style={{ color: "var(--theme-danger)", background: "rgba(242,63,67,0.12)" }}
                     >
                       <LogOut className="w-4 h-4 mr-2" />
                       Log Out
                     </Button>
                   </div>
 
-                  <div className="flex justify-end gap-2 pt-2 border-t" style={{ borderColor: "#1e1f22" }}>
+                  <div className="flex justify-end gap-2 pt-2 border-t" style={{ borderColor: "var(--theme-bg-tertiary)" }}>
                     <Button
                       onClick={handleSave}
                       disabled={loading}
-                      style={{ background: "#5865f2" }}
+                      style={{ background: "var(--theme-accent)" }}
                     >
                       {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                       Save Changes
@@ -515,23 +542,23 @@ function PasskeysSection() {
     <div className="space-y-4">
       <div>
         <h3 className="text-base font-semibold text-white mb-1">Passkeys</h3>
-        <p className="text-sm" style={{ color: "#949ba4" }}>Passkeys are phishing-resistant and work across biometrics, device PIN, or hardware keys. Keep at least one backup passkey on a second device.</p>
+        <p className="text-sm" style={{ color: "var(--theme-text-muted)" }}>Passkeys are phishing-resistant and work across biometrics, device PIN, or hardware keys. Keep at least one backup passkey on a second device.</p>
       </div>
-      <Button onClick={handleRegisterPasskey} disabled={loading} style={{ background: "#3ba55c" }}>
+      <Button onClick={handleRegisterPasskey} disabled={loading} style={{ background: "var(--theme-positive)" }}>
         {loading ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <KeyRound className="w-4 h-4 mr-2" />} Register Passkey
       </Button>
       <div className="space-y-2">
         {credentials.map((cred) => (
-          <div key={cred.id} className="rounded p-3 flex items-center gap-2" style={{ background: "#2b2d31", border: "1px solid #1e1f22" }}>
+          <div key={cred.id} className="rounded p-3 flex items-center gap-2" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
             <div className="flex-1">
               <p className="text-sm text-white">{cred.name}</p>
-              <p className="text-xs" style={{ color: "#949ba4" }}>Last used: {cred.last_used_at ? new Date(cred.last_used_at).toLocaleString() : "Never"}</p>
+              <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>Last used: {cred.last_used_at ? new Date(cred.last_used_at).toLocaleString() : "Never"}</p>
             </div>
-            <button onClick={() => rename(cred.id)} className="p-2 rounded" style={{ background: "#383a40" }}><Pencil className="w-4 h-4" /></button>
-            <button onClick={() => revoke(cred.id)} className="p-2 rounded" style={{ background: "rgba(242,63,67,0.15)", color: "#f23f43" }}><Trash2 className="w-4 h-4" /></button>
+            <button onClick={() => rename(cred.id)} className="p-2 rounded" style={{ background: "var(--theme-surface-input)" }}><Pencil className="w-4 h-4" /></button>
+            <button onClick={() => revoke(cred.id)} className="p-2 rounded" style={{ background: "rgba(242,63,67,0.15)", color: "var(--theme-danger)" }}><Trash2 className="w-4 h-4" /></button>
           </div>
         ))}
-        {credentials.length === 0 && <p className="text-xs" style={{ color: "#949ba4" }}>No passkeys yet. Add one now and keep password/magic-link recovery enabled until you register a backup device.</p>}
+        {credentials.length === 0 && <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>No passkeys yet. Add one now and keep password/magic-link recovery enabled until you register a backup device.</p>}
       </div>
     </div>
   )
@@ -561,15 +588,15 @@ function SecurityPolicySection() {
     <div className="space-y-4">
       <div className="space-y-1">
         <h3 className="text-base font-semibold text-white">Account Security Policy</h3>
-        <p className="text-sm" style={{ color: "#949ba4" }}>Choose passkey-first login. Owners/admins can optionally enforce passkeys and disable fallback methods.</p>
+        <p className="text-sm" style={{ color: "var(--theme-text-muted)" }}>Choose passkey-first login. Owners/admins can optionally enforce passkeys and disable fallback methods.</p>
       </div>
-      <div className="rounded-lg p-4 space-y-3" style={{ background: "#2b2d31", border: "1px solid #1e1f22" }}>
-        <label className="flex items-center justify-between text-sm" style={{ color: "#b5bac1" }}><span>Passkey-first sign in</span><input type="checkbox" checked={policy.passkey_first} onChange={(e) => save({ ...policy, passkey_first: e.target.checked })} /></label>
-        <label className="flex items-center justify-between text-sm" style={{ color: "#b5bac1" }}><span>Enforce passkey (admins/owners optional)</span><input type="checkbox" checked={policy.enforce_passkey} onChange={(e) => save({ ...policy, enforce_passkey: e.target.checked })} /></label>
-        <label className="flex items-center justify-between text-sm" style={{ color: "#b5bac1" }}><span>Allow password fallback</span><input type="checkbox" checked={policy.fallback_password} onChange={(e) => save({ ...policy, fallback_password: e.target.checked })} disabled={policy.enforce_passkey} /></label>
-        <label className="flex items-center justify-between text-sm" style={{ color: "#b5bac1" }}><span>Allow magic-link fallback</span><input type="checkbox" checked={policy.fallback_magic_link} onChange={(e) => save({ ...policy, fallback_magic_link: e.target.checked })} disabled={policy.enforce_passkey} /></label>
+      <div className="rounded-lg p-4 space-y-3" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
+        <label className="flex items-center justify-between text-sm" style={{ color: "var(--theme-text-secondary)" }}><span>Passkey-first sign in</span><input type="checkbox" checked={policy.passkey_first} onChange={(e) => save({ ...policy, passkey_first: e.target.checked })} /></label>
+        <label className="flex items-center justify-between text-sm" style={{ color: "var(--theme-text-secondary)" }}><span>Enforce passkey (admins/owners optional)</span><input type="checkbox" checked={policy.enforce_passkey} onChange={(e) => save({ ...policy, enforce_passkey: e.target.checked })} /></label>
+        <label className="flex items-center justify-between text-sm" style={{ color: "var(--theme-text-secondary)" }}><span>Allow password fallback</span><input type="checkbox" checked={policy.fallback_password} onChange={(e) => save({ ...policy, fallback_password: e.target.checked })} disabled={policy.enforce_passkey} /></label>
+        <label className="flex items-center justify-between text-sm" style={{ color: "var(--theme-text-secondary)" }}><span>Allow magic-link fallback</span><input type="checkbox" checked={policy.fallback_magic_link} onChange={(e) => save({ ...policy, fallback_magic_link: e.target.checked })} disabled={policy.enforce_passkey} /></label>
       </div>
-      {loading && <p className="text-xs" style={{ color: "#949ba4" }}>Saving policy…</p>}
+      {loading && <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>Saving policy…</p>}
     </div>
   )
 }
@@ -639,16 +666,16 @@ function SessionManagementSection({ onForcedLogout }: { onForcedLogout: () => Pr
     <div className="space-y-4">
       <div className="space-y-1">
         <h3 className="text-base font-semibold text-white">Session Management</h3>
-        <p className="text-sm" style={{ color: "#949ba4" }}>Mark devices as trusted to reduce repeated prompts. If a device is lost, revoke all sessions immediately.</p>
+        <p className="text-sm" style={{ color: "var(--theme-text-muted)" }}>Mark devices as trusted to reduce repeated prompts. If a device is lost, revoke all sessions immediately.</p>
       </div>
-      <div className="rounded-lg p-3 space-y-2" style={{ background: "#2b2d31", border: "1px solid #1e1f22" }}>
-        <p className="text-xs" style={{ color: "#949ba4" }}>Active sessions</p>
-        {sessionsError && <p className="text-xs" style={{ color: "#f23f43" }}>{sessionsError}</p>}
+      <div className="rounded-lg p-3 space-y-2" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
+        <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>Active sessions</p>
+        {sessionsError && <p className="text-xs" style={{ color: "var(--theme-danger)" }}>{sessionsError}</p>}
         {sessions.map((session) => (
           <div key={session.id} className="flex items-center justify-between gap-3">
             <div className="min-w-0">
               <p className="text-xs text-white truncate">{session.user_agent || "Unknown device"}</p>
-              <p className="text-[11px]" style={{ color: "#949ba4" }}>Last seen: {session.last_seen_at ? new Date(session.last_seen_at).toLocaleString() : "Unknown"}</p>
+              <p className="text-[11px]" style={{ color: "var(--theme-text-muted)" }}>Last seen: {session.last_seen_at ? new Date(session.last_seen_at).toLocaleString() : "Unknown"}</p>
             </div>
             <Button size="sm" variant="ghost" disabled={Boolean(session.revoked_at)} onClick={() => revokeSession(session.id)}>{session.revoked_at ? "Revoked" : "Revoke"}</Button>
           </div>
@@ -656,7 +683,7 @@ function SessionManagementSection({ onForcedLogout }: { onForcedLogout: () => Pr
       </div>
       <div className="rounded-lg p-4 space-y-3" style={{ background: "rgba(242,63,67,0.08)", border: "1px solid rgba(242,63,67,0.35)" }}>
         <p className="text-xs" style={{ color: "#b98f92" }}>This action signs out all active sessions and removes trusted devices.</p>
-        <Button variant="outline" onClick={revokeAll} disabled={loading} style={{ borderColor: "#f23f43", color: "#f23f43", background: "rgba(242,63,67,0.1)" }}>
+        <Button variant="outline" onClick={revokeAll} disabled={loading} style={{ borderColor: "var(--theme-danger)", color: "var(--theme-danger)", background: "rgba(242,63,67,0.1)" }}>
           {loading && <Loader2 className="w-4 h-4 mr-2 animate-spin" />} Revoke All Sessions
         </Button>
       </div>
@@ -678,7 +705,7 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
     <div className="space-y-8">
       <div>
         <h3 className="text-base font-semibold text-white mb-1">Theme Presets</h3>
-        <p className="text-sm mb-4" style={{ color: "#949ba4" }}>
+        <p className="text-sm mb-4" style={{ color: "var(--theme-text-muted)" }}>
           Pick a skin — changes apply instantly. Layer your own CSS on top for full BetterDiscord-style customization.
         </p>
         <div className="grid grid-cols-2 gap-3">
@@ -687,7 +714,7 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
               key: "discord",
               label: "Discord Classic",
               desc: "Familiar dark blue-grey",
-              swatches: ["#313338", "#5865f2", "#23a55a"],
+              swatches: ["var(--theme-bg-primary)", "var(--theme-accent)", "var(--theme-success)"],
             },
             {
               key: "midnight-neon",
@@ -705,7 +732,7 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
               key: "carbon",
               label: "Carbon Glass",
               desc: "Near-black + green",
-              swatches: ["#1f2124", "#3ba55c", "#5b8af0"],
+              swatches: ["#1f2124", "var(--theme-positive)", "#5b8af0"],
             },
           ] as const).map((preset) => (
             <button
@@ -714,9 +741,9 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
               onClick={() => setThemePreset(preset.key)}
               className="rounded-lg border px-3 py-2.5 text-left flex flex-col gap-2"
               style={{
-                background: themePreset === preset.key ? "rgba(88,101,242,0.15)" : "#2b2d31",
-                borderColor: themePreset === preset.key ? "#5865f2" : "#1e1f22",
-                color: themePreset === preset.key ? "#f2f3f5" : "#b5bac1",
+                background: themePreset === preset.key ? "rgba(88,101,242,0.15)" : "var(--theme-bg-secondary)",
+                borderColor: themePreset === preset.key ? "var(--theme-accent)" : "var(--theme-bg-tertiary)",
+                color: themePreset === preset.key ? "var(--theme-text-primary)" : "var(--theme-text-secondary)",
               }}
             >
               <div className="flex items-center justify-between w-full">
@@ -736,7 +763,7 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
       {/* Message Display */}
       <div>
         <h3 className="text-base font-semibold text-white mb-1">Message Display</h3>
-        <p className="text-sm mb-4" style={{ color: "#949ba4" }}>
+        <p className="text-sm mb-4" style={{ color: "var(--theme-text-muted)" }}>
           Choose how messages look in the chat.
         </p>
         <div className="grid grid-cols-2 gap-3">
@@ -746,18 +773,18 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
               onClick={() => setMessageDisplay(mode)}
               className="flex flex-col items-start gap-2 p-3 rounded-lg text-left transition-colors border"
               style={{
-                background: messageDisplay === mode ? "rgba(88,101,242,0.15)" : "#2b2d31",
-                borderColor: messageDisplay === mode ? "#5865f2" : "#1e1f22",
+                background: messageDisplay === mode ? "rgba(88,101,242,0.15)" : "var(--theme-bg-secondary)",
+                borderColor: messageDisplay === mode ? "var(--theme-accent)" : "var(--theme-bg-tertiary)",
               }}
             >
               <div className="w-full space-y-1.5 pointer-events-none">
                 {mode === "cozy" ? (
                   <>
                     <div className="flex items-start gap-2">
-                      <div className="w-6 h-6 rounded-full flex-shrink-0" style={{ background: "#5865f2" }} />
+                      <div className="w-6 h-6 rounded-full flex-shrink-0" style={{ background: "var(--theme-accent)" }} />
                       <div className="flex-1 space-y-1">
-                        <div className="h-2 rounded w-16" style={{ background: "#f2f3f5" }} />
-                        <div className="h-2 rounded w-24" style={{ background: "#949ba4" }} />
+                        <div className="h-2 rounded w-16" style={{ background: "var(--theme-text-primary)" }} />
+                        <div className="h-2 rounded w-24" style={{ background: "var(--theme-text-muted)" }} />
                       </div>
                     </div>
                   </>
@@ -765,15 +792,15 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
                   <>
                     {[28, 20, 24, 16].map((w, i) => (
                       <div key={i} className="flex items-center gap-1.5 h-2.5">
-                        <div className="w-5 h-1.5 rounded flex-shrink-0" style={{ background: "#4e5058" }} />
-                        <div className="h-1.5 rounded" style={{ background: "#949ba4", width: `${w}px` }} />
+                        <div className="w-5 h-1.5 rounded flex-shrink-0" style={{ background: "var(--theme-text-faint)" }} />
+                        <div className="h-1.5 rounded" style={{ background: "var(--theme-text-muted)", width: `${w}px` }} />
                         <div className="h-1.5 rounded flex-1" style={{ background: "#72767d" }} />
                       </div>
                     ))}
                   </>
                 )}
               </div>
-              <span className="text-sm font-medium capitalize" style={{ color: messageDisplay === mode ? "#f2f3f5" : "#b5bac1" }}>
+              <span className="text-sm font-medium capitalize" style={{ color: messageDisplay === mode ? "var(--theme-text-primary)" : "var(--theme-text-secondary)" }}>
                 {mode}
               </span>
             </button>
@@ -783,8 +810,8 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
 
       <div>
         <h3 className="text-base font-semibold text-white mb-1">Custom CSS</h3>
-        <p className="text-sm mb-3" style={{ color: "#949ba4" }}>
-          Paste any BetterDiscord / Vencord theme here — <code className="rounded px-1 text-xs" style={{ background: "#1e1f22", color: "#dcddde" }}>@import</code> and <code className="rounded px-1 text-xs" style={{ background: "#1e1f22", color: "#dcddde" }}>url()</code> are supported for HTTPS resources. Your CSS is injected on top of the preset, so you have full control.
+        <p className="text-sm mb-3" style={{ color: "var(--theme-text-muted)" }}>
+          Paste your full theme CSS here. Override the global tokens in the template (or add your own selectors). Your CSS is injected on top of the selected preset, so custom tokens and rules apply app-wide instantly.
         </p>
         <textarea
           value={customCss}
@@ -792,7 +819,7 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
           placeholder={CSS_TEMPLATE}
           spellCheck={false}
           className="w-full min-h-[240px] rounded-lg border p-3 text-xs font-mono leading-relaxed"
-          style={{ background: "#1e1f22", borderColor: customCss.length > 50000 ? "#f23f43" : "#1e1f22", color: "#dcddde", resize: "vertical" }}
+          style={{ background: "var(--theme-bg-tertiary)", borderColor: customCss.length > 50000 ? "var(--theme-danger)" : "var(--theme-bg-tertiary)", color: "var(--theme-text-normal)", resize: "vertical" }}
         />
         <div className="mt-1.5 flex items-center justify-between">
           <div className="flex gap-2">
@@ -809,12 +836,12 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
               Copy Template
             </Button>
             {customCss.trim() && (
-              <Button type="button" variant="outline" size="sm" onClick={() => setCustomCss("")} style={{ color: "#f23f43", borderColor: "rgba(242,63,67,0.4)" }}>
+              <Button type="button" variant="outline" size="sm" onClick={() => setCustomCss("")} style={{ color: "var(--theme-danger)", borderColor: "rgba(242,63,67,0.4)" }}>
                 Clear
               </Button>
             )}
           </div>
-          <span className="text-xs tabular-nums" style={{ color: customCss.length > 50000 ? "#f23f43" : "#4e5058" }}>
+          <span className="text-xs tabular-nums" style={{ color: customCss.length > 50000 ? "var(--theme-danger)" : "var(--theme-text-faint)" }}>
             {customCss.length.toLocaleString()} / 50,000
           </span>
         </div>
@@ -823,7 +850,7 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
       {/* Font Size */}
       <div>
         <h3 className="text-base font-semibold text-white mb-1">Chat Font Scaling</h3>
-        <p className="text-sm mb-4" style={{ color: "#949ba4" }}>
+        <p className="text-sm mb-4" style={{ color: "var(--theme-text-muted)" }}>
           Choose a comfortable size for reading messages.
         </p>
         <div className="flex items-center gap-3">
@@ -833,9 +860,9 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
               onClick={() => setFontScale(scale)}
               className="flex-1 py-2 rounded-lg text-sm font-medium transition-colors border capitalize"
               style={{
-                background: fontScale === scale ? "rgba(88,101,242,0.15)" : "#2b2d31",
-                borderColor: fontScale === scale ? "#5865f2" : "#1e1f22",
-                color: fontScale === scale ? "#f2f3f5" : "#b5bac1",
+                background: fontScale === scale ? "rgba(88,101,242,0.15)" : "var(--theme-bg-secondary)",
+                borderColor: fontScale === scale ? "var(--theme-accent)" : "var(--theme-bg-tertiary)",
+                color: fontScale === scale ? "var(--theme-text-primary)" : "var(--theme-text-secondary)",
                 fontSize: scale === "small" ? "13px" : scale === "large" ? "15px" : "14px",
               }}
             >
@@ -850,11 +877,11 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
         <h3 className="text-base font-semibold text-white mb-1">Accessibility</h3>
         <div
           className="flex items-center justify-between p-3 rounded-lg"
-          style={{ background: "#2b2d31", border: "1px solid #1e1f22" }}
+          style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}
         >
           <div>
             <p className="text-sm font-medium text-white">Reduced Saturation</p>
-            <p className="text-xs mt-0.5" style={{ color: "#949ba4" }}>
+            <p className="text-xs mt-0.5" style={{ color: "var(--theme-text-muted)" }}>
               Desaturates interface colors for color-sensitivity.
             </p>
           </div>
@@ -863,7 +890,7 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
             aria-checked={saturation === "reduced"}
             onClick={() => setSaturation(saturation === "reduced" ? "normal" : "reduced")}
             className="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full transition-colors duration-200"
-            style={{ background: saturation === "reduced" ? "#5865f2" : "#4e5058" }}
+            style={{ background: saturation === "reduced" ? "var(--theme-accent)" : "var(--theme-text-faint)" }}
           >
             <span
               className="pointer-events-none inline-block h-5 w-5 transform rounded-full shadow ring-0 transition duration-200 ease-in-out mt-0.5"
@@ -878,7 +905,7 @@ function AppearanceTab({ onSave, saving }: { onSave: () => Promise<void>; saving
       </div>
 
       <div className="flex justify-end">
-        <Button onClick={onSave} disabled={saving} style={{ background: "#5865f2" }}>
+        <Button onClick={onSave} disabled={saving} style={{ background: "var(--theme-accent)" }}>
           {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Save Theme & Appearance
         </Button>
       </div>
@@ -963,37 +990,37 @@ function TwoFactorSection({ supabase, toast }: { supabase: ReturnType<typeof imp
   const has2FA = verified.length > 0
 
   if (loading) {
-    return <div className="flex justify-center py-8"><Loader2 className="animate-spin" style={{ color: "#949ba4" }} /></div>
+    return <div className="flex justify-center py-8"><Loader2 className="animate-spin" style={{ color: "var(--theme-text-muted)" }} /></div>
   }
 
   return (
     <div className="space-y-6">
       <div>
         <h3 className="text-base font-semibold text-white mb-1">Two-Factor Authentication</h3>
-        <p className="text-sm" style={{ color: "#949ba4" }}>
+        <p className="text-sm" style={{ color: "var(--theme-text-muted)" }}>
           Add an extra layer of security to your account using an authenticator app (Google Authenticator, Authy, etc.).
         </p>
       </div>
 
       {/* Current 2FA status */}
-      <div className="rounded-lg p-4 flex items-center gap-3" style={{ background: has2FA ? "rgba(35,165,90,0.1)" : "#2b2d31", border: `1px solid ${has2FA ? "#23a55a" : "#1e1f22"}` }}>
+      <div className="rounded-lg p-4 flex items-center gap-3" style={{ background: has2FA ? "rgba(35,165,90,0.1)" : "var(--theme-bg-secondary)", border: `1px solid ${has2FA ? "var(--theme-success)" : "var(--theme-bg-tertiary)"}` }}>
         {has2FA
-          ? <ShieldCheck className="w-6 h-6 flex-shrink-0" style={{ color: "#23a55a" }} />
-          : <ShieldOff className="w-6 h-6 flex-shrink-0" style={{ color: "#4e5058" }} />}
+          ? <ShieldCheck className="w-6 h-6 flex-shrink-0" style={{ color: "var(--theme-success)" }} />
+          : <ShieldOff className="w-6 h-6 flex-shrink-0" style={{ color: "var(--theme-text-faint)" }} />}
         <div className="flex-1">
           <p className="text-sm font-medium text-white">{has2FA ? "2FA is enabled" : "2FA is not enabled"}</p>
-          <p className="text-xs" style={{ color: "#949ba4" }}>
+          <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>
             {has2FA ? `${verified.length} authenticator app${verified.length > 1 ? "s" : ""} registered.` : "Your account is protected by password only."}
           </p>
         </div>
         {has2FA
           ? (
-            <button onClick={() => handleUnenroll(verified[0].id)} className="px-3 py-1.5 rounded text-sm transition-colors" style={{ background: "rgba(242,63,67,0.15)", color: "#f23f43", border: "1px solid rgba(242,63,67,0.3)" }}>
+            <button onClick={() => handleUnenroll(verified[0].id)} className="px-3 py-1.5 rounded text-sm transition-colors" style={{ background: "rgba(242,63,67,0.15)", color: "var(--theme-danger)", border: "1px solid rgba(242,63,67,0.3)" }}>
               Remove
             </button>
           )
           : !qrCode && (
-            <button onClick={handleEnroll} disabled={enrolling} className="px-3 py-1.5 rounded text-sm font-semibold transition-colors" style={{ background: "#5865f2", color: "white" }}>
+            <button onClick={handleEnroll} disabled={enrolling} className="px-3 py-1.5 rounded text-sm font-semibold transition-colors" style={{ background: "var(--theme-accent)", color: "white" }}>
               {enrolling ? <Loader2 className="w-4 h-4 animate-spin" /> : "Enable 2FA"}
             </button>
           )}
@@ -1001,20 +1028,20 @@ function TwoFactorSection({ supabase, toast }: { supabase: ReturnType<typeof imp
 
       {/* QR code enrollment flow */}
       {qrCode && (
-        <div className="rounded-lg p-4 space-y-4" style={{ background: "#2b2d31", border: "1px solid #1e1f22" }}>
+        <div className="rounded-lg p-4 space-y-4" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
           <p className="text-sm font-medium text-white">Scan with your authenticator app</p>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src={qrCode} alt="2FA QR Code" className="w-40 h-40 rounded bg-white p-2 mx-auto" />
           {secret && (
             <div className="flex items-center gap-2">
-              <code className="flex-1 text-xs px-2 py-1.5 rounded break-all" style={{ background: "#1e1f22", color: "#949ba4", fontFamily: "monospace" }}>{secret}</code>
-              <button onClick={copySecret} className="flex-shrink-0 w-8 h-8 flex items-center justify-center rounded" style={{ background: "#383a40", color: "#b5bac1" }} title="Copy secret">
-                {copied ? <Check className="w-4 h-4" style={{ color: "#23a55a" }} /> : <Copy className="w-4 h-4" />}
+              <code className="flex-1 text-xs px-2 py-1.5 rounded break-all" style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-muted)", fontFamily: "monospace" }}>{secret}</code>
+              <button onClick={copySecret} className="flex-shrink-0 w-8 h-8 flex items-center justify-center rounded" style={{ background: "var(--theme-surface-input)", color: "var(--theme-text-secondary)" }} title="Copy secret">
+                {copied ? <Check className="w-4 h-4" style={{ color: "var(--theme-success)" }} /> : <Copy className="w-4 h-4" />}
               </button>
             </div>
           )}
           <div className="space-y-2">
-            <p className="text-sm" style={{ color: "#b5bac1" }}>Enter the 6-digit code from your app to confirm:</p>
+            <p className="text-sm" style={{ color: "var(--theme-text-secondary)" }}>Enter the 6-digit code from your app to confirm:</p>
             <div className="flex gap-2">
               <input
                 type="text"
@@ -1024,12 +1051,12 @@ function TwoFactorSection({ supabase, toast }: { supabase: ReturnType<typeof imp
                 onChange={(e) => setVerifyCode(e.target.value.replace(/\D/g, ""))}
                 placeholder="000000"
                 className="w-32 px-3 py-2 rounded text-center text-lg tracking-widest focus:outline-none"
-                style={{ background: "#1e1f22", color: "#f2f3f5", border: "1px solid #3f4147", fontFamily: "monospace" }}
+                style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-surface-elevated)", fontFamily: "monospace" }}
               />
-              <button onClick={handleVerify} disabled={verifyCode.length !== 6 || verifying} className="px-4 py-2 rounded font-semibold transition-colors disabled:opacity-50" style={{ background: "#5865f2", color: "white" }}>
+              <button onClick={handleVerify} disabled={verifyCode.length !== 6 || verifying} className="px-4 py-2 rounded font-semibold transition-colors disabled:opacity-50" style={{ background: "var(--theme-accent)", color: "white" }}>
                 {verifying ? <Loader2 className="w-4 h-4 animate-spin" /> : "Verify"}
               </button>
-              <button onClick={() => { setQrCode(null); setSecret(null); setFactorId(null) }} className="px-3 py-2 rounded text-sm" style={{ color: "#949ba4" }}>Cancel</button>
+              <button onClick={() => { setQrCode(null); setSecret(null); setFactorId(null) }} className="px-3 py-2 rounded text-sm" style={{ color: "var(--theme-text-muted)" }}>Cancel</button>
             </div>
           </div>
         </div>

--- a/apps/web/components/modals/quickswitcher-modal.tsx
+++ b/apps/web/components/modals/quickswitcher-modal.tsx
@@ -100,12 +100,12 @@ export function QuickSwitcherModal({ onClose }: Props) {
       style={{ background: "rgba(0,0,0,0.7)" }}
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="w-full max-w-xl rounded-xl overflow-hidden shadow-2xl" style={{ background: "#2b2d31" }}>
+      <div className="w-full max-w-xl rounded-xl overflow-hidden shadow-2xl" style={{ background: "var(--theme-bg-secondary)" }}>
         {/* Search input */}
-        <div className="flex items-center gap-3 px-4 py-3 border-b" style={{ borderColor: "#1e1f22" }}>
+        <div className="flex items-center gap-3 px-4 py-3 border-b" style={{ borderColor: "var(--theme-bg-tertiary)" }}>
           {loading
-            ? <Loader2 className="w-5 h-5 animate-spin flex-shrink-0" style={{ color: "#949ba4" }} />
-            : <Search className="w-5 h-5 flex-shrink-0" style={{ color: "#949ba4" }} />}
+            ? <Loader2 className="w-5 h-5 animate-spin flex-shrink-0" style={{ color: "var(--theme-text-muted)" }} />
+            : <Search className="w-5 h-5 flex-shrink-0" style={{ color: "var(--theme-text-muted)" }} />}
           <input
             ref={inputRef}
             type="text"
@@ -114,7 +114,7 @@ export function QuickSwitcherModal({ onClose }: Props) {
             placeholder="Where would you like to go?"
             className="flex-1 bg-transparent text-white text-sm focus:outline-none"
           />
-          <kbd className="hidden sm:inline-flex items-center px-1.5 py-0.5 rounded text-xs" style={{ background: "#1e1f22", color: "#4e5058" }}>
+          <kbd className="hidden sm:inline-flex items-center px-1.5 py-0.5 rounded text-xs" style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-faint)" }}>
             ESC
           </kbd>
         </div>
@@ -131,15 +131,15 @@ export function QuickSwitcherModal({ onClose }: Props) {
                   style={{ background: selected === i ? "rgba(88,101,242,0.2)" : "transparent" }}
                 >
                   {r.type === "channel" ? (
-                    r.channelType === "voice" ? <Volume2 className="w-4 h-4 flex-shrink-0" style={{ color: "#949ba4" }} /> :
-                    r.channelType === "stage" ? <Mic2 className="w-4 h-4 flex-shrink-0" style={{ color: "#949ba4" }} /> :
-                    r.channelType === "forum" ? <MessageSquare className="w-4 h-4 flex-shrink-0" style={{ color: "#949ba4" }} /> :
-                    r.channelType === "announcement" ? <Megaphone className="w-4 h-4 flex-shrink-0" style={{ color: "#949ba4" }} /> :
-                    r.channelType === "media" ? <Image className="w-4 h-4 flex-shrink-0" style={{ color: "#949ba4" }} /> :
-                    <Hash className="w-4 h-4 flex-shrink-0" style={{ color: "#949ba4" }} />
-                  ) : <Hash className="w-4 h-4 flex-shrink-0" style={{ color: "#949ba4" }} />}
+                    r.channelType === "voice" ? <Volume2 className="w-4 h-4 flex-shrink-0" style={{ color: "var(--theme-text-muted)" }} /> :
+                    r.channelType === "stage" ? <Mic2 className="w-4 h-4 flex-shrink-0" style={{ color: "var(--theme-text-muted)" }} /> :
+                    r.channelType === "forum" ? <MessageSquare className="w-4 h-4 flex-shrink-0" style={{ color: "var(--theme-text-muted)" }} /> :
+                    r.channelType === "announcement" ? <Megaphone className="w-4 h-4 flex-shrink-0" style={{ color: "var(--theme-text-muted)" }} /> :
+                    r.channelType === "media" ? <Image className="w-4 h-4 flex-shrink-0" style={{ color: "var(--theme-text-muted)" }} /> :
+                    <Hash className="w-4 h-4 flex-shrink-0" style={{ color: "var(--theme-text-muted)" }} />
+                  ) : <Hash className="w-4 h-4 flex-shrink-0" style={{ color: "var(--theme-text-muted)" }} />}
                   <span className="text-sm text-white">{r.name}</span>
-                  <span className="text-xs ml-auto" style={{ color: "#4e5058" }}>
+                  <span className="text-xs ml-auto" style={{ color: "var(--theme-text-faint)" }}>
                     {r.type === "channel" ? "Channel" : "Server"}
                   </span>
                 </button>
@@ -149,13 +149,13 @@ export function QuickSwitcherModal({ onClose }: Props) {
         )}
 
         {query && !loading && results.length === 0 && (
-          <div className="px-4 py-6 text-center text-sm" style={{ color: "#949ba4" }}>
+          <div className="px-4 py-6 text-center text-sm" style={{ color: "var(--theme-text-muted)" }}>
             No results for &ldquo;{query}&rdquo;
           </div>
         )}
 
         {!query && (
-          <div className="px-4 py-4 text-xs" style={{ color: "#4e5058" }}>
+          <div className="px-4 py-4 text-xs" style={{ color: "var(--theme-text-faint)" }}>
             <div className="flex justify-between mb-1"><span>Navigate channels</span><span>↑ ↓ to select, ↵ to go</span></div>
             <div className="flex justify-between"><span>Search servers</span><span>Ctrl+K to open</span></div>
           </div>

--- a/apps/web/components/modals/search-modal.tsx
+++ b/apps/web/components/modals/search-modal.tsx
@@ -52,15 +52,15 @@ export function SearchModal({ serverId, onClose, onJumpToMessage }: Props) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center pt-24" style={{ background: "rgba(0,0,0,0.7)" }} onClick={(e) => { if (e.target === e.currentTarget) onClose() }}>
-      <div className="w-full max-w-2xl rounded-xl overflow-hidden shadow-2xl flex flex-col" style={{ background: "#2b2d31", maxHeight: "70vh" }}>
-        <div className="flex items-center gap-3 px-4 py-3 border-b" style={{ borderColor: "#1e1f22" }}>
-          <Search className="w-5 h-5" style={{ color: "#949ba4" }} />
+      <div className="w-full max-w-2xl rounded-xl overflow-hidden shadow-2xl flex flex-col" style={{ background: "var(--theme-bg-secondary)", maxHeight: "70vh" }}>
+        <div className="flex items-center gap-3 px-4 py-3 border-b" style={{ borderColor: "var(--theme-bg-tertiary)" }}>
+          <Search className="w-5 h-5" style={{ color: "var(--theme-text-muted)" }} />
           <input ref={inputRef} type="text" value={query} onChange={handleInput} placeholder="Search… try from:<userId> has:link has:image before:2026-01-01" className="flex-1 bg-transparent text-white text-sm focus:outline-none" />
-          {loading && <Loader2 className="w-4 h-4 animate-spin" style={{ color: "#949ba4" }} />}
+          {loading && <Loader2 className="w-4 h-4 animate-spin" style={{ color: "var(--theme-text-muted)" }} />}
           <button type="button" onClick={onClose}><X className="w-5 h-5" /></button>
         </div>
 
-            <div className="px-4 py-1 text-[11px]" style={{ color: "#949ba4" }}>
+            <div className="px-4 py-1 text-[11px]" style={{ color: "var(--theme-text-muted)" }}>
               Filters: <code className="px-1 py-0.5 rounded bg-black/20">from:user-id</code> <code className="px-1 py-0.5 rounded bg-black/20">has:link</code> <code className="px-1 py-0.5 rounded bg-black/20">has:image</code> <code className="px-1 py-0.5 rounded bg-black/20">before:YYYY-MM-DD</code>
             </div>
 
@@ -69,7 +69,7 @@ export function SearchModal({ serverId, onClose, onJumpToMessage }: Props) {
           : results.length === 0 && !loading ? <div className="px-4 py-10"><BrandedEmptyState icon={Calendar} title="No results" description={`No results for “${query}”.`} /></div>
           : <>
             {loading && results.length === 0 && <div className="space-y-3 px-4 py-4">{Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-12 w-full" />)}</div>}
-            {total > 0 && <div className="px-4 py-2 text-xs" style={{ color: "#949ba4" }}>{total} results</div>}
+            {total > 0 && <div className="px-4 py-2 text-xs" style={{ color: "var(--theme-text-muted)" }}>{total} results</div>}
             {results.map((result) => {
               if (result.type === "message") {
                 const displayName = result.author?.display_name || result.author?.username || "Unknown"

--- a/apps/web/components/modals/server-settings-modal.tsx
+++ b/apps/web/components/modals/server-settings-modal.tsx
@@ -113,26 +113,26 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent
         className="max-w-4xl max-h-[90vh] overflow-hidden p-0"
-        style={{ background: '#313338', borderColor: '#1e1f22' }}
+        style={{ background: 'var(--theme-bg-primary)', borderColor: 'var(--theme-bg-tertiary)' }}
       >
         <Tabs defaultValue="overview" orientation="vertical" className="flex h-[80vh]">
           {/* Settings sidebar */}
-          <div className="w-48 flex-shrink-0 p-4 flex flex-col" style={{ background: '#2b2d31' }}>
-            <h3 className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: '#949ba4' }}>
+          <div className="w-48 flex-shrink-0 p-4 flex flex-col" style={{ background: 'var(--theme-bg-secondary)' }}>
+            <h3 className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: 'var(--theme-text-muted)' }}>
               {liveServer.name}
             </h3>
             <TabsList className="flex flex-col h-auto bg-transparent gap-0.5 w-full">
-              <TabsTrigger value="overview" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: '#b5bac1' }}>
+              <TabsTrigger value="overview" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: 'var(--theme-text-secondary)' }}>
                 Overview
               </TabsTrigger>
-              <TabsTrigger value="invites" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: '#b5bac1' }}>
+              <TabsTrigger value="invites" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: 'var(--theme-text-secondary)' }}>
                 Invites
               </TabsTrigger>
             </TabsList>
-            <p className="mt-3 px-2 text-xs leading-relaxed" style={{ color: '#949ba4' }}>
+            <p className="mt-3 px-2 text-xs leading-relaxed" style={{ color: 'var(--theme-text-muted)' }}>
               Need roles, moderation, integrations, or templates?
             </p>
-            <Button asChild variant="ghost" className="mt-2 justify-start px-2 text-sm" style={{ color: '#b5bac1' }}>
+            <Button asChild variant="ghost" className="mt-2 justify-start px-2 text-sm" style={{ color: 'var(--theme-text-secondary)' }}>
               <Link href={`/channels/${server.id}/settings`} onClick={onClose}>
                 Open Server Settings
               </Link>
@@ -143,19 +143,19 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
           <div className="flex-1 overflow-y-auto p-6">
             <TabsContent value="overview" className="mt-0 space-y-4">
               <div className="space-y-2">
-                <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+                <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
                   Server Name
                 </Label>
                 <Input
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   disabled={!isOwner}
-                  style={{ background: '#1e1f22', borderColor: '#1e1f22', color: '#f2f3f5' }}
+                  style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)' }}
                 />
               </div>
 
               <div className="space-y-2">
-                <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+                <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
                   Description
                 </Label>
                 <textarea
@@ -164,13 +164,13 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
                   disabled={!isOwner}
                   rows={3}
                   className="w-full rounded px-3 py-2 text-sm resize-none focus:outline-none"
-                  style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #1e1f22' }}
+                  style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-bg-tertiary)' }}
                   placeholder="What's this server about?"
                 />
               </div>
 
               {isOwner && (
-                <Button onClick={handleSave} disabled={loading} style={{ background: '#5865f2' }}>
+                <Button onClick={handleSave} disabled={loading} style={{ background: 'var(--theme-accent)' }}>
                   {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                   Save Changes
                 </Button>
@@ -196,7 +196,7 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
 
             <TabsContent value="invites" className="mt-0 space-y-4">
               <div>
-                <Label className="text-xs font-semibold uppercase tracking-wider mb-2 block" style={{ color: '#b5bac1' }}>
+                <Label className="text-xs font-semibold uppercase tracking-wider mb-2 block" style={{ color: 'var(--theme-text-secondary)' }}>
                   Invite Code
                 </Label>
                 <div className="flex gap-2">
@@ -204,13 +204,13 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
                     id="invite-code"
                     value={liveServer.invite_code}
                     readOnly
-                    style={{ background: '#1e1f22', borderColor: '#1e1f22', color: '#f2f3f5' }}
+                    style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)' }}
                   />
                   <Button
                     variant="ghost"
                     size="icon"
                     onClick={copyInvite}
-                    style={{ color: '#949ba4' }}
+                    style={{ color: 'var(--theme-text-muted)' }}
                     aria-label="Copy invite code"
                     aria-describedby="invite-code"
                   >
@@ -222,13 +222,13 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
                 <Button
                   variant="outline"
                   onClick={handleRegenerateInvite}
-                  style={{ borderColor: '#4e5058', color: '#b5bac1', background: 'transparent' }}
+                  style={{ borderColor: 'var(--theme-text-faint)', color: 'var(--theme-text-secondary)', background: 'transparent' }}
                 >
                   <RefreshCw className="mr-2 h-4 w-4" />
                   Regenerate Code
                 </Button>
               )}
-              <p className="text-xs" style={{ color: '#949ba4' }}>
+              <p className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>
                 Share this code with friends to invite them to your server.
               </p>
             </TabsContent>
@@ -238,10 +238,10 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
     </DialogContent>
 
       <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <DialogContent style={{ background: '#313338', borderColor: '#1e1f22', color: '#f2f3f5' }}>
+        <DialogContent style={{ background: 'var(--theme-bg-primary)', borderColor: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)' }}>
           <DialogHeader>
             <DialogTitle>Delete server?</DialogTitle>
-            <DialogDescription style={{ color: '#b5bac1' }}>
+            <DialogDescription style={{ color: 'var(--theme-text-secondary)' }}>
               This action is irreversible and will permanently remove
               <span className="font-semibold text-white"> {liveServer.name}</span>.
             </DialogDescription>
@@ -328,30 +328,30 @@ export function EmojisTab({ serverId }: { serverId: string }) {
     <div className="space-y-4">
       <div>
         <p className="text-white font-semibold mb-0.5">Custom Emoji</p>
-        <p className="text-xs" style={{ color: '#949ba4' }}>
+        <p className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>
           Upload custom emoji to use in messages on this server. Max 256 KB, PNG/GIF/WEBP.
         </p>
-        <p className="text-xs mt-1" style={{ color: '#b5bac1' }}>
+        <p className="text-xs mt-1" style={{ color: 'var(--theme-text-secondary)' }}>
           {emojis.length} / {CUSTOM_EMOJI_LIMIT} custom emojis used.
         </p>
       </div>
 
       {/* Upload form */}
-      <div className="rounded-lg p-4 space-y-3" style={{ background: '#2b2d31', border: '1px solid #1e1f22' }}>
-        <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>Upload Emoji</p>
+      <div className="rounded-lg p-4 space-y-3" style={{ background: 'var(--theme-bg-secondary)', border: '1px solid var(--theme-bg-tertiary)' }}>
+        <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>Upload Emoji</p>
         <div className="flex gap-2 flex-wrap">
           <input
             value={newName}
             onChange={(e) => setNewName(e.target.value.replace(/[^a-z0-9_]/gi, "").toLowerCase())}
             placeholder="emoji_name"
             className="flex-1 min-w-0 px-3 py-2 rounded text-sm focus:outline-none"
-            style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+            style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
           />
           <input ref={fileRef} type="file" accept="image/png,image/gif,image/webp" className="hidden" />
           <button
             onClick={() => fileRef.current?.click()}
             className="px-3 py-2 rounded text-sm transition-colors"
-            style={{ background: '#383a40', color: '#b5bac1' }}
+            style={{ background: 'var(--theme-surface-input)', color: 'var(--theme-text-secondary)' }}
           >
             Choose file
           </button>
@@ -359,7 +359,7 @@ export function EmojisTab({ serverId }: { serverId: string }) {
             onClick={handleUpload}
             disabled={uploading || !newName.trim() || emojis.length >= CUSTOM_EMOJI_LIMIT}
             className="px-3 py-2 rounded text-sm font-semibold disabled:opacity-50"
-            style={{ background: '#5865f2', color: 'white' }}
+            style={{ background: 'var(--theme-accent)', color: 'white' }}
           >
             {uploading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
           </button>
@@ -369,22 +369,22 @@ export function EmojisTab({ serverId }: { serverId: string }) {
       {/* Emoji list */}
       {loading ? (
         <div className="flex justify-center py-6">
-          <Loader2 className="animate-spin" style={{ color: '#949ba4' }} />
+          <Loader2 className="animate-spin" style={{ color: 'var(--theme-text-muted)' }} />
         </div>
       ) : emojis.length === 0 ? (
-        <div className="text-center py-8 text-sm" style={{ color: '#949ba4' }}>
+        <div className="text-center py-8 text-sm" style={{ color: 'var(--theme-text-muted)' }}>
           No custom emoji yet.
         </div>
       ) : (
         <div className="space-y-1">
           {emojis.map((e) => (
-            <div key={e.id} className="flex items-center gap-3 px-3 py-2 rounded-lg" style={{ background: '#2b2d31' }}>
+            <div key={e.id} className="flex items-center gap-3 px-3 py-2 rounded-lg" style={{ background: 'var(--theme-bg-secondary)' }}>
               <img src={e.image_url} alt={e.name} className="w-8 h-8 object-contain rounded" />
               <span className="flex-1 text-sm text-white">:{e.name}:</span>
               <button
                 onClick={() => handleDelete(e.id)}
                 className="w-7 h-7 flex items-center justify-center rounded hover:bg-red-500/20 transition-colors"
-                style={{ color: '#4e5058' }}
+                style={{ color: 'var(--theme-text-faint)' }}
                 title="Delete"
               >
                 <Trash2 className="w-3.5 h-3.5" />
@@ -481,30 +481,30 @@ export function WebhooksTab({ serverId, channels, open }: { serverId: string; ch
     <div className="space-y-4">
       <div>
         <p className="text-white font-semibold mb-0.5 flex items-center gap-2">
-          <Webhook className="w-4 h-4" style={{ color: '#5865f2' }} />
+          <Webhook className="w-4 h-4" style={{ color: 'var(--theme-accent)' }} />
           Webhooks
         </p>
-        <p className="text-xs" style={{ color: '#949ba4' }}>
+        <p className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>
           Create URLs that allow external services to post messages to your server.
         </p>
       </div>
 
       {/* Create form */}
-      <div className="rounded-lg p-4 space-y-3" style={{ background: '#2b2d31', border: '1px solid #1e1f22' }}>
-        <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>New Webhook</p>
+      <div className="rounded-lg p-4 space-y-3" style={{ background: 'var(--theme-bg-secondary)', border: '1px solid var(--theme-bg-tertiary)' }}>
+        <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>New Webhook</p>
         <div className="flex gap-2">
           <input
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
             placeholder="Webhook name"
             className="flex-1 px-3 py-2 rounded text-sm focus:outline-none"
-            style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+            style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
           />
           <select
             value={newChannelId}
             onChange={(e) => setNewChannelId(e.target.value)}
             className="px-2 py-2 rounded text-sm focus:outline-none"
-            style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+            style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
           >
             {channels.map((c) => (
               <option key={c.id} value={c.id}>#{c.name}</option>
@@ -514,7 +514,7 @@ export function WebhooksTab({ serverId, channels, open }: { serverId: string; ch
             onClick={handleCreate}
             disabled={creating || !newChannelId}
             className="px-3 py-2 rounded text-sm font-semibold transition-colors disabled:opacity-50"
-            style={{ background: '#5865f2', color: 'white' }}
+            style={{ background: 'var(--theme-accent)', color: 'white' }}
           >
             {creating ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
           </button>
@@ -524,38 +524,38 @@ export function WebhooksTab({ serverId, channels, open }: { serverId: string; ch
       {/* List */}
       {loading ? (
         <div className="flex justify-center py-6">
-          <Loader2 className="animate-spin" style={{ color: '#949ba4' }} />
+          <Loader2 className="animate-spin" style={{ color: 'var(--theme-text-muted)' }} />
         </div>
       ) : webhooks.length === 0 ? (
-        <div className="text-center py-8 text-sm" style={{ color: '#949ba4' }}>
+        <div className="text-center py-8 text-sm" style={{ color: 'var(--theme-text-muted)' }}>
           No webhooks yet. Create one above.
         </div>
       ) : (
         <div className="space-y-2">
           {webhooks.map((wh) => (
-            <div key={wh.id} className="rounded-lg p-3" style={{ background: '#2b2d31', border: '1px solid #1e1f22' }}>
+            <div key={wh.id} className="rounded-lg p-3" style={{ background: 'var(--theme-bg-secondary)', border: '1px solid var(--theme-bg-tertiary)' }}>
               <div className="flex items-center justify-between gap-2 mb-2">
                 <div>
                   <p className="text-sm font-medium text-white">{wh.name}</p>
-                  <p className="text-xs" style={{ color: '#949ba4' }}>#{channelName(wh.channel_id)}</p>
+                  <p className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>#{channelName(wh.channel_id)}</p>
                 </div>
                 <button
                   onClick={() => handleDelete(wh.id)}
                   className="w-7 h-7 flex items-center justify-center rounded hover:bg-red-500/20 transition-colors"
-                  style={{ color: '#4e5058' }}
+                  style={{ color: 'var(--theme-text-faint)' }}
                   title="Delete"
                 >
                   <Trash2 className="w-3.5 h-3.5" />
                 </button>
               </div>
               <div className="flex items-center gap-2">
-                <code className="flex-1 text-xs px-2 py-1 rounded truncate" style={{ background: '#1e1f22', color: '#949ba4', fontFamily: 'monospace' }}>
+                <code className="flex-1 text-xs px-2 py-1 rounded truncate" style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-muted)', fontFamily: 'monospace' }}>
                   {wh.url}
                 </code>
                 <button
                   onClick={() => copyUrl(wh.id, wh.url)}
                   className="flex-shrink-0 w-7 h-7 flex items-center justify-center rounded transition-colors hover:bg-white/10"
-                  style={{ color: copiedId === wh.id ? '#23a55a' : '#949ba4' }}
+                  style={{ color: copiedId === wh.id ? 'var(--theme-success)' : 'var(--theme-text-muted)' }}
                   title="Copy URL"
                 >
                   {copiedId === wh.id ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
@@ -656,36 +656,36 @@ export function SocialAlertsTab({ serverId, channels, open }: { serverId: string
     <div className="space-y-4">
       <div>
         <p className="text-white font-semibold mb-0.5 flex items-center gap-2">
-          <Radio className="w-4 h-4" style={{ color: '#5865f2' }} />
+          <Radio className="w-4 h-4" style={{ color: 'var(--theme-accent)' }} />
           Social Alerts
         </p>
-        <p className="text-xs" style={{ color: '#949ba4' }}>
+        <p className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>
           Connect RSS feeds and deliver new posts into a designated channel.
         </p>
       </div>
 
-      <div className="rounded-lg p-4 space-y-3" style={{ background: '#2b2d31', border: '1px solid #1e1f22' }}>
-        <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>New RSS Feed Alert</p>
+      <div className="rounded-lg p-4 space-y-3" style={{ background: 'var(--theme-bg-secondary)', border: '1px solid var(--theme-bg-tertiary)' }}>
+        <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>New RSS Feed Alert</p>
         <div className="grid grid-cols-1 md:grid-cols-4 gap-2">
           <input
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
             placeholder="Alert name"
             className="px-3 py-2 rounded text-sm focus:outline-none"
-            style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+            style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
           />
           <input
             value={newFeedUrl}
             onChange={(e) => setNewFeedUrl(e.target.value)}
             placeholder="https://example.com/feed.xml"
             className="md:col-span-2 px-3 py-2 rounded text-sm focus:outline-none"
-            style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+            style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
           />
           <select
             value={newChannelId}
             onChange={(e) => setNewChannelId(e.target.value)}
             className="px-2 py-2 rounded text-sm focus:outline-none"
-            style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+            style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
           >
             {channels.map((c) => (
               <option key={c.id} value={c.id}>#{c.name}</option>
@@ -697,32 +697,32 @@ export function SocialAlertsTab({ serverId, channels, open }: { serverId: string
           onClick={handleCreate}
           disabled={creating || !newChannelId || !newFeedUrl.trim()}
           className="px-3 py-2 rounded text-sm font-semibold transition-colors disabled:opacity-50"
-          style={{ background: '#5865f2', color: 'white' }}
+          style={{ background: 'var(--theme-accent)', color: 'white' }}
         >
           {creating ? <Loader2 className="w-4 h-4 animate-spin" /> : "Create Alert"}
         </button>
       </div>
 
       {loading ? (
-        <div className="flex justify-center py-6"><Loader2 className="animate-spin" style={{ color: '#949ba4' }} /></div>
+        <div className="flex justify-center py-6"><Loader2 className="animate-spin" style={{ color: 'var(--theme-text-muted)' }} /></div>
       ) : alerts.length === 0 ? (
-        <div className="text-center py-8 text-sm" style={{ color: '#949ba4' }}>
+        <div className="text-center py-8 text-sm" style={{ color: 'var(--theme-text-muted)' }}>
           No social alerts yet. Add an RSS feed above.
         </div>
       ) : (
         <div className="space-y-2">
           {alerts.map((alert) => (
-            <div key={alert.id} className="rounded-lg p-3" style={{ background: '#2b2d31', border: '1px solid #1e1f22' }}>
+            <div key={alert.id} className="rounded-lg p-3" style={{ background: 'var(--theme-bg-secondary)', border: '1px solid var(--theme-bg-tertiary)' }}>
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
                   <p className="text-sm font-medium text-white">{alert.name}</p>
-                  <p className="text-xs truncate" style={{ color: '#949ba4' }}>{alert.feed_url}</p>
-                  <p className="text-xs mt-1" style={{ color: '#949ba4' }}>
+                  <p className="text-xs truncate" style={{ color: 'var(--theme-text-muted)' }}>{alert.feed_url}</p>
+                  <p className="text-xs mt-1" style={{ color: 'var(--theme-text-muted)' }}>
                     #{channelName(alert.channel_id)} {alert.last_checked_at ? `• Checked ${new Date(alert.last_checked_at).toLocaleString()}` : ""}
                   </p>
                 </div>
                 <div className="flex items-center gap-2">
-                  <label className="text-xs" style={{ color: '#b5bac1' }}>
+                  <label className="text-xs" style={{ color: 'var(--theme-text-secondary)' }}>
                     <input
                       type="checkbox"
                       checked={alert.enabled}
@@ -735,7 +735,7 @@ export function SocialAlertsTab({ serverId, channels, open }: { serverId: string
                     type="button"
                     onClick={() => handleDelete(alert.id)}
                     className="w-7 h-7 flex items-center justify-center rounded hover:bg-red-500/20 transition-colors"
-                    style={{ color: '#4e5058' }}
+                    style={{ color: 'var(--theme-text-faint)' }}
                     title="Delete"
                   >
                     <Trash2 className="w-3.5 h-3.5" />
@@ -809,31 +809,31 @@ export function ModerationTab({ serverId, open }: { serverId: string; open: bool
     setSaving(false)
   }
 
-  if (loading) return <div className="flex justify-center py-10"><Loader2 className="animate-spin" style={{ color: '#949ba4' }} /></div>
+  if (loading) return <div className="flex justify-center py-10"><Loader2 className="animate-spin" style={{ color: 'var(--theme-text-muted)' }} /></div>
   if (!settings) return null
 
   return (
     <div className="space-y-6">
       <div>
         <p className="text-white font-semibold flex items-center gap-2 mb-0.5">
-          <Shield className="w-4 h-4" style={{ color: '#5865f2' }} />
+          <Shield className="w-4 h-4" style={{ color: 'var(--theme-accent)' }} />
           Moderation Settings
         </p>
-        <p className="text-xs" style={{ color: '#949ba4' }}>
+        <p className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>
           Configure server-level safety and content filters.
         </p>
       </div>
 
       {/* Verification Level */}
       <div className="space-y-2">
-        <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+        <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
           Verification Level
         </Label>
         <select
           value={settings.verification_level}
           onChange={(e) => setSettings({ ...settings, verification_level: Number(e.target.value) })}
           className="w-full px-3 py-2 rounded text-sm focus:outline-none"
-          style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+          style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
         >
           {VERIFICATION_LEVELS.map((v) => (
             <option key={v.value} value={v.value}>{v.label} — {v.description}</option>
@@ -843,14 +843,14 @@ export function ModerationTab({ serverId, open }: { serverId: string; open: bool
 
       {/* Explicit Content Filter */}
       <div className="space-y-2">
-        <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+        <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
           Explicit Content Filter
         </Label>
         <select
           value={settings.explicit_content_filter}
           onChange={(e) => setSettings({ ...settings, explicit_content_filter: Number(e.target.value) })}
           className="w-full px-3 py-2 rounded text-sm focus:outline-none"
-          style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+          style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
         >
           {CONTENT_FILTERS.map((f) => (
             <option key={f.value} value={f.value}>{f.label}</option>
@@ -860,14 +860,14 @@ export function ModerationTab({ serverId, open }: { serverId: string; open: bool
 
       {/* Default Notifications */}
       <div className="space-y-2">
-        <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+        <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
           Default Message Notifications
         </Label>
         <select
           value={settings.default_message_notifications}
           onChange={(e) => setSettings({ ...settings, default_message_notifications: Number(e.target.value) })}
           className="w-full px-3 py-2 rounded text-sm focus:outline-none"
-          style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+          style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
         >
           <option value={0}>All Messages</option>
           <option value={1}>Only @mentions</option>
@@ -875,10 +875,10 @@ export function ModerationTab({ serverId, open }: { serverId: string; open: bool
       </div>
 
       {/* Screening Toggle */}
-      <div className="flex items-center justify-between rounded-lg p-3" style={{ background: '#2b2d31' }}>
+      <div className="flex items-center justify-between rounded-lg p-3" style={{ background: 'var(--theme-bg-secondary)' }}>
         <div>
           <p className="text-sm font-medium text-white">Membership Screening</p>
-          <p className="text-xs" style={{ color: '#949ba4' }}>Require new members to accept rules before participating</p>
+          <p className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>Require new members to accept rules before participating</p>
         </div>
         <button
           onClick={() => setSettings({ ...settings, screening_enabled: !settings.screening_enabled })}
@@ -888,7 +888,7 @@ export function ModerationTab({ serverId, open }: { serverId: string; open: bool
         </button>
       </div>
 
-      <Button onClick={handleSave} disabled={saving} style={{ background: '#5865f2' }}>
+      <Button onClick={handleSave} disabled={saving} style={{ background: 'var(--theme-accent)' }}>
         {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
         Save Changes
       </Button>
@@ -967,48 +967,48 @@ export function ScreeningTab({ serverId, open }: { serverId: string; open: boole
     }
   }
 
-  if (loading) return <div className="flex justify-center py-10"><Loader2 className="animate-spin" style={{ color: '#949ba4' }} /></div>
+  if (loading) return <div className="flex justify-center py-10"><Loader2 className="animate-spin" style={{ color: 'var(--theme-text-muted)' }} /></div>
 
   return (
     <div className="space-y-4">
       <div>
         <p className="text-white font-semibold flex items-center gap-2 mb-0.5">
-          <ShieldCheck className="w-4 h-4" style={{ color: '#5865f2' }} />
+          <ShieldCheck className="w-4 h-4" style={{ color: 'var(--theme-accent)' }} />
           Membership Screening
         </p>
-        <p className="text-xs" style={{ color: '#949ba4' }}>
+        <p className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>
           New members must read and accept these rules before they can send messages.
         </p>
       </div>
 
       <div className="space-y-2">
-        <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>Title</Label>
+        <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>Title</Label>
         <Input
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          style={{ background: '#1e1f22', borderColor: '#3f4147', color: '#f2f3f5' }}
+          style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-surface-elevated)', color: 'var(--theme-text-primary)' }}
         />
       </div>
 
       <div className="space-y-2">
-        <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>Description (optional)</Label>
+        <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>Description (optional)</Label>
         <Input
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           placeholder="A short intro shown above the rules"
-          style={{ background: '#1e1f22', borderColor: '#3f4147', color: '#f2f3f5' }}
+          style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-surface-elevated)', color: 'var(--theme-text-primary)' }}
         />
       </div>
 
       <div className="space-y-2">
-        <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>Rules Text</Label>
+        <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>Rules Text</Label>
         <textarea
           value={rulesText}
           onChange={(e) => setRulesText(e.target.value)}
           rows={8}
           className="w-full rounded px-3 py-2 text-sm resize-none focus:outline-none"
           placeholder="1. Be respectful&#10;2. No spam&#10;..."
-          style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+          style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
         />
       </div>
 
@@ -1023,7 +1023,7 @@ export function ScreeningTab({ serverId, open }: { serverId: string; open: boole
       </div>
 
       <div className="flex gap-2">
-        <Button onClick={handleSave} disabled={saving} style={{ background: '#5865f2' }}>
+        <Button onClick={handleSave} disabled={saving} style={{ background: 'var(--theme-accent)' }}>
           {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           Save Rules
         </Button>
@@ -1289,35 +1289,35 @@ export function AutoModTab({ serverId, channels, open }: { serverId: string; cha
       )
     : null
 
-  if (loading) return <div className="flex justify-center py-10"><Loader2 className="animate-spin" style={{ color: '#949ba4' }} /></div>
+  if (loading) return <div className="flex justify-center py-10"><Loader2 className="animate-spin" style={{ color: 'var(--theme-text-muted)' }} /></div>
 
   return (
     <div className="space-y-4">
       <div className="flex items-start justify-between">
         <div>
           <p className="text-white font-semibold flex items-center gap-2 mb-0.5">
-            <Zap className="w-4 h-4" style={{ color: '#5865f2' }} />
+            <Zap className="w-4 h-4" style={{ color: 'var(--theme-accent)' }} />
             AutoMod Rules
           </p>
-          <p className="text-xs" style={{ color: '#949ba4' }}>
+          <p className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>
             Rules that automatically moderate messages in this server.
           </p>
         </div>
-        <Button size="sm" onClick={startNew} style={{ background: '#5865f2' }}>
+        <Button size="sm" onClick={startNew} style={{ background: 'var(--theme-accent)' }}>
           <Plus className="w-3.5 h-3.5 mr-1" /> New Rule
         </Button>
       </div>
 
       {/* Existing rules list */}
       {rules.length === 0 && editingId !== "new" && (
-        <div className="text-center py-8 text-sm" style={{ color: '#949ba4' }}>
+        <div className="text-center py-8 text-sm" style={{ color: 'var(--theme-text-muted)' }}>
           No AutoMod rules yet. Create one to get started.
         </div>
       )}
 
       <div className="space-y-2">
         {rules.map((rule) => (
-          <div key={rule.id} className="rounded-lg p-3 flex items-center gap-3" style={{ background: '#2b2d31', border: '1px solid #1e1f22' }}>
+          <div key={rule.id} className="rounded-lg p-3 flex items-center gap-3" style={{ background: 'var(--theme-bg-secondary)', border: '1px solid var(--theme-bg-tertiary)' }}>
             <button
               onClick={() => toggleEnabled(rule)}
               className={`relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors ${rule.enabled ? 'bg-indigo-600' : 'bg-gray-600'}`}
@@ -1326,23 +1326,23 @@ export function AutoModTab({ serverId, channels, open }: { serverId: string; cha
             </button>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-white truncate">{rule.name}</p>
-              <p className="text-xs" style={{ color: '#949ba4' }}>{TRIGGER_LABELS[rule.trigger_type] ?? rule.trigger_type}</p>
+              <p className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>{TRIGGER_LABELS[rule.trigger_type] ?? rule.trigger_type}</p>
             </div>
             <div className="flex gap-1.5">
               <button
                 onClick={() => movePriority(rule, -1)}
                 className="text-xs px-2 py-1 rounded transition-colors hover:bg-white/10"
-                style={{ color: '#b5bac1' }}
+                style={{ color: 'var(--theme-text-secondary)' }}
               >↑</button>
               <button
                 onClick={() => movePriority(rule, 1)}
                 className="text-xs px-2 py-1 rounded transition-colors hover:bg-white/10"
-                style={{ color: '#b5bac1' }}
+                style={{ color: 'var(--theme-text-secondary)' }}
               >↓</button>
               <button
                 onClick={() => startEdit(rule)}
                 className="text-xs px-2 py-1 rounded transition-colors hover:bg-white/10"
-                style={{ color: '#b5bac1' }}
+                style={{ color: 'var(--theme-text-secondary)' }}
               >
                 Edit
               </button>
@@ -1360,27 +1360,27 @@ export function AutoModTab({ serverId, channels, open }: { serverId: string; cha
 
       {/* Rule editor form */}
       {editingId !== null && (
-        <div className="rounded-lg p-4 space-y-3" style={{ background: '#2b2d31', border: '1px solid #3f4147' }}>
+        <div className="rounded-lg p-4 space-y-3" style={{ background: 'var(--theme-bg-secondary)', border: '1px solid var(--theme-surface-elevated)' }}>
           <p className="text-sm font-semibold text-white">{editingId === "new" ? "New Rule" : "Edit Rule"}</p>
 
           <div className="space-y-1">
-            <label className="text-xs" style={{ color: '#b5bac1' }}>Rule name</label>
+            <label className="text-xs" style={{ color: 'var(--theme-text-secondary)' }}>Rule name</label>
             <input
               value={form.name}
               onChange={(e) => updateForm("name", e.target.value)}
               placeholder="My Rule"
               className="w-full px-3 py-1.5 rounded text-sm focus:outline-none"
-              style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+              style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
             />
           </div>
 
           <div className="space-y-1">
-            <label className="text-xs" style={{ color: '#b5bac1' }}>Trigger type</label>
+            <label className="text-xs" style={{ color: 'var(--theme-text-secondary)' }}>Trigger type</label>
             <select
               value={form.trigger_type}
               onChange={(e) => updateForm("trigger_type", e.target.value)}
               className="w-full px-3 py-1.5 rounded text-sm focus:outline-none"
-              style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+              style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
             >
               <option value="keyword_filter">Keyword Filter</option>
               <option value="regex_filter">Regex Filter</option>
@@ -1393,34 +1393,34 @@ export function AutoModTab({ serverId, channels, open }: { serverId: string; cha
           {form.trigger_type === "keyword_filter" && (
             <>
               <div className="space-y-1">
-                <label className="text-xs" style={{ color: '#b5bac1' }}>Blocked keywords (comma-separated)</label>
+                <label className="text-xs" style={{ color: 'var(--theme-text-secondary)' }}>Blocked keywords (comma-separated)</label>
                 <input
                   value={form.keywords}
                   onChange={(e) => updateForm("keywords", e.target.value)}
                   placeholder="spam, badword, ..."
                   className="w-full px-3 py-1.5 rounded text-sm focus:outline-none"
-                  style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+                  style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
                 />
               </div>
               <div className="space-y-1">
-                <label className="text-xs" style={{ color: '#b5bac1' }}>Priority (lower runs first)</label>
+                <label className="text-xs" style={{ color: 'var(--theme-text-secondary)' }}>Priority (lower runs first)</label>
                 <input
                   type="number"
                   min={1}
                   value={form.priority}
                   onChange={(e) => updateForm("priority", Number(e.target.value))}
                   className="w-full px-3 py-1.5 rounded text-sm focus:outline-none"
-                  style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+                  style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
                 />
               </div>
               <div className="space-y-1">
-                <label className="text-xs" style={{ color: '#b5bac1' }}>Regex patterns (comma-separated, optional)</label>
+                <label className="text-xs" style={{ color: 'var(--theme-text-secondary)' }}>Regex patterns (comma-separated, optional)</label>
                 <input
                   value={form.regex_patterns}
                   onChange={(e) => updateForm("regex_patterns", e.target.value)}
                   placeholder="\\bspam\\b, ..."
                   className="w-full px-3 py-1.5 rounded text-sm focus:outline-none"
-                  style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+                  style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
                 />
               </div>
             </>
@@ -1428,41 +1428,41 @@ export function AutoModTab({ serverId, channels, open }: { serverId: string; cha
 
           {form.trigger_type === "regex_filter" && (
             <div className="space-y-1">
-              <label className="text-xs" style={{ color: '#b5bac1' }}>Regex patterns (comma-separated)</label>
+              <label className="text-xs" style={{ color: 'var(--theme-text-secondary)' }}>Regex patterns (comma-separated)</label>
               <input
                 value={form.regex_patterns}
                 onChange={(e) => updateForm("regex_patterns", e.target.value)}
                 placeholder="\\bspam\\b, ..."
                 className="w-full px-3 py-1.5 rounded text-sm focus:outline-none"
-                style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+                style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
               />
             </div>
           )}
 
           {form.trigger_type === "mention_spam" && (
             <div className="space-y-1">
-              <label className="text-xs" style={{ color: '#b5bac1' }}>Max mentions per message</label>
+              <label className="text-xs" style={{ color: 'var(--theme-text-secondary)' }}>Max mentions per message</label>
               <input
                 type="number"
                 min={1}
                 value={form.mention_threshold}
                 onChange={(e) => updateForm("mention_threshold", Number(e.target.value))}
                 className="w-full px-3 py-1.5 rounded text-sm focus:outline-none"
-                style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+                style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
               />
             </div>
           )}
 
           {form.trigger_type === "link_spam" && (
             <div className="space-y-1">
-              <label className="text-xs" style={{ color: '#b5bac1' }}>Max links per message</label>
+              <label className="text-xs" style={{ color: 'var(--theme-text-secondary)' }}>Max links per message</label>
               <input
                 type="number"
                 min={1}
                 value={form.link_threshold}
                 onChange={(e) => updateForm("link_threshold", Number(e.target.value))}
                 className="w-full px-3 py-1.5 rounded text-sm focus:outline-none"
-                style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+                style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
               />
             </div>
           )}
@@ -1470,33 +1470,33 @@ export function AutoModTab({ serverId, channels, open }: { serverId: string; cha
           {form.trigger_type === "rapid_message" && (
             <div className="grid grid-cols-2 gap-2">
               <div className="space-y-1">
-                <label className="text-xs" style={{ color: '#b5bac1' }}>Messages in window</label>
-                <input type="number" min={1} value={form.message_threshold} onChange={(e) => updateForm("message_threshold", Number(e.target.value))} className="w-full px-3 py-1.5 rounded text-sm focus:outline-none" style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }} />
+                <label className="text-xs" style={{ color: 'var(--theme-text-secondary)' }}>Messages in window</label>
+                <input type="number" min={1} value={form.message_threshold} onChange={(e) => updateForm("message_threshold", Number(e.target.value))} className="w-full px-3 py-1.5 rounded text-sm focus:outline-none" style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }} />
               </div>
               <div className="space-y-1">
-                <label className="text-xs" style={{ color: '#b5bac1' }}>Window (seconds)</label>
-                <input type="number" min={1} value={form.window_seconds} onChange={(e) => updateForm("window_seconds", Number(e.target.value))} className="w-full px-3 py-1.5 rounded text-sm focus:outline-none" style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }} />
+                <label className="text-xs" style={{ color: 'var(--theme-text-secondary)' }}>Window (seconds)</label>
+                <input type="number" min={1} value={form.window_seconds} onChange={(e) => updateForm("window_seconds", Number(e.target.value))} className="w-full px-3 py-1.5 rounded text-sm focus:outline-none" style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }} />
               </div>
             </div>
           )}
 
           <div className="grid grid-cols-2 gap-2">
             <div className="space-y-1">
-              <label className="text-xs" style={{ color: '#b5bac1' }}>Channel scope (optional)</label>
-              <select value={form.channel_scope} onChange={(e) => updateForm("channel_scope", e.target.value)} className="w-full px-2 py-1 rounded text-sm focus:outline-none" style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}>
+              <label className="text-xs" style={{ color: 'var(--theme-text-secondary)' }}>Channel scope (optional)</label>
+              <select value={form.channel_scope} onChange={(e) => updateForm("channel_scope", e.target.value)} className="w-full px-2 py-1 rounded text-sm focus:outline-none" style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}>
                 <option value="">All channels</option>
                 {channels.map((c) => <option key={c.id} value={c.id}>#{c.name}</option>)}
               </select>
             </div>
             <div className="space-y-1">
-              <label className="text-xs" style={{ color: '#b5bac1' }}>Minimum account age (minutes)</label>
-              <input type="number" min={0} value={form.min_account_age_minutes} onChange={(e) => updateForm("min_account_age_minutes", Number(e.target.value))} className="w-full px-3 py-1.5 rounded text-sm focus:outline-none" style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }} />
+              <label className="text-xs" style={{ color: 'var(--theme-text-secondary)' }}>Minimum account age (minutes)</label>
+              <input type="number" min={0} value={form.min_account_age_minutes} onChange={(e) => updateForm("min_account_age_minutes", Number(e.target.value))} className="w-full px-3 py-1.5 rounded text-sm focus:outline-none" style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }} />
             </div>
           </div>
 
           {/* Actions */}
           <div>
-            <p className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: '#b5bac1' }}>Actions</p>
+            <p className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: 'var(--theme-text-secondary)' }}>Actions</p>
             <div className="space-y-2">
               <label className="flex items-center gap-2 cursor-pointer">
                 <input type="checkbox" checked={form.block_message} onChange={(e) => updateForm("block_message", e.target.checked)} className="rounded" />
@@ -1524,9 +1524,9 @@ export function AutoModTab({ serverId, channels, open }: { serverId: string; cha
                       updateForm("timeout_duration", Math.min(Math.max(1, v), 2_419_200))
                     }}
                     className="w-20 px-2 py-1 rounded text-sm focus:outline-none"
-                    style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+                    style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
                   />
-                  <span className="text-xs" style={{ color: '#949ba4' }}>seconds (max 28 days)</span>
+                  <span className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>seconds (max 28 days)</span>
                 </div>
               )}
 
@@ -1545,7 +1545,7 @@ export function AutoModTab({ serverId, channels, open }: { serverId: string; cha
                     value={form.alert_channel_id}
                     onChange={(e) => updateForm("alert_channel_id", e.target.value)}
                     className="w-full px-2 py-1 rounded text-sm focus:outline-none"
-                    style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #3f4147' }}
+                    style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
                   >
                     {channels.map((c) => (
                       <option key={c.id} value={c.id}>#{c.name}</option>
@@ -1556,33 +1556,33 @@ export function AutoModTab({ serverId, channels, open }: { serverId: string; cha
             </div>
           </div>
 
-          <div className="space-y-2 rounded p-3" style={{ background: '#1e1f22', border: '1px solid #3f4147' }}>
-            <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>Sample message evaluator</p>
+          <div className="space-y-2 rounded p-3" style={{ background: 'var(--theme-bg-tertiary)', border: '1px solid var(--theme-surface-elevated)' }}>
+            <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>Sample message evaluator</p>
             <input
               value={sampleMessage}
               onChange={(e) => setSampleMessage(e.target.value)}
               placeholder="Type a sample message to test this rule"
               className="w-full px-3 py-1.5 rounded text-sm focus:outline-none"
-              style={{ background: '#111214', color: '#f2f3f5', border: '1px solid #3f4147' }}
+              style={{ background: '#111214', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-surface-elevated)' }}
             />
-            <p className="text-xs" style={{ color: sampleMessage ? (sampleViolation ? '#f0b232' : '#57f287') : '#949ba4' }}>
+            <p className="text-xs" style={{ color: sampleMessage ? (sampleViolation ? 'var(--theme-warning)' : '#57f287') : 'var(--theme-text-muted)' }}>
               {sampleMessage
                 ? sampleViolation
                   ? `Triggered: ${sampleViolation.reason}`
                   : 'No trigger match.'
                 : 'Enter a sample message for live evaluation.'}
             </p>
-            <p className="text-xs" style={{ color: '#949ba4' }}>
+            <p className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>
               Conflict resolution: lower priority value executes first; block/quarantine overrides warn-only outcomes.
             </p>
           </div>
 
           <div className="flex gap-2 pt-1">
-            <Button size="sm" onClick={handleSave} disabled={saving} style={{ background: '#5865f2' }}>
+            <Button size="sm" onClick={handleSave} disabled={saving} style={{ background: 'var(--theme-accent)' }}>
               {saving && <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />}
               {editingId === "new" ? "Create" : "Update"}
             </Button>
-            <Button size="sm" variant="ghost" onClick={() => setEditingId(null)} style={{ color: '#b5bac1' }}>
+            <Button size="sm" variant="ghost" onClick={() => setEditingId(null)} style={{ color: 'var(--theme-text-secondary)' }}>
               Cancel
             </Button>
           </div>
@@ -1590,10 +1590,10 @@ export function AutoModTab({ serverId, channels, open }: { serverId: string; cha
       )}
 
       <Dialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>
-        <DialogContent style={{ background: '#313338', borderColor: '#1e1f22' }}>
+        <DialogContent style={{ background: 'var(--theme-bg-primary)', borderColor: 'var(--theme-bg-tertiary)' }}>
           <DialogHeader>
             <DialogTitle className="text-white">Delete AutoMod rule?</DialogTitle>
-            <DialogDescription style={{ color: '#b5bac1' }}>
+            <DialogDescription style={{ color: 'var(--theme-text-secondary)' }}>
               This action can&apos;t be undone. The rule <span className="font-semibold text-white">{deleteTarget?.name}</span> will stop moderating messages immediately.
             </DialogDescription>
           </DialogHeader>

--- a/apps/web/components/modals/template-manager.tsx
+++ b/apps/web/components/modals/template-manager.tsx
@@ -83,12 +83,12 @@ export function TemplateManager({ serverId, createName, createDescription, iconU
   return (
     <div className="space-y-3">
       <div className="space-y-1">
-        <Label className="text-xs uppercase" style={{ color: '#b5bac1' }}>Starter template</Label>
+        <Label className="text-xs uppercase" style={{ color: 'var(--theme-text-secondary)' }}>Starter template</Label>
         <select
           value={starterKey}
           onChange={(e) => setStarterKey(e.target.value)}
           className="w-full rounded px-3 py-2 text-sm"
-          style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #1e1f22' }}
+          style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-bg-tertiary)' }}
         >
           <option value="">Custom JSON</option>
           {Object.keys(starterTemplates).map((key) => (
@@ -98,26 +98,26 @@ export function TemplateManager({ serverId, createName, createDescription, iconU
       </div>
 
       <div className="space-y-1">
-        <Label className="text-xs uppercase" style={{ color: '#b5bac1' }}>Template JSON</Label>
+        <Label className="text-xs uppercase" style={{ color: 'var(--theme-text-secondary)' }}>Template JSON</Label>
         <textarea
           value={rawTemplate}
           onChange={(e) => { setRawTemplate(e.target.value); setStarterKey("") }}
           rows={8}
           placeholder='{"metadata":{"source":"custom","version":"1.0.0","created_by":"you"},"roles":[],"categories":[],"channels":[]}'
           className="w-full rounded px-3 py-2 text-xs font-mono resize-y"
-          style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #1e1f22' }}
+          style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-bg-tertiary)' }}
         />
       </div>
 
       <div className="flex gap-2">
         {serverId && <Button variant="outline" onClick={() => request("preview")} disabled={loading}>Preview Diff</Button>}
-        {serverId && <Button onClick={() => request("apply")} disabled={loading} style={{ background: '#5865f2' }}>Import Template</Button>}
-        {!serverId && <Button onClick={() => request("create-server")} disabled={loading || !createName?.trim()} style={{ background: '#5865f2' }}>Create from Template</Button>}
+        {serverId && <Button onClick={() => request("apply")} disabled={loading} style={{ background: 'var(--theme-accent)' }}>Import Template</Button>}
+        {!serverId && <Button onClick={() => request("create-server")} disabled={loading || !createName?.trim()} style={{ background: 'var(--theme-accent)' }}>Create from Template</Button>}
         {serverId && <Button variant="outline" onClick={() => request("export")} disabled={loading}>Export</Button>}
       </div>
 
       {diff && (
-        <div className="text-xs rounded p-2" style={{ background: '#1e1f22', color: '#b5bac1' }}>
+        <div className="text-xs rounded p-2" style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-secondary)' }}>
           <div>Roles: {diff.roles.current} → {diff.roles.incoming}</div>
           <div>Categories: {diff.categories.current} → {diff.categories.incoming}</div>
           <div>Channels: {diff.channels.current} → {diff.channels.incoming}</div>
@@ -132,8 +132,8 @@ export function TemplateManager({ serverId, createName, createDescription, iconU
 
       {exportValue && (
         <div className="space-y-1">
-          <Label className="text-xs uppercase" style={{ color: '#b5bac1' }}>Exported template</Label>
-          <textarea readOnly value={exportValue} rows={8} className="w-full rounded px-3 py-2 text-xs font-mono" style={{ background: '#1e1f22', color: '#f2f3f5', border: '1px solid #1e1f22' }} />
+          <Label className="text-xs uppercase" style={{ color: 'var(--theme-text-secondary)' }}>Exported template</Label>
+          <textarea readOnly value={exportValue} rows={8} className="w-full rounded px-3 py-2 text-xs font-mono" style={{ background: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)', border: '1px solid var(--theme-bg-tertiary)' }} />
         </div>
       )}
     </div>

--- a/apps/web/components/modals/webhooks-modal.tsx
+++ b/apps/web/components/modals/webhooks-modal.tsx
@@ -82,33 +82,33 @@ export function WebhooksModal({ open, onClose, serverId, channels }: Props) {
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto" style={{ background: "#313338", borderColor: "#1e1f22" }}>
+      <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto" style={{ background: "var(--theme-bg-primary)", borderColor: "var(--theme-bg-tertiary)" }}>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-white">
-            <Webhook className="w-5 h-5" style={{ color: "#5865f2" }} />
+            <Webhook className="w-5 h-5" style={{ color: "var(--theme-accent)" }} />
             Webhooks
           </DialogTitle>
-          <p className="text-sm" style={{ color: "#949ba4" }}>
+          <p className="text-sm" style={{ color: "var(--theme-text-muted)" }}>
             Create URLs that allow external services to post messages to your server.
           </p>
         </DialogHeader>
 
         {/* Create form */}
-        <div className="rounded-lg p-4 space-y-3" style={{ background: "#2b2d31", border: "1px solid #1e1f22" }}>
-          <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: "#b5bac1" }}>New Webhook</p>
+        <div className="rounded-lg p-4 space-y-3" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
+          <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-secondary)" }}>New Webhook</p>
           <div className="flex gap-2">
             <input
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
               placeholder="Webhook name"
               className="flex-1 px-3 py-2 rounded text-sm focus:outline-none"
-              style={{ background: "#1e1f22", color: "#f2f3f5", border: "1px solid #3f4147" }}
+              style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-surface-elevated)" }}
             />
             <select
               value={newChannelId}
               onChange={(e) => setNewChannelId(e.target.value)}
               className="px-2 py-2 rounded text-sm focus:outline-none"
-              style={{ background: "#1e1f22", color: "#f2f3f5", border: "1px solid #3f4147" }}
+              style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-surface-elevated)" }}
             >
               {channels.map((c) => (
                 <option key={c.id} value={c.id}>#{c.name}</option>
@@ -118,7 +118,7 @@ export function WebhooksModal({ open, onClose, serverId, channels }: Props) {
               onClick={handleCreate}
               disabled={creating || !newChannelId}
               className="px-3 py-2 rounded text-sm font-semibold transition-colors disabled:opacity-50"
-              style={{ background: "#5865f2", color: "white" }}
+              style={{ background: "var(--theme-accent)", color: "white" }}
             >
               {creating ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
             </button>
@@ -128,33 +128,33 @@ export function WebhooksModal({ open, onClose, serverId, channels }: Props) {
         {/* List */}
         {loading ? (
           <div className="flex justify-center py-6">
-            <Loader2 className="animate-spin" style={{ color: "#949ba4" }} />
+            <Loader2 className="animate-spin" style={{ color: "var(--theme-text-muted)" }} />
           </div>
         ) : webhooks.length === 0 ? (
-          <div className="text-center py-8 text-sm" style={{ color: "#949ba4" }}>
+          <div className="text-center py-8 text-sm" style={{ color: "var(--theme-text-muted)" }}>
             No webhooks yet. Create one above.
           </div>
         ) : (
           <div className="space-y-2">
             {webhooks.map((wh) => (
-              <div key={wh.id} className="rounded-lg p-3" style={{ background: "#2b2d31", border: "1px solid #1e1f22" }}>
+              <div key={wh.id} className="rounded-lg p-3" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
                 <div className="flex items-center justify-between gap-2 mb-2">
                   <div>
                     <p className="text-sm font-medium text-white">{wh.name}</p>
-                    <p className="text-xs" style={{ color: "#949ba4" }}>#{channelName(wh.channel_id)}</p>
+                    <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>#{channelName(wh.channel_id)}</p>
                   </div>
-                  <button onClick={() => handleDelete(wh.id)} className="w-7 h-7 flex items-center justify-center rounded hover:bg-red-500/20 transition-colors" style={{ color: "#4e5058" }} title="Delete">
+                  <button onClick={() => handleDelete(wh.id)} className="w-7 h-7 flex items-center justify-center rounded hover:bg-red-500/20 transition-colors" style={{ color: "var(--theme-text-faint)" }} title="Delete">
                     <Trash2 className="w-3.5 h-3.5" />
                   </button>
                 </div>
                 <div className="flex items-center gap-2">
-                  <code className="flex-1 text-xs px-2 py-1 rounded truncate" style={{ background: "#1e1f22", color: "#949ba4", fontFamily: "monospace" }}>
+                  <code className="flex-1 text-xs px-2 py-1 rounded truncate" style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-muted)", fontFamily: "monospace" }}>
                     {wh.url}
                   </code>
                   <button
                     onClick={() => copyUrl(wh.id, wh.url)}
                     className="flex-shrink-0 w-7 h-7 flex items-center justify-center rounded transition-colors hover:bg-white/10"
-                    style={{ color: copiedId === wh.id ? "#23a55a" : "#949ba4" }}
+                    style={{ color: copiedId === wh.id ? "var(--theme-success)" : "var(--theme-text-muted)" }}
                     title="Copy URL"
                   >
                     {copiedId === wh.id ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}

--- a/apps/web/components/notifications/notification-bell.tsx
+++ b/apps/web/components/notifications/notification-bell.tsx
@@ -214,7 +214,7 @@ export function NotificationBell({ userId, variant = "icon" }: Props) {
           {unreadCount > 0 && (
             <span
               className="min-w-[18px] h-[18px] rounded-full px-1 text-[10px] font-bold flex items-center justify-center"
-              style={{ background: "#f23f43", color: "white" }}
+              style={{ background: "var(--theme-danger)", color: "white" }}
             >
               {unreadCount > 99 ? "99+" : unreadCount}
             </span>
@@ -225,7 +225,7 @@ export function NotificationBell({ userId, variant = "icon" }: Props) {
           ref={triggerRef}
           onClick={() => setOpen((v) => !v)}
           className="relative w-9 h-9 flex items-center justify-center rounded-full transition-colors hover:bg-white/10 focus-ring"
-          style={{ color: open ? "#f2f3f5" : "#949ba4" }}
+          style={{ color: open ? "var(--theme-text-primary)" : "var(--theme-text-muted)" }}
           title="Notifications"
           aria-label="Open notifications"
           aria-expanded={open}
@@ -235,7 +235,7 @@ export function NotificationBell({ userId, variant = "icon" }: Props) {
           {unreadCount > 0 && (
             <span
               className="absolute -top-0.5 -right-0.5 min-w-[16px] h-4 rounded-full flex items-center justify-center text-xs font-bold px-0.5"
-              style={{ background: "#f23f43", color: "white", fontSize: "10px" }}
+              style={{ background: "var(--theme-danger)", color: "white", fontSize: "10px" }}
             >
               {unreadCount > 99 ? "99+" : unreadCount}
             </span>
@@ -252,17 +252,17 @@ export function NotificationBell({ userId, variant = "icon" }: Props) {
           aria-label="Notifications inbox"
           tabIndex={-1}
           className="absolute right-0 top-full mt-2 w-80 rounded-xl shadow-2xl overflow-hidden z-50"
-          style={{ background: "#2b2d31", border: "1px solid #1e1f22" }}
+          style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}
         >
           {/* Header */}
-          <div className="flex items-center justify-between px-4 py-3 border-b" style={{ borderColor: "#1e1f22" }}>
+          <div className="flex items-center justify-between px-4 py-3 border-b" style={{ borderColor: "var(--theme-bg-tertiary)" }}>
             <span className="text-sm font-semibold text-white">Notifications</span>
             <div className="flex items-center gap-1">
               {unreadCount > 0 && (
                 <button
                   onClick={markAllRead}
                   className="flex items-center gap-1 text-xs transition-colors hover:text-white focus-ring rounded px-1"
-                  style={{ color: "#949ba4" }}
+                  style={{ color: "var(--theme-text-muted)" }}
                   title="Mark all as read"
                   aria-label="Mark all notifications as read"
                 >
@@ -293,7 +293,7 @@ export function NotificationBell({ userId, variant = "icon" }: Props) {
                 <div
                   key={n.id}
                   className="flex items-start justify-between gap-2 px-4 py-3 border-b transition-colors hover:bg-white/5"
-                  style={{ borderColor: "#1e1f22", background: n.read ? "transparent" : "rgba(88,101,242,0.05)" }}
+                  style={{ borderColor: "var(--theme-bg-tertiary)", background: n.read ? "transparent" : "rgba(88,101,242,0.05)" }}
                   role="group"
                   aria-label={`Notification: ${n.title}`}
                 >
@@ -306,13 +306,13 @@ export function NotificationBell({ userId, variant = "icon" }: Props) {
                     {/* Type icon */}
                     <div
                       className="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center mt-0.5"
-                      style={{ background: n.read ? "#383a40" : "#5865f2", color: "white" }}
+                      style={{ background: n.read ? "var(--theme-surface-input)" : "var(--theme-accent)", color: "white" }}
                     >
                       {TYPE_ICONS[n.type]}
                     </div>
 
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium truncate" style={{ color: n.read ? "#b5bac1" : "#f2f3f5" }}>{n.title}</p>
+                      <p className="text-sm font-medium truncate" style={{ color: n.read ? "var(--theme-text-secondary)" : "var(--theme-text-primary)" }}>{n.title}</p>
                       {n.body && (
                         <p className="text-xs truncate mt-0.5 tertiary-metadata">{n.body}</p>
                       )}
@@ -327,7 +327,7 @@ export function NotificationBell({ userId, variant = "icon" }: Props) {
                       <button
                         onClick={(e) => { e.stopPropagation(); markRead(n.id) }}
                         className="w-5 h-5 flex items-center justify-center rounded hover:bg-white/10 focus-ring"
-                        style={{ color: "#949ba4" }}
+                        style={{ color: "var(--theme-text-muted)" }}
                         title={`Mark "${n.title}" as read`}
                         aria-label={`Mark "${n.title}" as read`}
                       >

--- a/apps/web/components/roles/role-manager.tsx
+++ b/apps/web/components/roles/role-manager.tsx
@@ -252,7 +252,7 @@ export function RoleManager({ serverId, isOwner }: Props) {
   }
 
   if (loading) {
-    return <div className="flex justify-center py-8"><Loader2 className="animate-spin" style={{ color: '#949ba4' }} /></div>
+    return <div className="flex justify-center py-8"><Loader2 className="animate-spin" style={{ color: 'var(--theme-text-muted)' }} /></div>
   }
 
   return (
@@ -260,9 +260,9 @@ export function RoleManager({ serverId, isOwner }: Props) {
       {/* Role list */}
       <div className="w-40 flex-shrink-0">
         <div className="flex justify-between items-center mb-2">
-          <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#949ba4' }}>Roles</span>
+          <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-muted)' }}>Roles</span>
           {isOwner && (
-            <button onClick={handleCreateRole} style={{ color: '#23a55a' }}>
+            <button onClick={handleCreateRole} style={{ color: 'var(--theme-success)' }}>
               <Plus className="w-4 h-4" />
             </button>
           )}
@@ -276,13 +276,13 @@ export function RoleManager({ serverId, isOwner }: Props) {
               className="w-full flex items-center gap-2 px-2 py-1.5 rounded text-sm text-left transition-colors"
               style={{
                 background: selectedRole?.id === role.id ? 'rgba(255,255,255,0.1)' : 'transparent',
-                color: '#f2f3f5',
+                color: 'var(--theme-text-primary)',
               }}
             >
               <span className="w-3 h-3 rounded-full flex-shrink-0" style={{ background: role.color }} />
               <span className="truncate">{role.name}</span>
               {role.is_default && (
-                <span className="ml-auto text-xs" style={{ color: '#949ba4' }}>default</span>
+                <span className="ml-auto text-xs" style={{ color: 'var(--theme-text-muted)' }}>default</span>
               )}
             </button>
           ))}
@@ -293,7 +293,7 @@ export function RoleManager({ serverId, isOwner }: Props) {
       {selectedRole ? (
         <div className="flex-1 overflow-y-auto space-y-4 pr-1">
           <div className="space-y-1">
-            <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+            <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
               Role Name
             </Label>
             <div className="flex items-center gap-3">
@@ -302,7 +302,7 @@ export function RoleManager({ serverId, isOwner }: Props) {
                 onChange={(e) => setEditName(e.target.value)}
                 disabled={selectedRole.is_default}
                 className="flex-1"
-                style={{ background: '#1e1f22', borderColor: '#1e1f22', color: '#f2f3f5' }}
+                style={{ background: 'var(--theme-bg-tertiary)', borderColor: 'var(--theme-bg-tertiary)', color: 'var(--theme-text-primary)' }}
               />
               <div className="flex items-center gap-2 flex-shrink-0">
                 <input
@@ -310,7 +310,7 @@ export function RoleManager({ serverId, isOwner }: Props) {
                   value={editColor}
                   onChange={(e) => setEditColor(e.target.value)}
                   className="w-9 h-9 rounded cursor-pointer border-0 p-0.5"
-                  style={{ background: '#1e1f22' }}
+                  style={{ background: 'var(--theme-bg-tertiary)' }}
                 />
               </div>
             </div>
@@ -328,13 +328,13 @@ export function RoleManager({ serverId, isOwner }: Props) {
           </div>
 
           <div>
-            <Label className="text-xs font-semibold uppercase tracking-wider mb-2 block" style={{ color: '#b5bac1' }}>
+            <Label className="text-xs font-semibold uppercase tracking-wider mb-2 block" style={{ color: 'var(--theme-text-secondary)' }}>
               Permissions
             </Label>
             <div className="space-y-4 overflow-y-auto" style={{ maxHeight: 'calc(100% - 2rem)' }}>
               {PERMISSION_CATEGORIES.map(({ label: catLabel, perms }) => (
                 <div key={catLabel}>
-                  <div className="text-xs font-semibold uppercase tracking-wider mb-1" style={{ color: '#5865f2' }}>
+                  <div className="text-xs font-semibold uppercase tracking-wider mb-1" style={{ color: 'var(--theme-accent)' }}>
                     {catLabel}
                   </div>
                   <div className="space-y-1">
@@ -342,7 +342,7 @@ export function RoleManager({ serverId, isOwner }: Props) {
                       <div key={key} className="flex items-center justify-between py-1">
                         <div>
                           <div className="text-sm font-medium text-white">{label}</div>
-                          <div className="text-xs" style={{ color: '#949ba4' }}>{description}</div>
+                          <div className="text-xs" style={{ color: 'var(--theme-text-muted)' }}>{description}</div>
                         </div>
                         <Switch
                           checked={!!(editPermissions & PERMISSIONS[key])}
@@ -361,14 +361,14 @@ export function RoleManager({ serverId, isOwner }: Props) {
           {!selectedRole.is_default && (
             <div>
               <div className="flex items-center justify-between mb-2">
-                <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#b5bac1' }}>
+                <Label className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--theme-text-secondary)' }}>
                   Members — {roleMembers.length}
                 </Label>
                 {isOwner && (
                   <button
                     onClick={() => setShowAddMember(!showAddMember)}
                     className="text-xs px-2 py-1 rounded transition-colors hover:bg-white/10"
-                    style={{ color: '#23a55a' }}
+                    style={{ color: 'var(--theme-success)' }}
                   >
                     <Plus className="w-3.5 h-3.5 inline mr-1" />
                     Add
@@ -379,17 +379,17 @@ export function RoleManager({ serverId, isOwner }: Props) {
               {showAddMember && (() => {
                 const availableMembers = allMembers.filter((m) => !roleMembers.some((rm) => rm.id === m.id))
                 return (
-                <div className="mb-2 p-2 rounded space-y-1 max-h-32 overflow-y-auto" style={{ background: '#1e1f22' }}>
+                <div className="mb-2 p-2 rounded space-y-1 max-h-32 overflow-y-auto" style={{ background: 'var(--theme-bg-tertiary)' }}>
                   {availableMembers.map((member) => (
                       <button
                         key={member.id}
                         onClick={() => handleAddMemberToRole(member.id)}
                         className="w-full flex items-center gap-2 px-2 py-1.5 rounded text-sm text-left hover:bg-white/10 transition-colors"
-                        style={{ color: '#f2f3f5' }}
+                        style={{ color: 'var(--theme-text-primary)' }}
                       >
                         <Avatar className="w-5 h-5">
                           {member.avatar_url && <AvatarImage src={member.avatar_url} />}
-                          <AvatarFallback style={{ background: '#5865f2', color: 'white', fontSize: '10px' }}>
+                          <AvatarFallback style={{ background: 'var(--theme-accent)', color: 'white', fontSize: '10px' }}>
                             {(member.display_name || member.username).slice(0, 2).toUpperCase()}
                           </AvatarFallback>
                         </Avatar>
@@ -397,7 +397,7 @@ export function RoleManager({ serverId, isOwner }: Props) {
                       </button>
                     ))}
                   {availableMembers.length === 0 && (
-                    <p className="text-xs text-center py-1" style={{ color: '#949ba4' }}>All members have this role</p>
+                    <p className="text-xs text-center py-1" style={{ color: 'var(--theme-text-muted)' }}>All members have this role</p>
                   )}
                 </div>
                 )
@@ -408,11 +408,11 @@ export function RoleManager({ serverId, isOwner }: Props) {
                   <div
                     key={member.id}
                     className="flex items-center gap-2 px-2 py-1.5 rounded text-sm group"
-                    style={{ background: '#2b2d31', color: '#f2f3f5' }}
+                    style={{ background: 'var(--theme-bg-secondary)', color: 'var(--theme-text-primary)' }}
                   >
                     <Avatar className="w-5 h-5">
                       {member.avatar_url && <AvatarImage src={member.avatar_url} />}
-                      <AvatarFallback style={{ background: '#5865f2', color: 'white', fontSize: '10px' }}>
+                      <AvatarFallback style={{ background: 'var(--theme-accent)', color: 'white', fontSize: '10px' }}>
                         {(member.display_name || member.username).slice(0, 2).toUpperCase()}
                       </AvatarFallback>
                     </Avatar>
@@ -421,7 +421,7 @@ export function RoleManager({ serverId, isOwner }: Props) {
                       <button
                         onClick={() => handleRemoveMemberFromRole(member.id)}
                         className="opacity-0 group-hover:opacity-100 transition-opacity"
-                        style={{ color: '#f23f43' }}
+                        style={{ color: 'var(--theme-danger)' }}
                       >
                         <X className="w-3.5 h-3.5" />
                       </button>
@@ -429,7 +429,7 @@ export function RoleManager({ serverId, isOwner }: Props) {
                   </div>
                 ))}
                 {roleMembers.length === 0 && (
-                  <p className="text-xs py-1" style={{ color: '#949ba4' }}>No members have this role</p>
+                  <p className="text-xs py-1" style={{ color: 'var(--theme-text-muted)' }}>No members have this role</p>
                 )}
               </div>
             </div>
@@ -441,7 +441,7 @@ export function RoleManager({ serverId, isOwner }: Props) {
                 variant="ghost"
                 size="sm"
                 onClick={() => handleDeleteRole(selectedRole.id)}
-                style={{ color: '#f23f43' }}
+                style={{ color: 'var(--theme-danger)' }}
               >
                 <Trash2 className="w-4 h-4 mr-1" />
                 Delete
@@ -451,7 +451,7 @@ export function RoleManager({ serverId, isOwner }: Props) {
               size="sm"
               onClick={handleSaveRole}
               disabled={saving}
-              style={{ background: '#5865f2' }}
+              style={{ background: 'var(--theme-accent)' }}
               className="ml-auto"
             >
               {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
@@ -460,7 +460,7 @@ export function RoleManager({ serverId, isOwner }: Props) {
           </div>
         </div>
       ) : (
-        <div className="flex-1 flex items-center justify-center" style={{ color: '#949ba4' }}>
+        <div className="flex-1 flex items-center justify-center" style={{ color: 'var(--theme-text-muted)' }}>
           Select a role to edit
         </div>
       )}

--- a/apps/web/components/settings/apps-tab.tsx
+++ b/apps/web/components/settings/apps-tab.tsx
@@ -132,18 +132,18 @@ export function AppsTab({ serverId, canManageApps }: AppsTabProps) {
     <div className="space-y-6">
       <div>
         <h3 className="text-lg font-semibold text-white">Installed Apps</h3>
-        <p className="text-sm" style={{ color: "#949ba4" }}>Install apps with scoped permissions. Webhooks continue to work unchanged.</p>
+        <p className="text-sm" style={{ color: "var(--theme-text-muted)" }}>Install apps with scoped permissions. Webhooks continue to work unchanged.</p>
       </div>
 
-      {loading ? <p style={{ color: "#949ba4" }}>Loading apps…</p> : (
+      {loading ? <p style={{ color: "var(--theme-text-muted)" }}>Loading apps…</p> : (
         <div className="grid gap-3">
-          {installed.length === 0 && <p style={{ color: "#949ba4" }}>No apps installed on this server.</p>}
+          {installed.length === 0 && <p style={{ color: "var(--theme-text-muted)" }}>No apps installed on this server.</p>}
           {installed.map((entry) => (
-            <div key={entry.id} className="rounded border p-3" style={{ borderColor: "#3f4147" }}>
+            <div key={entry.id} className="rounded border p-3" style={{ borderColor: "var(--theme-surface-elevated)" }}>
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-white font-medium">{entry.app_catalog?.name ?? entry.app_id}</p>
-                  <p className="text-xs" style={{ color: "#949ba4" }}>
+                  <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>
                     Scopes: {entry.install_scopes.join(", ")} · Permissions: {entry.granted_permissions.join(", ")}
                   </p>
                 </div>
@@ -165,13 +165,13 @@ export function AppsTab({ serverId, canManageApps }: AppsTabProps) {
         <h4 className="text-md font-semibold text-white mb-2">Marketplace quick install</h4>
         <div className="grid gap-3">
           {market.slice(0, 6).map((app) => (
-            <div key={app.id} className="rounded border p-3 flex items-center justify-between" style={{ borderColor: "#3f4147" }}>
+            <div key={app.id} className="rounded border p-3 flex items-center justify-between" style={{ borderColor: "var(--theme-surface-elevated)" }}>
               <div>
                 <div className="flex items-center gap-2">
                   <p className="text-white">{app.name}</p>
                   {app.trust_badge && <BadgeCheck className="w-4 h-4 text-emerald-400" />}
                 </div>
-                <p className="text-xs" style={{ color: "#949ba4" }}>
+                <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>
                   <Shield className="w-3 h-3 inline mr-1" />{app.category} · <Star className="w-3 h-3 inline mr-1" />{app.average_rating.toFixed(1)} ({app.review_count})
                 </p>
               </div>

--- a/apps/web/components/settings/server-settings-admin.tsx
+++ b/apps/web/components/settings/server-settings-admin.tsx
@@ -21,10 +21,10 @@ interface Props {
 
 export function ServerSettingsAdmin({ serverId, serverName, isOwner, channels }: Props) {
   return (
-    <main className="flex-1 overflow-y-auto p-6" style={{ background: "#1e1f22" }}>
+    <main className="flex-1 overflow-y-auto p-6" style={{ background: "var(--theme-bg-tertiary)" }}>
       <div className="mx-auto max-w-6xl">
         <h1 className="text-2xl font-semibold text-white">Server Settings</h1>
-        <p className="mt-1 text-sm" style={{ color: "#949ba4" }}>{serverName}</p>
+        <p className="mt-1 text-sm" style={{ color: "var(--theme-text-muted)" }}>{serverName}</p>
 
         <Tabs defaultValue="roles" className="mt-6 flex gap-6">
           <div className="w-56 flex-shrink-0">
@@ -34,7 +34,7 @@ export function ServerSettingsAdmin({ serverId, serverName, isOwner, channels }:
               <TabsTrigger value="webhooks" className="w-full justify-start">Webhooks</TabsTrigger>
               <TabsTrigger value="social-alerts" className="w-full justify-start">Social Alerts</TabsTrigger>
               <TabsTrigger value="apps" className="w-full justify-start">Apps</TabsTrigger>
-              <div className="mt-2 mb-1 px-3 text-xs font-semibold uppercase tracking-wider" style={{ color: "#949ba4" }}>
+              <div className="mt-2 mb-1 px-3 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-muted)" }}>
                 Moderation
               </div>
               <TabsTrigger value="moderation" className="w-full justify-start">
@@ -53,7 +53,7 @@ export function ServerSettingsAdmin({ serverId, serverName, isOwner, channels }:
             </TabsList>
           </div>
 
-          <div className="min-w-0 flex-1 rounded-md p-4" style={{ background: "#313338" }}>
+          <div className="min-w-0 flex-1 rounded-md p-4" style={{ background: "var(--theme-bg-primary)" }}>
             <TabsContent value="roles" className="mt-0">
               <RoleManager serverId={serverId} isOwner={isOwner} />
             </TabsContent>
@@ -79,7 +79,7 @@ export function ServerSettingsAdmin({ serverId, serverName, isOwner, channels }:
               <AutoModTab serverId={serverId} channels={channels} open />
             </TabsContent>
             <TabsContent value="templates" className="mt-0">
-              {isOwner ? <TemplateManager serverId={serverId} /> : <p style={{ color: "#b5bac1" }}>Only the owner can import/export templates.</p>}
+              {isOwner ? <TemplateManager serverId={serverId} /> : <p style={{ color: "var(--theme-text-secondary)" }}>Only the owner can import/export templates.</p>}
             </TabsContent>
           </div>
         </Tabs>

--- a/apps/web/components/ui/branded-empty-state.tsx
+++ b/apps/web/components/ui/branded-empty-state.tsx
@@ -9,13 +9,13 @@ interface Props {
 
 export function BrandedEmptyState({ icon: Icon, title, description, hint }: Props) {
   return (
-    <div className="mx-auto flex max-w-md flex-col items-center justify-center rounded-2xl border border-white/10 bg-[#232428] px-6 py-10 text-center">
-      <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-[#5865f2]/20 text-[#9da7ff]">
+    <div className="mx-auto flex max-w-md flex-col items-center justify-center rounded-2xl border border-white/10 px-6 py-10 text-center" style={{ background: "var(--theme-bg-tertiary)" }}>
+      <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl" style={{ background: "color-mix(in srgb, var(--theme-accent) 20%, transparent)", color: "var(--theme-accent)" }}>
         <Icon className="h-7 w-7" />
       </div>
       <h3 className="text-base font-semibold text-white">{title}</h3>
-      <p className="mt-1 text-sm" style={{ color: "#b5bac1" }}>{description}</p>
-      {hint && <p className="mt-3 text-xs" style={{ color: "#949ba4" }}>{hint}</p>}
+      <p className="mt-1 text-sm" style={{ color: "var(--theme-text-secondary)" }}>{description}</p>
+      {hint && <p className="mt-3 text-xs" style={{ color: "var(--theme-text-muted)" }}>{hint}</p>}
     </div>
   )
 }

--- a/apps/web/components/ui/context-menu.tsx
+++ b/apps/web/components/ui/context-menu.tsx
@@ -65,7 +65,7 @@ const ContextMenuItem = React.forwardRef<
     className={cn(
       "motion-interactive relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
-      variant === "destructive" && "text-[#f23f43] focus:bg-red-500/20 focus:text-[#f23f43]",
+      variant === "destructive" && "text-[var(--theme-danger)] focus:bg-red-500/20 focus:text-[var(--theme-danger)]",
       className
     )}
     {...props}

--- a/apps/web/components/user-profile-popover.tsx
+++ b/apps/web/components/user-profile-popover.tsx
@@ -32,10 +32,10 @@ interface UserProfilePopoverProps {
 
 function getStatusColor(status?: string) {
   switch (status) {
-    case "online": return "#23a55a"
-    case "idle": return "#f0b132"
-    case "dnd": return "#f23f43"
-    default: return "#80848e"
+    case "online": return "var(--theme-success)"
+    case "idle": return "var(--theme-warning)"
+    case "dnd": return "var(--theme-danger)"
+    default: return "var(--theme-presence-offline)"
   }
 }
 
@@ -120,12 +120,12 @@ export function UserProfilePopover({
         align={align}
         sideOffset={8}
         className="w-72 p-0 overflow-hidden"
-        style={{ background: "#232428", borderColor: "#1e1f22" }}
+        style={{ background: "#232428", borderColor: "var(--theme-bg-tertiary)" }}
       >
         {/* Banner */}
         <div
           className="h-16"
-          style={{ background: user?.banner_color ?? "#5865f2" }}
+          style={{ background: user?.banner_color ?? "var(--theme-accent)" }}
         />
 
         {/* Avatar + Info */}
@@ -134,7 +134,7 @@ export function UserProfilePopover({
             <Avatar className="w-14 h-14 ring-4" style={{ "--tw-ring-color": "#232428" } as React.CSSProperties}>
               {user?.avatar_url && <AvatarImage src={user.avatar_url} />}
               <AvatarFallback
-                style={{ background: "#5865f2", color: "white", fontSize: "18px" }}
+                style={{ background: "var(--theme-accent)", color: "white", fontSize: "18px" }}
               >
                 {initials}
               </AvatarFallback>
@@ -150,17 +150,17 @@ export function UserProfilePopover({
 
           {/* Name */}
           <div className="font-bold text-white text-base">{displayName}</div>
-          <div className="text-sm" style={{ color: "#b5bac1" }}>
+          <div className="text-sm" style={{ color: "var(--theme-text-secondary)" }}>
             {user?.username}
           </div>
           {user?.custom_tag && (
-            <div className="text-xs mt-0.5" style={{ color: "#949ba4" }}>
+            <div className="text-xs mt-0.5" style={{ color: "var(--theme-text-muted)" }}>
               {user.custom_tag}
             </div>
           )}
 
           {/* Divider */}
-          <div className="my-2 border-t" style={{ borderColor: "#1e1f22" }} />
+          <div className="my-2 border-t" style={{ borderColor: "var(--theme-bg-tertiary)" }} />
 
           {/* Status */}
           <div className="flex items-center gap-1.5 mb-1">
@@ -168,13 +168,13 @@ export function UserProfilePopover({
               className="w-2.5 h-2.5 rounded-full flex-shrink-0"
               style={{ background: getStatusColor(status) }}
             />
-            <span className="text-xs" style={{ color: "#b5bac1" }}>
+            <span className="text-xs" style={{ color: "var(--theme-text-secondary)" }}>
               {getStatusLabel(status)}
             </span>
           </div>
 
           {user?.status_message && (
-            <div className="text-xs mb-2" style={{ color: "#dcddde" }}>
+            <div className="text-xs mb-2" style={{ color: "var(--theme-text-normal)" }}>
               {user.status_message}
             </div>
           )}
@@ -182,10 +182,10 @@ export function UserProfilePopover({
           {/* Bio */}
           {user?.bio && (
             <>
-              <div className="text-xs font-semibold uppercase tracking-wider mb-1" style={{ color: "#b5bac1" }}>
+              <div className="text-xs font-semibold uppercase tracking-wider mb-1" style={{ color: "var(--theme-text-secondary)" }}>
                 About Me
               </div>
-              <div className="text-sm" style={{ color: "#dcddde" }}>
+              <div className="text-sm" style={{ color: "var(--theme-text-normal)" }}>
                 {user.bio}
               </div>
             </>
@@ -194,7 +194,7 @@ export function UserProfilePopover({
           {/* Roles */}
           {roles.length > 0 && (
             <>
-              <div className="text-xs font-semibold uppercase tracking-wider mt-2 mb-1" style={{ color: "#b5bac1" }}>
+              <div className="text-xs font-semibold uppercase tracking-wider mt-2 mb-1" style={{ color: "var(--theme-text-secondary)" }}>
                 Roles
               </div>
               <div className="flex flex-wrap gap-1">
@@ -202,11 +202,11 @@ export function UserProfilePopover({
                   <span
                     key={role.id}
                     className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs"
-                    style={{ background: "#1e1f22", color: role.color || "#dcddde" }}
+                    style={{ background: "var(--theme-bg-tertiary)", color: role.color || "var(--theme-text-normal)" }}
                   >
                     <span
                       className="w-2.5 h-2.5 rounded-full flex-shrink-0"
-                      style={{ background: role.color || "#dcddde" }}
+                      style={{ background: role.color || "var(--theme-text-normal)" }}
                     />
                     {role.name}
                   </span>
@@ -218,14 +218,14 @@ export function UserProfilePopover({
           {/* Action buttons */}
           {showActions && (
             <>
-              <div className="my-2 border-t" style={{ borderColor: "#1e1f22" }} />
+              <div className="my-2 border-t" style={{ borderColor: "var(--theme-bg-tertiary)" }} />
               <div className="flex gap-2">
                 <button
                   type="button"
                   onClick={handleMessage}
                   disabled={actionLoading === "message"}
                   className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-125 disabled:opacity-50"
-                  style={{ background: "#5865f2", color: "white" }}
+                  style={{ background: "var(--theme-accent)", color: "white" }}
                 >
                   <MessageSquare className="w-3.5 h-3.5" />
                   Message
@@ -235,7 +235,7 @@ export function UserProfilePopover({
                   onClick={handleAddFriend}
                   disabled={actionLoading === "friend"}
                   className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-125 disabled:opacity-50"
-                  style={{ background: "#23a55a", color: "white" }}
+                  style={{ background: "var(--theme-success)", color: "white" }}
                 >
                   <UserPlus className="w-3.5 h-3.5" />
                   Add Friend

--- a/apps/web/components/voice/voice-channel.tsx
+++ b/apps/web/components/voice/voice-channel.tsx
@@ -33,9 +33,9 @@ interface VoiceParticipantInfo {
 type VoiceSessionTone = "stable" | "listening" | "attention"
 
 const TONE_STYLES: Record<VoiceSessionTone, { dot: string; badgeBg: string; badgeText: string }> = {
-  stable: { dot: "#80848e", badgeBg: "rgba(128,132,142,0.18)", badgeText: "#c9ccd1" },
-  listening: { dot: "#23a55a", badgeBg: "rgba(35,165,90,0.2)", badgeText: "#9ae6b4" },
-  attention: { dot: "#f0b132", badgeBg: "rgba(240,177,50,0.2)", badgeText: "#ffd58a" },
+  stable: { dot: "var(--theme-presence-offline)", badgeBg: "rgba(128,132,142,0.18)", badgeText: "#c9ccd1" },
+  listening: { dot: "var(--theme-success)", badgeBg: "rgba(35,165,90,0.2)", badgeText: "#9ae6b4" },
+  attention: { dot: "var(--theme-warning)", badgeBg: "rgba(240,177,50,0.2)", badgeText: "#ffd58a" },
 }
 
 /** Derive the voice session status label, detail text, and visual tone from current state. */
@@ -264,26 +264,26 @@ export function VoiceChannel({ channelId, channelName, serverId, currentUserId }
 
   return (
     <TooltipProvider>
-      <div className="flex flex-col flex-1" style={{ background: "#313338" }}>
-        <div className="flex items-center gap-2 px-4 py-3 border-b flex-shrink-0" style={{ borderColor: "#1e1f22" }}>
-          <Volume2 className="w-5 h-5" style={{ color: "#23a55a" }} />
+      <div className="flex flex-col flex-1" style={{ background: "var(--theme-bg-primary)" }}>
+        <div className="flex items-center gap-2 px-4 py-3 border-b flex-shrink-0" style={{ borderColor: "var(--theme-bg-tertiary)" }}>
+          <Volume2 className="w-5 h-5" style={{ color: "var(--theme-success)" }} />
           <span className="font-semibold text-white">{channelName}</span>
           <div className="ml-1 flex items-center gap-2">
             <span className="text-xs px-2 py-0.5 rounded-full inline-flex items-center gap-1" style={{ background: activeTone.badgeBg, color: activeTone.badgeText }}>
               <span className="w-1.5 h-1.5 rounded-full" style={{ background: activeTone.dot }} />
               {sessionState.label}
             </span>
-            <span className="text-xs" style={{ color: "#949ba4" }}>{sessionState.detail}</span>
+            <span className="text-xs" style={{ color: "var(--theme-text-muted)" }}>{sessionState.detail}</span>
           </div>
           <div className="ml-auto flex items-center gap-2">
-            {cpuBypassActive && <span className="text-xs" style={{ color: "#f0b132" }}>CPU bypass enabled</span>}
-            {audioInitError && <span className="text-xs" style={{ color: "#f0b132" }}>{audioInitError}</span>}
+            {cpuBypassActive && <span className="text-xs" style={{ color: "var(--theme-warning)" }}>CPU bypass enabled</span>}
+            {audioInitError && <span className="text-xs" style={{ color: "var(--theme-warning)" }}>{audioInitError}</span>}
           </div>
         </div>
 
         {inSpotlight ? (
           <div className="flex-1 flex flex-col overflow-hidden">
-            <div className="flex-1 relative flex items-center justify-center overflow-hidden" style={{ background: "#1e1f22" }}>
+            <div className="flex-1 relative flex items-center justify-center overflow-hidden" style={{ background: "var(--theme-bg-tertiary)" }}>
               <button
                 type="button"
                 aria-label="Close spotlight"
@@ -294,12 +294,12 @@ export function VoiceChannel({ channelId, channelName, serverId, currentUserId }
                 <X className="w-4 h-4 text-white" />
               </button>
               <div className="absolute top-3 left-3 z-10 flex items-center gap-2 px-2.5 py-1 rounded-md" style={{ background: "rgba(0,0,0,0.6)" }}>
-                <Monitor className="w-3.5 h-3.5" style={{ color: "#23a55a" }} />
+                <Monitor className="w-3.5 h-3.5" style={{ color: "var(--theme-success)" }} />
                 <span className="text-xs text-white">{spotlightDisplayName}&apos;s Screen</span>
               </div>
               <SpotlightVideo stream={spotlightStream} />
             </div>
-            <div className="flex gap-2 px-4 py-3 overflow-x-auto flex-shrink-0" style={{ background: "#2b2d31", borderTop: "1px solid #1e1f22" }}>
+            <div className="flex gap-2 px-4 py-3 overflow-x-auto flex-shrink-0" style={{ background: "var(--theme-bg-secondary)", borderTop: "1px solid var(--theme-bg-tertiary)" }}>
               {currentUser && (
                 <div className="w-48 flex-shrink-0 min-w-0">
                   <ParticipantTile
@@ -337,9 +337,9 @@ export function VoiceChannel({ channelId, channelName, serverId, currentUserId }
           <div className="flex-1 flex items-center justify-center p-8 overflow-y-auto">
             {peerArray.length === 0 && !currentUser ? (
               <div className="text-center">
-                <Volume2 className="w-16 h-16 mx-auto mb-4" style={{ color: "#4e5058" }} />
+                <Volume2 className="w-16 h-16 mx-auto mb-4" style={{ color: "var(--theme-text-faint)" }} />
                 <p className="text-white text-lg font-semibold mb-1">You&apos;re the only one here</p>
-                <p style={{ color: "#949ba4" }} className="text-sm">Invite others to join this voice channel</p>
+                <p style={{ color: "var(--theme-text-muted)" }} className="text-sm">Invite others to join this voice channel</p>
               </div>
             ) : (
               <div className="grid gap-4 w-full" style={{ gridTemplateColumns: hasVideo ? "repeat(auto-fill, minmax(320px, 1fr))" : "repeat(auto-fill, minmax(200px, 1fr))" }}>
@@ -378,15 +378,15 @@ export function VoiceChannel({ channelId, channelName, serverId, currentUserId }
           </div>
         )}
 
-        <div className="h-20 border-t px-6 flex items-center justify-center gap-3" style={{ borderColor: "#1e1f22", background: "#2b2d31" }}>
-          <Tooltip><TooltipTrigger asChild><button onClick={toggleMute} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: muted ? "#f23f43" : "#4e5058" }}>{muted ? <MicOff className="w-5 h-5 text-white" /> : <Mic className="w-5 h-5 text-white" />}</button></TooltipTrigger><TooltipContent>{muted ? "Unmute" : "Mute"}</TooltipContent></Tooltip>
-          <Tooltip><TooltipTrigger asChild><button onClick={toggleDeafen} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: deafened ? "#f23f43" : "#4e5058" }}><Headphones className="w-5 h-5 text-white" /></button></TooltipTrigger><TooltipContent>{deafened ? "Undeafen" : "Deafen"}</TooltipContent></Tooltip>
-          <Tooltip><TooltipTrigger asChild><button onClick={() => setPttEnabled((v) => !v)} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: pttEnabled ? "#5865f2" : "#4e5058" }} title="Push-to-Talk (Space)"><Radio className="w-5 h-5 text-white" /></button></TooltipTrigger><TooltipContent>{pttEnabled ? "Disable PTT" : "Enable Push-to-Talk (Space)"}</TooltipContent></Tooltip>
-          <Tooltip><TooltipTrigger asChild><button onClick={toggleVideo} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: videoEnabled ? "#23a55a" : "#4e5058" }}>{videoEnabled ? <Video className="w-5 h-5 text-white" /> : <VideoOff className="w-5 h-5 text-white" />}</button></TooltipTrigger><TooltipContent>{videoEnabled ? "Turn Off Camera" : "Turn On Camera"}</TooltipContent></Tooltip>
-          <Tooltip><TooltipTrigger asChild><button onClick={toggleScreenShare} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: screenSharing ? "#23a55a" : "#4e5058" }}>{screenSharing ? <MonitorOff className="w-5 h-5 text-white" /> : <Monitor className="w-5 h-5 text-white" />}</button></TooltipTrigger><TooltipContent>{screenSharing ? "Stop Sharing" : "Share Screen"}</TooltipContent></Tooltip>
+        <div className="h-20 border-t px-6 flex items-center justify-center gap-3" style={{ borderColor: "var(--theme-bg-tertiary)", background: "var(--theme-bg-secondary)" }}>
+          <Tooltip><TooltipTrigger asChild><button onClick={toggleMute} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: muted ? "var(--theme-danger)" : "var(--theme-text-faint)" }}>{muted ? <MicOff className="w-5 h-5 text-white" /> : <Mic className="w-5 h-5 text-white" />}</button></TooltipTrigger><TooltipContent>{muted ? "Unmute" : "Mute"}</TooltipContent></Tooltip>
+          <Tooltip><TooltipTrigger asChild><button onClick={toggleDeafen} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: deafened ? "var(--theme-danger)" : "var(--theme-text-faint)" }}><Headphones className="w-5 h-5 text-white" /></button></TooltipTrigger><TooltipContent>{deafened ? "Undeafen" : "Deafen"}</TooltipContent></Tooltip>
+          <Tooltip><TooltipTrigger asChild><button onClick={() => setPttEnabled((v) => !v)} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: pttEnabled ? "var(--theme-accent)" : "var(--theme-text-faint)" }} title="Push-to-Talk (Space)"><Radio className="w-5 h-5 text-white" /></button></TooltipTrigger><TooltipContent>{pttEnabled ? "Disable PTT" : "Enable Push-to-Talk (Space)"}</TooltipContent></Tooltip>
+          <Tooltip><TooltipTrigger asChild><button onClick={toggleVideo} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: videoEnabled ? "var(--theme-success)" : "var(--theme-text-faint)" }}>{videoEnabled ? <Video className="w-5 h-5 text-white" /> : <VideoOff className="w-5 h-5 text-white" />}</button></TooltipTrigger><TooltipContent>{videoEnabled ? "Turn Off Camera" : "Turn On Camera"}</TooltipContent></Tooltip>
+          <Tooltip><TooltipTrigger asChild><button onClick={toggleScreenShare} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: screenSharing ? "var(--theme-success)" : "var(--theme-text-faint)" }}>{screenSharing ? <MonitorOff className="w-5 h-5 text-white" /> : <Monitor className="w-5 h-5 text-white" />}</button></TooltipTrigger><TooltipContent>{screenSharing ? "Stop Sharing" : "Share Screen"}</TooltipContent></Tooltip>
 
           <div className="relative">
-            <Tooltip><TooltipTrigger asChild><button onClick={() => setDeviceMenuOpen((v) => !v)} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: deviceMenuOpen ? "#5865f2" : "#4e5058" }}><Settings className="w-5 h-5 text-white" /></button></TooltipTrigger><TooltipContent>Audio Settings</TooltipContent></Tooltip>
+            <Tooltip><TooltipTrigger asChild><button onClick={() => setDeviceMenuOpen((v) => !v)} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: deviceMenuOpen ? "var(--theme-accent)" : "var(--theme-text-faint)" }}><Settings className="w-5 h-5 text-white" /></button></TooltipTrigger><TooltipContent>Audio Settings</TooltipContent></Tooltip>
             {deviceMenuOpen && (
               <VoiceSettingsPanel
                 audioInputDevices={audioInputDevices}
@@ -402,7 +402,7 @@ export function VoiceChannel({ channelId, channelName, serverId, currentUserId }
             )}
           </div>
 
-          <Tooltip><TooltipTrigger asChild><button onClick={handleLeave} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: "#f23f43" }}><PhoneOff className="w-5 h-5 text-white" /></button></TooltipTrigger><TooltipContent>Disconnect</TooltipContent></Tooltip>
+          <Tooltip><TooltipTrigger asChild><button onClick={handleLeave} className="w-12 h-12 rounded-full flex items-center justify-center transition-colors" style={{ background: "var(--theme-danger)" }}><PhoneOff className="w-5 h-5 text-white" /></button></TooltipTrigger><TooltipContent>Disconnect</TooltipContent></Tooltip>
         </div>
 
         {peerArray.map(([peerId, { stream, userId }], idx) => (
@@ -471,78 +471,78 @@ function VoiceSettingsPanel({
   }, [onClose])
 
   return (
-    <div ref={panelRef} className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-[360px] rounded-xl shadow-2xl p-4 space-y-4 z-50" style={{ background: "#2b2d31", border: "1px solid #1e1f22" }}>
+    <div ref={panelRef} className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-[360px] rounded-xl shadow-2xl p-4 space-y-4 z-50" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
       <div className="flex items-center justify-between">
         <p className="text-sm font-semibold text-white">Voice Settings</p>
         <button
           onClick={() => setSettings(createDefaultAudioSettings())}
           className="text-xs px-2 py-1 rounded inline-flex items-center gap-1"
-          style={{ background: "#1e1f22", color: "#f2f3f5" }}
+          style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)" }}
         >
           <RotateCcw className="w-3 h-3" /> Reset
         </button>
       </div>
 
       <div className="grid grid-cols-2 gap-2">
-        <label className="text-xs" style={{ color: "#b5bac1" }}>Profile</label>
-        <select value={settings.preset} onChange={(e) => setSettings(applyPresetToSettings(e.target.value as AudioPreset, settings))} className="w-full px-2 py-1.5 rounded text-sm" style={{ background: "#1e1f22", color: "#f2f3f5", border: "1px solid #3f4147" }}>
+        <label className="text-xs" style={{ color: "var(--theme-text-secondary)" }}>Profile</label>
+        <select value={settings.preset} onChange={(e) => setSettings(applyPresetToSettings(e.target.value as AudioPreset, settings))} className="w-full px-2 py-1.5 rounded text-sm" style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-surface-elevated)" }}>
           {PRESET_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
         </select>
       </div>
 
       <div>
-        <label className="block text-xs mb-1" style={{ color: "#b5bac1" }}>Microphone (live preview)</label>
+        <label className="block text-xs mb-1" style={{ color: "var(--theme-text-secondary)" }}>Microphone (live preview)</label>
         <input type="range" min={0.2} max={2} step={0.01} value={settings.inputGain} onChange={(e) => setSettings(markCustomSettings(settings, { inputGain: Number(e.target.value) }))} className="w-full" />
       </div>
       <div>
-        <label className="block text-xs mb-1" style={{ color: "#b5bac1" }}>Output gain</label>
+        <label className="block text-xs mb-1" style={{ color: "var(--theme-text-secondary)" }}>Output gain</label>
         <input type="range" min={0.2} max={2} step={0.01} value={settings.outputGain} onChange={(e) => setSettings(markCustomSettings(settings, { outputGain: Number(e.target.value) }))} className="w-full" />
       </div>
 
       <div className="space-y-2">
-        <label className="block text-xs" style={{ color: "#b5bac1" }}>EQ (6 bands)</label>
+        <label className="block text-xs" style={{ color: "var(--theme-text-secondary)" }}>EQ (6 bands)</label>
         <div className="grid grid-cols-3 gap-2">
           {settings.eqBands.map((band, idx) => (
             <div key={idx}>
-              <p className="text-[10px]" style={{ color: "#949ba4" }}>{band.frequency}Hz</p>
+              <p className="text-[10px]" style={{ color: "var(--theme-text-muted)" }}>{band.frequency}Hz</p>
               <input type="range" min={-12} max={12} step={0.5} value={band.gain} onChange={(e) => setSettings(withEqBandGain(settings, idx, Number(e.target.value)))} className="w-full" />
             </div>
           ))}
         </div>
       </div>
 
-      <label className="flex items-center justify-between text-xs" style={{ color: "#b5bac1" }}>
+      <label className="flex items-center justify-between text-xs" style={{ color: "var(--theme-text-secondary)" }}>
         Bypass processing
         <input type="checkbox" checked={settings.bypassProcessing} onChange={(e) => setSettings({ ...settings, bypassProcessing: e.target.checked })} />
       </label>
-      <label className="flex items-center justify-between text-xs" style={{ color: "#b5bac1" }}>
+      <label className="flex items-center justify-between text-xs" style={{ color: "var(--theme-text-secondary)" }}>
         Auto bypass on CPU constraint
         <input type="checkbox" checked={settings.bypassOnCpuConstraint} onChange={(e) => setSettings({ ...settings, bypassOnCpuConstraint: e.target.checked })} />
       </label>
-      <label className="flex items-center justify-between text-xs" style={{ color: "#b5bac1" }}>
+      <label className="flex items-center justify-between text-xs" style={{ color: "var(--theme-text-secondary)" }}>
         Spatial pan
         <input type="checkbox" checked={settings.spatialAudioEnabled} onChange={(e) => setSettings({ ...settings, spatialAudioEnabled: e.target.checked })} />
       </label>
 
       <div className="grid grid-cols-2 gap-2">
         <div>
-          <label className="block text-xs font-semibold uppercase mb-1" style={{ color: "#b5bac1" }}>Microphone device</label>
-          <select value={selectedInputId ?? ""} onChange={(e) => setSelectedInputId(e.target.value || null)} className="w-full px-2 py-1.5 rounded text-sm" style={{ background: "#1e1f22", color: "#f2f3f5", border: "1px solid #3f4147" }}>
+          <label className="block text-xs font-semibold uppercase mb-1" style={{ color: "var(--theme-text-secondary)" }}>Microphone device</label>
+          <select value={selectedInputId ?? ""} onChange={(e) => setSelectedInputId(e.target.value || null)} className="w-full px-2 py-1.5 rounded text-sm" style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-surface-elevated)" }}>
             <option value="">Default</option>
             {audioInputDevices.map((d) => <option key={d.deviceId} value={d.deviceId}>{d.label || `Microphone ${d.deviceId.slice(0, 6)}`}</option>)}
           </select>
         </div>
         {audioOutputDevices.length > 0 && (
           <div>
-            <label className="block text-xs font-semibold uppercase mb-1" style={{ color: "#b5bac1" }}>Speaker device</label>
-            <select value={selectedOutputId ?? ""} onChange={(e) => setSelectedOutputId(e.target.value || null)} className="w-full px-2 py-1.5 rounded text-sm" style={{ background: "#1e1f22", color: "#f2f3f5", border: "1px solid #3f4147" }}>
+            <label className="block text-xs font-semibold uppercase mb-1" style={{ color: "var(--theme-text-secondary)" }}>Speaker device</label>
+            <select value={selectedOutputId ?? ""} onChange={(e) => setSelectedOutputId(e.target.value || null)} className="w-full px-2 py-1.5 rounded text-sm" style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-surface-elevated)" }}>
               <option value="">Default</option>
               {audioOutputDevices.map((d) => <option key={d.deviceId} value={d.deviceId}>{d.label || `Speaker ${d.deviceId.slice(0, 6)}`}</option>)}
             </select>
           </div>
         )}
       </div>
-      <p className="text-xs" style={{ color: "#4e5058" }}>Input device changes require rejoin. Presets and custom EQ are saved per user/profile.</p>
+      <p className="text-xs" style={{ color: "var(--theme-text-faint)" }}>Input device changes require rejoin. Presets and custom EQ are saved per user/profile.</p>
     </div>
   )
 }
@@ -696,10 +696,10 @@ const ParticipantTile = memo(function ParticipantTile({
     <div
       className={cn(
         "group rounded-lg overflow-hidden flex flex-col relative transition-all duration-300",
-        speaking && !muted ? "ring-2 ring-green-500/80" : "ring-1 ring-[#4e5058]/60"
+        speaking && !muted ? "ring-2 ring-green-500/80" : "ring-1 ring-[var(--theme-text-faint)]/60"
       )}
       style={{
-        background: "#1e1f22",
+        background: "var(--theme-bg-tertiary)",
         minHeight: compact ? "100px" : (showScreen || showCamera || showRemoteVideo ? "240px" : "160px"),
       }}
     >
@@ -711,7 +711,7 @@ const ParticipantTile = memo(function ParticipantTile({
         <div className="flex-1 flex items-center justify-center p-4">
           <Avatar className={compact ? "w-12 h-12" : "w-20 h-20"}>
             {user?.avatar_url && <AvatarImage src={user.avatar_url} />}
-            <AvatarFallback style={{ background: "#5865f2", color: "white", fontSize: compact ? "14px" : "24px" }}>{initials}</AvatarFallback>
+            <AvatarFallback style={{ background: "var(--theme-accent)", color: "white", fontSize: compact ? "14px" : "24px" }}>{initials}</AvatarFallback>
           </Avatar>
         </div>
       )}
@@ -723,7 +723,7 @@ const ParticipantTile = memo(function ParticipantTile({
             onClick={() => onViewStream()}
             onMouseDown={(e) => e.preventDefault()}
             className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors hover:brightness-110"
-            style={{ background: "#5865f2" }}
+            style={{ background: "var(--theme-accent)" }}
           >
             <Monitor className="w-4 h-4" />
             View Stream
@@ -738,18 +738,18 @@ const ParticipantTile = memo(function ParticipantTile({
             Speaking
           </span>
         )}
-        {isLocal && <span className="text-xs px-1 rounded" style={{ background: "#5865f2", color: "white" }}>You</span>}
-        {muted && <MicOff className="w-3 h-3 flex-shrink-0" style={{ color: "#f23f43" }} />}
-        {deafened && <Headphones className="w-3 h-3 flex-shrink-0" style={{ color: "#f23f43" }} />}
+        {isLocal && <span className="text-xs px-1 rounded" style={{ background: "var(--theme-accent)", color: "white" }}>You</span>}
+        {muted && <MicOff className="w-3 h-3 flex-shrink-0" style={{ color: "var(--theme-danger)" }} />}
+        {deafened && <Headphones className="w-3 h-3 flex-shrink-0" style={{ color: "var(--theme-danger)" }} />}
       </div>
 
       {!isLocal && !compact && onVolumeChange && (
         <div className="px-3 pb-3 space-y-1">
-          <label className="text-[10px]" style={{ color: "#949ba4" }}>Volume {(volume ?? 1).toFixed(2)}x</label>
+          <label className="text-[10px]" style={{ color: "var(--theme-text-muted)" }}>Volume {(volume ?? 1).toFixed(2)}x</label>
           <input type="range" min={0} max={2} step={0.05} value={volume ?? 1} onChange={(e) => onVolumeChange(Number(e.target.value))} className="w-full" />
           {spatialEnabled && onPanChange && (
             <>
-              <label className="text-[10px]" style={{ color: "#949ba4" }}>Pan {(pan ?? 0).toFixed(2)}</label>
+              <label className="text-[10px]" style={{ color: "var(--theme-text-muted)" }}>Pan {(pan ?? 0).toFixed(2)}</label>
               <input type="range" min={-1} max={1} step={0.05} value={pan ?? 0} onChange={(e) => onPanChange(Number(e.target.value))} className="w-full" />
             </>
           )}


### PR DESCRIPTION
### Motivation

- Centralize color and surface tokens so the app can support custom themes and avoid repeated hard-coded color literals.
- Make components consume semantic tokens (accent, text, background, success/warning/danger, etc.) for consistent theming.

### Description

- Add a set of semantic CSS variables (`--theme-*`, `--app-*`) to `globals.css` and extend existing theme presets with those tokens.
- Replace dozens of inline hard-coded color values across the app (login/register, channel views, components, modals, panels, voice UI, etc.) with `var(--theme-...)` usages so components read from the new tokens.
- Update the Profile Settings custom CSS template and other UI components to reference the new semantic tokens and surface tokens (e.g. `--theme-accent`, `--theme-text-secondary`, `--theme-bg-primary`).
- Adjust small UI behaviors (scrollbar, color-mix uses, border colors) to use the new token values for better consistency.

### Testing

- Ran a TypeScript type check with `tsc` and it completed successfully.
- Ran the linting step with `eslint` and fixed style issues introduced by the changes; the linter passed.
- Performed a production build using `next build` to validate compilation and bundling, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e78ec8b08832599a1fdce3902fe3b)