### PR TITLE
Add poll creation flow to chat composer

### DIFF
--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -123,7 +123,10 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
       const clickedToggleButton = composerMenuButtonRef.current?.contains(target)
       if (!clickedInsideMenu && !clickedInsidePollCreator && !clickedToggleButton) {
         setShowComposerMenu(false)
-        setShowPollCreator(false)
+        if (showPollCreator) {
+          setShowPollCreator(false)
+          resetPollDraftToBlank()
+        }
       }
     }
 
@@ -277,6 +280,25 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
     setCursorPosition(e.currentTarget.selectionStart)
   }
 
+  const canInsertPoll = pollQuestion.trim().length > 0 && pollOptions.filter((option) => option.trim().length > 0).length >= 2
+
+  function resetPollDraftToBlank() {
+    setPollQuestion("")
+    setPollOptions([])
+  }
+
+  function handlePollInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key !== "Enter" || event.shiftKey) return
+    if (!canInsertPoll) return
+    event.preventDefault()
+    handleCreatePoll()
+  }
+
+  function removePollOption(index: number) {
+    if (pollOptions.length <= 2) return
+    setPollOptions((prev) => prev.filter((_, optionIndex) => optionIndex !== index))
+  }
+
   function handleCreatePoll() {
     const question = pollQuestion.trim()
     const options = pollOptions.map((option) => option.trim()).filter(Boolean)
@@ -391,31 +413,47 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
         >
           <div className="flex items-center justify-between">
             <p className="text-xs font-semibold" style={{ color: "var(--theme-text-primary)" }}>Create poll</p>
-            <button type="button" onClick={() => setShowPollCreator(false)} style={{ color: "var(--theme-text-muted)" }}>
+            <button type="button" onClick={() => {
+              setShowPollCreator(false)
+              resetPollDraftToBlank()
+            }} style={{ color: "var(--theme-text-muted)" }}>
               <X className="w-3.5 h-3.5" />
             </button>
           </div>
           <input
             value={pollQuestion}
             onChange={(event) => setPollQuestion(event.target.value)}
+            onKeyDown={handlePollInputKeyDown}
             placeholder="Poll question"
             className="w-full px-2 py-1.5 rounded text-sm focus:outline-none"
             style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-normal)" }}
           />
           <div className="space-y-1.5">
             {pollOptions.map((option, index) => (
-              <input
-                key={`poll-option-${index}`}
-                value={option}
-                onChange={(event) => {
-                  const next = [...pollOptions]
-                  next[index] = event.target.value
-                  setPollOptions(next)
-                }}
-                placeholder={`Option ${index + 1}`}
-                className="w-full px-2 py-1.5 rounded text-sm focus:outline-none"
-                style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-normal)" }}
-              />
+              <div key={`poll-option-${index}`} className="flex items-center gap-1.5">
+                <input
+                  value={option}
+                  onChange={(event) => {
+                    const next = [...pollOptions]
+                    next[index] = event.target.value
+                    setPollOptions(next)
+                  }}
+                  onKeyDown={handlePollInputKeyDown}
+                  placeholder={`Option ${index + 1}`}
+                  className="w-full px-2 py-1.5 rounded text-sm focus:outline-none"
+                  style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-normal)" }}
+                />
+                <button
+                  type="button"
+                  onClick={() => removePollOption(index)}
+                  disabled={pollOptions.length <= 2}
+                  className="px-2 py-1 rounded text-xs disabled:opacity-50"
+                  style={{ color: "var(--theme-text-muted)", border: "1px solid var(--theme-bg-tertiary)" }}
+                  aria-label={`Remove option ${index + 1}`}
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </div>
             ))}
           </div>
           <div className="flex items-center justify-between">
@@ -431,7 +469,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
             <button
               type="button"
               onClick={handleCreatePoll}
-              disabled={pollQuestion.trim().length === 0 || pollOptions.filter((option) => option.trim().length > 0).length < 2}
+              disabled={!canInsertPoll}
               className="px-2 py-1 rounded text-xs font-medium disabled:opacity-50"
               style={{ background: "var(--theme-accent)", color: "white" }}
             >
