### PR TITLE
Make recovery_codes policies idempotent in migration 00034

### DIFF
--- a/supabase/migrations/00034_recovery_codes.sql
+++ b/supabase/migrations/00034_recovery_codes.sql
@@ -16,10 +16,12 @@ CREATE INDEX IF NOT EXISTS idx_recovery_codes_user_unused ON public.recovery_cod
 ALTER TABLE public.recovery_codes ENABLE ROW LEVEL SECURITY;
 
 -- Users can read their own codes (to see count remaining) but service role handles insert/update
+DROP POLICY IF EXISTS "Users can view own recovery codes" ON public.recovery_codes;
 CREATE POLICY "Users can view own recovery codes"
   ON public.recovery_codes FOR SELECT
   USING (user_id = auth.uid());
 
+DROP POLICY IF EXISTS "Users can manage own recovery codes" ON public.recovery_codes;
 CREATE POLICY "Users can manage own recovery codes"
   ON public.recovery_codes FOR ALL
   USING (user_id = auth.uid())


### PR DESCRIPTION
### Motivation

- Prevent running migration `00034` from failing with `ERROR: 42710: policy "Users can view own recovery codes" for table "recovery_codes" already exists` when policies are already present.

### Description

- Add `DROP POLICY IF EXISTS` immediately before both `CREATE POLICY` statements in `supabase/migrations/00034_recovery_codes.sql` to make the policy creation idempotent.
- The two guarded policies are `"Users can view own recovery codes"` and `"Users can manage own recovery codes"` and no other schema or permission logic was changed.

### Testing

- Reviewed the updated SQL file and diff to confirm only idempotency guards were added and policy logic unchanged. (succeeded)
- Ran `git diff --check HEAD~1..HEAD` and `git status --short` to validate the change and commit state. (succeeded)
- Committed the change with message `Make recovery code policies idempotent in migration 00034`. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a051d546648325b799a9bea8da40f8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened security controls for recovery codes to ensure users can only access and modify their own codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->