### PR TITLE
Fix Postgres transition table trigger definition in DM E2EE migration

### DIFF
--- a/supabase/migrations/00030_dm_e2ee.sql
+++ b/supabase/migrations/00030_dm_e2ee.sql
@@ -126,8 +126,15 @@ END;
 $$;
 
 DROP TRIGGER IF EXISTS dm_channel_keys_prune_after_write ON public.dm_channel_keys;
-CREATE TRIGGER dm_channel_keys_prune_after_write
-  AFTER INSERT OR UPDATE ON public.dm_channel_keys
+DROP TRIGGER IF EXISTS dm_channel_keys_prune_after_insert ON public.dm_channel_keys;
+CREATE TRIGGER dm_channel_keys_prune_after_insert
+  AFTER INSERT ON public.dm_channel_keys
+  REFERENCING NEW TABLE AS new_rows
+  FOR EACH STATEMENT EXECUTE FUNCTION public.dm_channel_keys_prune_trigger();
+
+DROP TRIGGER IF EXISTS dm_channel_keys_prune_after_update ON public.dm_channel_keys;
+CREATE TRIGGER dm_channel_keys_prune_after_update
+  AFTER UPDATE ON public.dm_channel_keys
   REFERENCING NEW TABLE AS new_rows
   FOR EACH STATEMENT EXECUTE FUNCTION public.dm_channel_keys_prune_trigger();
 


### PR DESCRIPTION
### Motivation
- Running migration `supabase/migrations/00030_dm_e2ee.sql` failed with `transition tables cannot be specified for triggers with more than one event`, because a statement-level trigger was defined with `AFTER INSERT OR UPDATE` while using `REFERENCING NEW TABLE`. 
- The change separates events to comply with PostgreSQL constraints while preserving the original prune behavior.

### Description
- Updated `supabase/migrations/00030_dm_e2ee.sql` to drop the old trigger and create two statement-level triggers: `dm_channel_keys_prune_after_insert` (`AFTER INSERT`) and `dm_channel_keys_prune_after_update` (`AFTER UPDATE`), both using `REFERENCING NEW TABLE AS new_rows` and executing `public.dm_channel_keys_prune_trigger()`.
- Added a defensive `DROP TRIGGER IF EXISTS dm_channel_keys_prune_after_write` to clean up any previous installation that used the combined trigger name.
- Did not modify the `public.dm_channel_keys_prune_trigger()` function logic, so the pruning behavior remains the same.

### Testing
- Reviewed the SQL diff with `git diff -- supabase/migrations/00030_dm_e2ee.sql`, which showed the new separate triggers (succeeded). 
- Confirmed the change was recorded in the repository with `git show --stat --oneline HEAD` (succeeded). 
- Inspected the updated file content with `nl -ba supabase/migrations/00030_dm_e2ee.sql | sed -n '118,155p'` to verify the trigger definitions (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fad4ee5848325a7bc8323f088c053)