@@ -451,10 +489,14 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
       >
         <div className="relative mb-1">
           <button
+            type="button"
             ref={composerMenuButtonRef}
             onClick={() => {
               setShowComposerMenu((prev) => !prev)
-              setShowPollCreator(false)
+              if (showPollCreator) {
+                setShowPollCreator(false)
+                resetPollDraftToBlank()
+              }
             }}
             className="motion-interactive motion-press flex-shrink-0 hover:text-white"
             style={{ color: "var(--theme-text-secondary)" }}
@@ -483,6 +525,9 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
                 type="button"
                 onClick={() => {
                   setShowComposerMenu(false)
+                  if (pollOptions.length === 0) {
+                    setPollOptions(["", ""])
+                  }
                   setShowPollCreator(true)
                 }}
                 className="w-full flex items-center gap-2 px-2 py-1.5 rounded text-left text-xs hover:bg-white/10"

--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -118,6 +118,8 @@ export const MessageItem = memo(function MessageItem({
     },
     {} as Record<string, { count: number; users: string[]; hasOwn: boolean }>
   )
+  const pollEmojiSet = parsedPoll ? new Set(parsedPoll.options.map((_, index) => POLL_NUMBER_EMOJIS[index])) : null
+  const genericReactionEntries = Object.entries(reactionGroups).filter(([emoji]) => !pollEmojiSet?.has(emoji))
 
   async function handleEditSubmit() {
     if (editContent.trim() && editContent !== message.content) {
@@ -424,6 +426,7 @@ export const MessageItem = memo(function MessageItem({
                           const votes = reactionGroups[emoji]?.count ?? 0
                           return (
                             <button
+                              type="button"
                               key={`poll-option-${message.id}-${index}`}
                               onClick={() => onReaction(emoji)}
                               className="w-full flex items-center justify-between rounded px-2 py-1.5 text-sm hover:bg-white/5"
@@ -475,9 +478,9 @@ export const MessageItem = memo(function MessageItem({
                   )}
 
                   {/* Reactions */}
-                  {Object.entries(reactionGroups).length > 0 && (
+                  {genericReactionEntries.length > 0 && (
                     <div className="flex flex-wrap gap-1 mt-2">
-                      {Object.entries(reactionGroups).map(([emoji, { count, hasOwn, users }]) => (
+                      {genericReactionEntries.map(([emoji, { count, hasOwn, users }]) => (
                         <button
                           key={emoji}
                           onClick={() => onReaction(emoji)}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, Discord-like poll UX from the chat composer so users can create quick polls without leaving the composer. 
- Reuse the existing reactions system to represent poll votes so poll state is persisted without adding a new backend model.

### Description
- Replaced the composer single `+` action with a small composer menu that offers `Attach file` and `Create poll` actions in `apps/web/components/chat/message-input.tsx`.
- Added an inline poll creator panel in the composer that accepts a question and 2–8 options and inserts a poll into the draft as a `[POLL]...[/POLL]` block when the user clicks `Insert poll` in `apps/web/components/chat/message-input.tsx`.
- Implemented poll parsing and rendering in the message view by extracting `[POLL]` blocks and rendering a poll card with numbered options in `apps/web/components/chat/message-item.tsx`.
- Wired poll option buttons to trigger the existing emoji reaction handler using number emojis (`1️⃣`–`8️⃣`), so votes are recorded via the existing reaction plumbing.

### Testing
- Ran type checking with `npm run type-check` in `apps/web` and it completed successfully.
- Ran unit tests with `npm test` (Vitest) in `apps/web` and all tests passed (87 tests across 15 files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f4042c72c8325a30defd291533c73)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now create polls within the message composer
  * New "Add to message" menu provides options to attach files or create polls
  * Polls display inline in conversations with questions and voting options marked with emoji indicators
  * Recipients can vote on polls using emoji reactions to see real-time vote counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->