### PR TITLE
Fix member list loading by using server members API

### DIFF
--- a/apps/web/components/layout/member-list.tsx
+++ b/apps/web/components/layout/member-list.tsx
@@ -66,6 +66,7 @@ export function MemberList({ serverId }: Props) {
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null)
   const [loadingMembers, setLoadingMembers] = useState(true)
   const channelRef = useRef<RealtimeChannel | null>(null)
+  const memberFetchControllerRef = useRef<AbortController | null>(null)
   const supabase = useMemo(() => createClientSupabaseClient(), [])
 
   useEffect(() => {
@@ -74,12 +75,18 @@ export function MemberList({ serverId }: Props) {
 
   useEffect(() => {
     async function fetchMembers() {
+      memberFetchControllerRef.current?.abort()
+      const controller = new AbortController()
+      memberFetchControllerRef.current = controller
+      const encodedServerId = encodeURIComponent(serverId)
+
       setLoadingMembers(true)
       try {
-        const response = await fetch(`/api/servers/${serverId}/members`, {
+        const response = await fetch(`/api/servers/${encodedServerId}/members`, {
           method: "GET",
           credentials: "include",
           cache: "no-store",
+          signal: controller.signal,
         })
 
         if (!response.ok) {
@@ -89,6 +96,8 @@ export function MemberList({ serverId }: Props) {
         type ApiRoleEntry = { role_id: string; roles: RoleRow | null }
         type ApiMember = Omit<MemberData, "roles"> & { roles?: ApiRoleEntry[] }
         const rawMembers = (await response.json()) as ApiMember[]
+        if (controller.signal.aborted) return
+
         const merged: MemberData[] = rawMembers.map((member) => ({
           ...member,
           roles: (member.roles ?? [])
@@ -107,11 +116,16 @@ export function MemberList({ serverId }: Props) {
           nickname: m.nickname,
         })))
       } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") return
+
         console.error("Failed to fetch members:", error)
         setMembers([])
         useAppStore.getState().setMembers(serverId, [])
       } finally {
-        setLoadingMembers(false)
+        if (memberFetchControllerRef.current === controller) {
+          memberFetchControllerRef.current = null
+          setLoadingMembers(false)
+        }
       }
     }
 
@@ -180,6 +194,8 @@ export function MemberList({ serverId }: Props) {
       })
 
     return () => {
+      memberFetchControllerRef.current?.abort()
+      memberFetchControllerRef.current = null
       channelRef.current = null
       supabase.removeChannel(channel)
       for (const timer of recentActivityTimersRef.current.values()) {


### PR DESCRIPTION
### Motivation
- The client-side member hydration used two direct Supabase queries and brittle join logic which could break after backend/schema changes causing the right-side member list to appear empty.
- Loading members through the server API keeps the UI aligned with server-side auth/policy behavior and avoids relation-shape drift.

### Description
- Replaced the dual client-side Supabase queries in `MemberList` with a single `fetch` to `/api/servers/${serverId}/members` in `apps/web/components/layout/member-list.tsx`.
- Normalized the API payload shape (`roles: member_roles(...)`) into the `RoleRow[]` format consumed by the UI so role coloring and role-dependent rendering continue to work.
- Added `try/catch/finally` defensive handling to clear stale member state on error and always set `loadingMembers` to `false`.
- Presence tracking and UI rendering logic were left unchanged and mention-store hydration still updates `useAppStore` with lightweight member data.

### Testing
- Ran `npm run -w apps/web type-check`, which succeeded (`tsc --noEmit`).
- Ran `npm run -w apps/web lint`, which failed due to existing `style-guardrails` baseline violations unrelated to this change.
- Attempted a Playwright page screenshot to validate UI, but the run failed because no dev server was available (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a062414cc0832595a82d51545e0bf9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of member list loading with enhanced error handling and fallback behavior.

* **Performance**
  * Optimized member list data fetching for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->