### PR TITLE
Align login page styling with home page aesthetic

### DIFF
--- a/apps/web/app/(auth)/layout.tsx
+++ b/apps/web/app/(auth)/layout.tsx
@@ -6,8 +6,9 @@ export default function AuthLayout({
   children: React.ReactNode
 }) {
   return (
-    <div className="min-h-screen flex items-center justify-center" style={{ background: 'linear-gradient(135deg, #1a1b1e 0%, #2d2f36 50%, #1a1b1e 100%)' }}>
-      <div className="w-full max-w-md">
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-950 px-6">
+      <div className="pointer-events-none absolute -top-24 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-indigo-500/30 blur-3xl" />
+      <div className="relative w-full max-w-md">
         {children}
       </div>
     </div>

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useToast } from "@/components/ui/use-toast"
-import { Loader2, ShieldCheck, Zap } from "lucide-react"
+import { Loader2, ShieldCheck, Sparkles } from "lucide-react"
 import { startPasskeyLogin, supportsPasskeys } from "@/lib/auth/passkeys-client"
 
 export default function LoginPage() {
@@ -81,19 +81,30 @@ export default function LoginPage() {
   const showFallbacks = !policy.enforce_passkey
 
   return (
-    <div className="rounded-lg p-8 shadow-2xl" style={{ background: "var(--theme-bg-primary)" }}>
-      <div className="text-center mb-8">
-        <div className="flex justify-center mb-4"><div className="w-12 h-12 rounded-full flex items-center justify-center" style={{ background: "var(--theme-accent)" }}><Zap className="w-7 h-7 text-white" /></div></div>
+    <div className="rounded-2xl border border-white/10 bg-slate-900/80 p-8 text-slate-100 shadow-2xl backdrop-blur">
+      <div className="mb-8 text-center">
+        <div className="mb-4 flex justify-center">
+          <div className="inline-flex items-center gap-2 rounded-full border border-indigo-400/40 bg-indigo-500/10 px-3 py-1 text-xs font-medium text-indigo-200">
+            <Sparkles className="h-3.5 w-3.5" /> Secure sign in
+          </div>
+        </div>
         <h1 className="text-2xl font-bold text-white">{isNewUser ? "Verify your email" : "Welcome back!"}</h1>
-        <p style={{ color: "var(--theme-text-secondary)" }} className="text-sm mt-1">{isNewUser ? "Check your inbox for a verification link, then log in below." : "We’re so excited to see you again!"}</p>
+        <p className="mt-1 text-sm text-slate-300">
+          {isNewUser ? "Check your inbox for a verification link, then log in below." : "We’re so excited to see you again!"}
+        </p>
       </div>
 
-      <div className="rounded-md p-3 mb-4 text-sm" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)", color: "var(--theme-text-secondary)" }}>
-        <p className="font-medium text-white flex items-center gap-2 mb-1"><ShieldCheck className="w-4 h-4" />Passkey-first security</p>
+      <div className="mb-4 rounded-lg border border-white/10 bg-slate-950/60 p-3 text-sm text-slate-300">
+        <p className="mb-1 flex items-center gap-2 font-medium text-white"><ShieldCheck className="h-4 w-4 text-emerald-400" />Passkey-first security</p>
         <p>Use your device passkey for phishing-resistant sign in. If your policy allows it, password and magic link remain available as backups.</p>
       </div>
 
-      <Button type="button" disabled={passkeyLoading} onClick={handlePasskeyLogin} className="w-full h-11 font-medium mb-4" style={{ background: "var(--theme-positive)" }}>
+      <Button
+        type="button"
+        disabled={passkeyLoading}
+        onClick={handlePasskeyLogin}
+        className="mb-4 h-11 w-full bg-indigo-500 font-medium text-white transition hover:bg-indigo-400"
+      >
         {passkeyLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Continue with Passkey
       </Button>
 
@@ -101,27 +112,49 @@ export default function LoginPage() {
         <>
           <form onSubmit={handleLogin} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="email" className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-secondary)" }}>Email <span className="text-red-500">*</span></Label>
-              <Input id="email" type="email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} required className="h-10" style={{ background: "var(--theme-bg-tertiary)", borderColor: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)" }} />
+              <Label htmlFor="email" className="text-xs font-semibold uppercase tracking-wider text-slate-300">Email <span className="text-red-400">*</span></Label>
+              <Input
+                id="email"
+                type="email"
+                value={form.email}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+                required
+                className="h-10 border-white/10 bg-slate-800 text-slate-100 placeholder:text-slate-500"
+              />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="password" className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-secondary)" }}>Password <span className="text-red-500">*</span></Label>
-              <Input id="password" type="password" value={form.password} onChange={(e) => setForm({ ...form, password: e.target.value })} required className="h-10" style={{ background: "var(--theme-bg-tertiary)", borderColor: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)" }} />
+              <Label htmlFor="password" className="text-xs font-semibold uppercase tracking-wider text-slate-300">Password <span className="text-red-400">*</span></Label>
+              <Input
+                id="password"
+                type="password"
+                value={form.password}
+                onChange={(e) => setForm({ ...form, password: e.target.value })}
+                required
+                className="h-10 border-white/10 bg-slate-800 text-slate-100 placeholder:text-slate-500"
+              />
             </div>
-            <Button type="submit" disabled={loading} className="w-full h-11 font-medium" style={{ background: "var(--theme-accent)" }}>
+            <Button type="submit" disabled={loading} className="h-11 w-full bg-indigo-500 font-medium text-white transition hover:bg-indigo-400">
               {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Log In with Password
             </Button>
           </form>
 
-          <Button type="button" variant="outline" disabled={magicLinkLoading} onClick={handleMagicLink} className="w-full h-10 mt-4" style={{ borderColor: "var(--theme-text-faint)", color: "var(--theme-text-secondary)", background: "transparent" }}>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={magicLinkLoading}
+            onClick={handleMagicLink}
+            className="mt-4 h-10 w-full border-white/20 bg-white/5 text-slate-200 hover:bg-white/10"
+          >
             {magicLinkLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Send Magic Link
           </Button>
         </>
       )}
 
-      {!showFallbacks && <p className="text-xs mt-3" style={{ color: "var(--theme-warning)" }}>Your account policy requires passkey login. Contact an owner/admin if you need recovery help.</p>}
+      {!showFallbacks && <p className="mt-3 text-xs text-amber-300">Your account policy requires passkey login. Contact an owner/admin if you need recovery help.</p>}
 
-      <p className="text-center text-sm mt-6" style={{ color: "var(--theme-text-secondary)" }}>Need an account? <Link href="/register" className="hover:underline" style={{ color: "var(--theme-link)" }}>Register</Link></p>
+      <p className="mt-6 text-center text-sm text-slate-300">
+        Need an account? <Link href="/register" className="text-indigo-300 hover:underline">Register</Link>
+      </p>
     </div>
   )
 }


