### PR TITLE
Fix login presence auto-detection to default online

### DIFF
--- a/apps/web/hooks/use-presence-sync.ts
+++ b/apps/web/hooks/use-presence-sync.ts
@@ -16,6 +16,7 @@ export function usePresenceSync(userId: string | null, status?: PresenceStatus) 
   const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null)
   const currentStatusRef = useRef<PresenceStatus>(resolveInitialPresenceStatus(status))
   const explicitStatusRef = useRef<PresenceStatus>(resolveInitialPresenceStatus(status))
+  const isIdleExplicitRef = useRef<boolean>(status === "idle")
   const idleTimerRef = useRef<number | undefined>(undefined)
   const userIdRef = useRef<string | null>(null)
 
@@ -24,6 +25,7 @@ export function usePresenceSync(userId: string | null, status?: PresenceStatus) 
   useEffect(() => {
     if (status === "idle" || status === "dnd" || status === "invisible") {
       explicitStatusRef.current = status
+      isIdleExplicitRef.current = status === "idle"
     }
   }, [status])
 
@@ -38,6 +40,14 @@ export function usePresenceSync(userId: string | null, status?: PresenceStatus) 
       currentStatusRef.current = nextStatus
       if (rememberExplicit) {
         explicitStatusRef.current = nextStatus
+      }
+
+      if (nextStatus === "idle") {
+        isIdleExplicitRef.current = rememberExplicit
+      } else if (nextStatus === "online") {
+        isIdleExplicitRef.current = false
+      } else if (rememberExplicit) {
+        isIdleExplicitRef.current = false
       }
 
       if (persistUserRecord) {
@@ -96,7 +106,7 @@ export function usePresenceSync(userId: string | null, status?: PresenceStatus) 
       })
 
     const onActivity = () => {
-      if (currentStatusRef.current === "idle") {
+      if (currentStatusRef.current === "idle" && !isIdleExplicitRef.current) {
         persistStatus("online", { persistUserRecord: false, rememberExplicit: false })
       }
       scheduleIdle()
@@ -113,7 +123,7 @@ export function usePresenceSync(userId: string | null, status?: PresenceStatus) 
         return
       }
 
-      persistStatus("online")
+      persistStatus("online", { persistUserRecord: false, rememberExplicit: false })
       scheduleIdle()
     }
 


### PR DESCRIPTION
### Motivation
- Ensure a user session marks the user `online` on login by default unless they have explicitly chosen an explicit profile status (`idle`, `dnd`, or `invisible`).
- Prevent transient, auto-detected states (idle on inactivity, offline on tab hide/unload) from overwriting the user's persisted profile `status` and leaving users stuck as offline.

### Description
- Added `resolveInitialPresenceStatus` and initialized presence refs with it so sessions start `online` unless the user previously set an explicit status. 
- Refactored `persistStatus` to accept options and stopped writing transient auto-detected states (`idle`, `offline`, auto-restore `online`) back to the `users` table while still tracking them via the realtime presence channel. 
- Avoided persisting `offline` on page unload and now only `untrack`s the realtime presence to preserve manual profile statuses. 
- Preserved explicit/manual statuses by remembering them when appropriate and continuing to track realtime presence via Supabase.

### Testing
- Ran `npm --prefix apps/web run type-check` and it completed successfully. 
- Ran `npm --prefix apps/web run test -- use-presence-sync` and the test filter found no matching tests. 
- Ran `npm --prefix apps/web run lint -- hooks/use-presence-sync.ts` which failed due to pre-existing style-guardrail issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f38ecb4b883259bda9790f8372737)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized presence status synchronization by reducing unnecessary database writes during visibility changes, activity detection, and page unload scenarios.
  
* **Bug Fixes**
  * Improved handling of idle status to ensure it's properly preserved as an explicit user status across state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->