### PR TITLE
Fix server list loading in /channels layout to avoid empty sidebar

### DIFF
--- a/apps/web/app/channels/layout.tsx
+++ b/apps/web/app/channels/layout.tsx
@@ -28,7 +28,7 @@ export default async function ChannelsLayout({
   if (profileError || !profile) redirect("/login")
 
   if (serverMembersError) {
-    console.error("Failed to load server memberships", serverMembersError)
+    throw new Error(`Failed to load server memberships: ${serverMembersError.message}`)
   }
 
   const membershipIds = (serverMembers ?? []).map((membership) => membership.server_id)
@@ -37,7 +37,7 @@ export default async function ChannelsLayout({
     : { data: [], error: null }
 
   if (serversError) {
-    console.error("Failed to load server rows", serversError)
+    throw new Error(`Failed to load servers for membershipIds (${membershipIds.join(", ")}): ${serversError.message}`)
   }
 
   const serversById = new Map((serverRows ?? []).map((server) => [server.id, server]))


### PR DESCRIPTION
### Motivation
- The layout previously relied on a nested Supabase relation (`server_members` with `servers(*)`) and did not surface query errors, which could silently result in an empty server sidebar when the embedding path failed.
- The intent is to make server loading more robust and observable so the UI no longer hides joined servers due to a failed nested relation fetch.

### Description
- Reworked data loading in `apps/web/app/channels/layout.tsx` to first fetch `server_members` (`server_id`, `joined_at`) for the current user and then fetch server rows with a dedicated `servers` query using those IDs.
- Preserved membership ordering by mapping server rows back into the membership ID order before passing the list into `AppProvider`.
- Added explicit error logging for both the membership query and the servers query so failures are visible instead of failing silently.
- Removed the previous dependency on the nested `servers(*)` embed to avoid relation/embedding failure modes.

### Testing
- Ran type checks with `npm run -w apps/web type-check` and it succeeded.✅
- Ran lint with `npm run -w apps/web lint` which failed due to pre-existing repository-wide style-guardrail violations unrelated to this change (reported many `inline-style-color` and token issues).⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a05b0dd5a88325ae5d75d913c60365)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized server data loading with a two-step fetch and reconstruction of server entries.
  * Added clearer error handling for server-related fetches.
  * Preserves the existing rendering behavior and public interfaces (no visible API changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->