### PR DESCRIPTION
### Motivation

- Make the login experience visually consistent with the home/landing page by reusing the same background gradient, glow accent, and component surface treatments.
- Improve contrast and visual hierarchy for the auth area while keeping existing login and passkey flows unchanged.

### Description

- Updated the auth container background to use the same indigo/slate gradient and added the soft glow accent used on the home page by changing `apps/web/app/(auth)/layout.tsx`.
- Restyled the login card in `apps/web/app/(auth)/login/page.tsx` to a rounded, bordered, semi-transparent slate surface with `backdrop-blur`, adjusted text colors to `text-slate-*`, and swapped the small hero icon to `Sparkles` to match the landing language.
- Harmonized CTAs and inputs to use indigo-accent buttons and slate input surfaces (updated button/input classes and removed inline theme tokens where appropriate) while preserving all auth logic and handlers.
- Minor copy/color tweaks for the passkey callout, magic-link button, and register link to match the home page visual language.

### Testing

- Ran `npm run lint --workspace @vortex/web` which failed due to pre-existing style-guardrail violations across unrelated files and not caused by these changes. 
- Ran `npx eslint 'apps/web/app/(auth)/login/page.tsx' 'apps/web/app/(auth)/layout.tsx'` which was not usable in this environment due to the root-level ESLint flat-config discovery issue. 
- Verified visually by launching the dev server with `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run dev --workspace @vortex/web`, loading `/login`, and capturing a screenshot for confirmation that the login page now matches the home page aesthetic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f353107748325ba247dcc489ad81b)