### PR TITLE
Harden search channel authorization and improve realtime message dedupe

### DIFF
--- a/apps/web/__tests__/search-permissions-contract.test.ts
+++ b/apps/web/__tests__/search-permissions-contract.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+describe("search route permission contracts", () => {
+  it("enforces per-channel VIEW_CHANNELS permission checks", () => {
+    const routePath = resolve(process.cwd(), "app/api/search/route.ts")
+    const source = readFileSync(routePath, "utf8")
+
+    expect(source).toContain("getChannelPermissions")
+    expect(source).toContain('hasPermission(permissions, "VIEW_CHANNELS")')
+  })
+})

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { getChannelPermissions, hasPermission } from "@/lib/permissions"
 
 interface SearchFilters {
   fromUserId?: string
@@ -58,12 +59,39 @@ export async function GET(req: NextRequest) {
     if (!member) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
   }
 
-  let channelIds: string[] = []
-  if (channelId) channelIds = [channelId]
-  else {
-    const { data: channels } = await supabase.from("channels").select("id").eq("server_id", serverId as string).in("type", ["text", "announcement", "forum", "media"])
-    channelIds = (channels ?? []).map((c) => c.id)
+  let scopedChannels: Array<{ id: string; server_id: string | null }> = []
+  if (channelId) {
+    const { data: requestedChannel } = await supabase
+      .from("channels")
+      .select("id, server_id")
+      .eq("id", channelId)
+      .maybeSingle()
+
+    if (!requestedChannel) return NextResponse.json({ error: "Channel not found" }, { status: 404 })
+    if (serverId && requestedChannel.server_id !== serverId) {
+      return NextResponse.json({ error: "Channel does not belong to server" }, { status: 400 })
+    }
+
+    scopedChannels = [requestedChannel]
+  } else {
+    const { data: channels } = await supabase
+      .from("channels")
+      .select("id, server_id")
+      .eq("server_id", serverId as string)
+      .in("type", ["text", "announcement", "forum", "media"])
+    scopedChannels = channels ?? []
   }
+
+  const permissionCheckedChannels = await Promise.all(
+    scopedChannels.map(async (channel) => {
+      if (!channel.server_id) return null
+      const { isAdmin, permissions } = await getChannelPermissions(supabase, channel.server_id, channel.id, user.id)
+      if (!isAdmin && !hasPermission(permissions, "VIEW_CHANNELS")) return null
+      return channel.id
+    })
+  )
+
+  const channelIds = permissionCheckedChannels.filter((id): id is string => Boolean(id))
 
   if (channelIds.length === 0) return NextResponse.json({ results: [], total: 0 })
 

--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -143,7 +143,17 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
 
   const upsertMessage = useCallback((incoming: MessageWithAuthor) => {
     setMessages((prev) => {
-      const existingIndex = prev.findIndex((m) => m.id === incoming.id)
+      const existingIndex = prev.findIndex((m) => {
+        if (m.id === incoming.id) return true
+
+        if (!m.client_nonce || !incoming.client_nonce) return false
+        return (
+          m.client_nonce === incoming.client_nonce
+          && m.author_id === incoming.author_id
+          && m.channel_id === incoming.channel_id
+        )
+      })
+
       const next = existingIndex === -1
         ? [...prev, incoming]
         : prev.map((message, idx) => (idx === existingIndex ? { ...prev[existingIndex], ...incoming } : message))


### PR DESCRIPTION
### Motivation
- Prevent search from leaking messages in channels a user is not allowed to see by enforcing effective per-channel permission checks. 
- Reduce duplicate/incorrect ordering of messages caused by optimistic UI inserts colliding with realtime inserts during reconnects.
- Add a lightweight contract to guard against regressing the search permission enforcement.

### Description
- Enforce per-channel effective permissions in `/api/search` by loading channel rows and filtering them via `getChannelPermissions()` and `hasPermission(..., "VIEW_CHANNELS")`, including validation for `channelId` existence and `serverId`/`channelId` consistency. 
- Improve realtime upsert/dedupe logic in the chat message merge by treating `client_nonce + author_id + channel_id` as an identity match in addition to `id`, so optimistic messages are merged with their server-confirmed rows instead of creating duplicates. 
- Add `apps/web/__tests__/search-permissions-contract.test.ts` to assert the search route uses `getChannelPermissions` and `VIEW_CHANNELS` checks to prevent accidental hardcoding or regressions.

### Testing
- Ran targeted Vitest contract tests `__tests__/permissions-contract.test.ts` and `__tests__/search-permissions-contract.test.ts`, and both tests passed. 
- Performed TypeScript type-check (`tsc --noEmit`) with no errors. 
- Manual inspection and unit-level reasoning used to validate behavior changes to search scope and realtime dedupe logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e7e35fe6c8325bdb98489790a3634)