### PR TITLE
Add duplication audit and extract shared presence-status helpers

### DIFF
--- a/apps/web/components/layout/member-list.tsx
+++ b/apps/web/components/layout/member-list.tsx
@@ -17,6 +17,7 @@ import type { RealtimeChannel } from "@supabase/supabase-js"
 import { Skeleton } from "@/components/ui/skeleton"
 import { openDmChannel, sendFriendRequest } from "@/lib/social-actions"
 import { ReportModal } from "@/components/modals/report-modal"
+import { getStatusColor } from "@/lib/presence-status"
 
 interface Props {
   serverId: string
@@ -44,14 +45,6 @@ interface MemberData {
   roles: RoleRow[]
 }
 
-function getStatusColor(status?: string) {
-  switch (status) {
-    case "online": return "var(--theme-success)"
-    case "idle": return "var(--theme-warning)"
-    case "dnd": return "var(--theme-danger)"
-    default: return "var(--theme-presence-offline)"
-  }
-}
 
 /** Collapsible member list panel showing server members grouped by role with real-time presence indicators. */
 export function MemberList({ serverId }: Props) {

--- a/apps/web/components/profile/profile-panel.tsx
+++ b/apps/web/components/profile/profile-panel.tsx
@@ -8,6 +8,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { useToast } from "@/components/ui/use-toast"
 import { openDmChannel, sendFriendRequest } from "@/lib/social-actions"
 import { sanitizeBannerColor } from "@/lib/banner-color"
+import { getStatusLabel } from "@/lib/presence-status"
 import type { RoleRow } from "@/types/database"
 import { PERMISSIONS } from "@vortex/shared"
 
@@ -33,15 +34,6 @@ interface ProfilePanelProps {
   onClose: () => void
 }
 
-function getStatusLabel(status?: string) {
-  switch (status) {
-    case "online": return "Online"
-    case "idle": return "Idle"
-    case "dnd": return "Do Not Disturb"
-    case "invisible": return "Invisible"
-    default: return "Offline"
-  }
-}
 
 function getJoinedDate(rawDate?: string) {
   if (!rawDate) return "Unknown"

--- a/apps/web/components/user-profile-popover.tsx
+++ b/apps/web/components/user-profile-popover.tsx
@@ -7,6 +7,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { useToast } from "@/components/ui/use-toast"
 import type { RoleRow } from "@/types/database"
+import { getStatusColor, getStatusLabel } from "@/lib/presence-status"
 
 interface UserProfileData {
   username: string
@@ -30,24 +31,6 @@ interface UserProfilePopoverProps {
   children: React.ReactNode
 }
 
-function getStatusColor(status?: string) {
-  switch (status) {
-    case "online": return "var(--theme-success)"
-    case "idle": return "var(--theme-warning)"
-    case "dnd": return "var(--theme-danger)"
-    default: return "var(--theme-presence-offline)"
-  }
-}
-
-function getStatusLabel(status?: string) {
-  switch (status) {
-    case "online": return "Online"
-    case "idle": return "Idle"
-    case "dnd": return "Do Not Disturb"
-    case "invisible": return "Invisible"
-    default: return "Offline"
-  }
-}
 
 /** Popover card showing a user's profile (avatar, name, status, bio, roles) with optional Message and Add Friend actions. */
 export function UserProfilePopover({

--- a/apps/web/lib/presence-status.ts
+++ b/apps/web/lib/presence-status.ts
@@ -1,0 +1,27 @@
+export function getStatusColor(status?: string) {
+  switch (status) {
+    case "online":
+      return "var(--theme-success)"
+    case "idle":
+      return "var(--theme-warning)"
+    case "dnd":
+      return "var(--theme-danger)"
+    default:
+      return "var(--theme-presence-offline)"
+  }
+}
+
+export function getStatusLabel(status?: string) {
+  switch (status) {
+    case "online":
+      return "Online"
+    case "idle":
+      return "Idle"
+    case "dnd":
+      return "Do Not Disturb"
+    case "invisible":
+      return "Invisible"
+    default:
+      return "Offline"
+  }
+}

--- a/docs/duplication-audit-report.md
+++ b/docs/duplication-audit-report.md
@@ -1,0 +1,188 @@
+# Code Duplication Audit Report
+
+Date: 2026-02-26
+
+Scope reviewed: `apps/web`, `apps/signal`, `packages/shared`, `supabase/migrations`.
+
+> Note: Automated third-party duplication scanner (`jscpd`) could not be installed in this environment due npm registry policy (`403 Forbidden`), so this audit uses repository-local static inspection and targeted function-level matching.
+
+## Findings
+
+### 1) EXACT DUPLICATE — webhook CRUD helper functions in two modal components
+
+**Locations**
+- `handleCreate` duplicated between:
+  - `apps/web/components/modals/server-settings-modal.tsx`
+  - `apps/web/components/modals/webhooks-modal.tsx`
+- `handleDelete` duplicated between same files.
+- `copyUrl` duplicated between same files.
+- `channelName` duplicated between same files.
+
+**Measured duplication**
+- Duplicated lines: `33` identical lines across these helper functions (`18 + 7 + 5 + 3`).
+- Duplication density in smaller file (`webhooks-modal.tsx`): `33 / 170 = 19.4%`.
+- Duplication density across both files combined: `33 / 2165 = 1.5%`.
+
+**Importance**: **7/10**
+
+**Extraction method**: module-level utility for webhook mutations + UI formatting helper.
+
+**Drop-in DRY remediation**
+```ts
+// apps/web/lib/webhooks.ts
+export async function createWebhook(channelId: string, name: string) { /* fetch POST ... */ }
+export async function deleteWebhook(webhookId: string) { /* fetch DELETE ... */ }
+export async function copyToClipboard(text: string) { return navigator.clipboard.writeText(text) }
+export function formatChannelName(id: string | null, channels: { id: string; name: string }[]) {
+  return channels.find((c) => c.id === id)?.name ?? "Unknown channel"
+}
+```
+Then both modal components call these utilities and only handle local UI state/toasts.
+
+**Estimated effort**: **S (1-2 hours)**.
+
+---
+
+### 2) EXACT DUPLICATE — DM call media toggles
+
+**Locations**
+- `toggleMute` duplicated between:
+  - `apps/web/components/dm/dm-channel-area.tsx`
+  - `apps/web/components/dm/dm-call.tsx`
+- `toggleVideo` duplicated between same files.
+
+**Measured duplication**
+- Duplicated lines: `8` identical lines.
+- Duplication density in `dm-call.tsx`: `8 / 351 = 2.3%`.
+- Duplication density across both files combined: `8 / 1539 = 0.5%`.
+
+**Importance**: **6/10**
+
+**Extraction method**: React hook utility (`useCallMediaToggles`).
+
+**Drop-in DRY remediation**
+```ts
+// apps/web/lib/webrtc/use-call-media-toggles.ts
+export function useCallMediaToggles(setMuted: (v: boolean) => void, setVideoOff: (v: boolean) => void) {
+  const toggleMute = () => setMuted((prev) => !prev)
+  const toggleVideo = () => setVideoOff((prev) => !prev)
+  return { toggleMute, toggleVideo }
+}
+```
+
+**Estimated effort**: **S (30-60 minutes)**.
+
+---
+
+### 3) NEAR DUPLICATE (remediated) — presence/status mapping helpers across profile/member UI
+
+**Previously duplicated locations**
+- `getStatusColor` in:
+  - `apps/web/components/user-profile-popover.tsx`
+  - `apps/web/components/layout/member-list.tsx`
+- `getStatusLabel` in:
+  - `apps/web/components/user-profile-popover.tsx`
+  - `apps/web/components/profile/profile-panel.tsx`
+
+**Measured duplication (before fix)**
+- `getStatusColor`: 100% identical between two files.
+- `getStatusLabel`: 100% identical between two files.
+- Approx. duplicated lines removed: `~22` lines.
+
+**Importance**: **5/10**
+
+**Extraction method**: shared utility module.
+
+**Implemented DRY fix (this change)**
+- Added `apps/web/lib/presence-status.ts` and migrated all three components to import shared helpers.
+
+**Estimated effort**: **Completed (S, <30 minutes)**.
+
+---
+
+### 4) STRUCTURAL DUPLICATE — auth/permission/hierarchy flow repeated in member role assignment API
+
+**Location**
+- `apps/web/app/api/servers/[serverId]/members/[userId]/roles/route.ts`
+  - `POST` and `DELETE` handlers repeat the same sequence:
+    1. user auth check
+    2. MANAGE_ROLES check
+    3. role hierarchy constraint for non-admin
+
+**Measured duplication**
+- Shared structure appears in ~`34` lines in both handlers.
+- Duplication density in file: `34 / 142 = 23.9%` (near-duplicate pattern, not byte-identical due to message/action differences).
+
+**Importance**: **8/10**
+
+**Extraction method**: route-local helper module (`assertRoleMutationAllowed`).
+
+**Drop-in DRY remediation**
+```ts
+async function assertRoleMutationAllowed(
+  supabase: Awaited<ReturnType<typeof createServerSupabaseClient>>,
+  serverId: string,
+  actorUserId: string,
+  roleId: string,
+  denyMessage: string,
+) {
+  const { isAdmin, permissions } = await getMemberPermissions(supabase, serverId, actorUserId)
+  if (!isAdmin && !hasPermission(permissions, "MANAGE_ROLES")) {
+    return NextResponse.json({ error: "Missing MANAGE_ROLES permission" }, { status: 403 })
+  }
+  if (isAdmin) return null
+
+  const [{ data: targetRole }, actorMaxPosition] = await Promise.all([
+    supabase.from("roles").select("position").eq("id", roleId).eq("server_id", serverId).single(),
+    getActorMaxRolePosition(supabase, serverId, actorUserId),
+  ])
+  if (!targetRole) return NextResponse.json({ error: "Role not found" }, { status: 404 })
+  if (targetRole.position >= actorMaxPosition) {
+    return NextResponse.json({ error: denyMessage }, { status: 403 })
+  }
+  return null
+}
+```
+
+**Estimated effort**: **M (2-4 hours including tests)**.
+
+---
+
+### 5) DATA DUPLICATION — report status enum duplicated between API and UI
+
+**Locations**
+- `apps/web/app/api/reports/route.ts`: `VALID_STATUSES` and transition list.
+- `apps/web/components/settings/reports-tab.tsx`: `STATUS_FILTERS` and `getStatusIcon` switch use same status keys.
+
+**Measured duplication**
+- Status literals duplicated: `pending`, `reviewed`, `resolved`, `dismissed` (4/4 overlap = **100% enum duplication**).
+- This is semantic duplication that risks drift between API validation and UI filters.
+
+**Importance**: **7/10**
+
+**Extraction method**: shared constant/type module in `apps/web/lib/reports-status.ts`.
+
+**Drop-in DRY remediation**
+```ts
+// apps/web/lib/report-status.ts
+export const REPORT_STATUSES = ["pending", "reviewed", "resolved", "dismissed"] as const
+export type ReportStatus = (typeof REPORT_STATUSES)[number]
+```
+Use this constant in both API (`includes`) and UI filters/icon mapping.
+
+**Estimated effort**: **S (1 hour)**.
+
+---
+
+## Unable to verify
+
+- Full-file clone detection for SQL migrations and all TS/TSX blocks with token-level thresholds was **unable to verify** using external scanner due package install restriction in this environment.
+- Evidence that would improve confidence: successful run of `jscpd`/Sonar clone report in CI.
+
+## Summary recommendations (priority order)
+
+1. Extract role-mutation authorization/hierarchy guard (`8/10`).
+2. De-duplicate webhook modal handlers (`7/10`).
+3. Centralize report statuses (`7/10`).
+4. Extract call media toggle hook (`6/10`).
+5. Keep status label/color mapping centralized (already completed in this patch).


### PR DESCRIPTION
### Motivation

- Reduce duplicated presence/status mapping logic spread across UI components by centralizing helpers.  
- Provide a concrete, repo-scoped duplication audit that identifies exact, near, structural, and data duplication to guide follow-up refactors.  
- Make small, low-risk refactors now (status helpers) as a stepping stone to larger DRY extractions (webhooks, role-guard, call toggles, report statuses).

### Description

- Added a duplication audit at `docs/duplication-audit-report.md` that lists findings, duplication percentages, importance (1–10), extraction suggestions, DRY remediation snippets, and estimated effort.  
- Introduced `apps/web/lib/presence-status.ts` exporting `getStatusColor` and `getStatusLabel` to centralize presence/status semantics.  
- Replaced local duplicate implementations by importing `getStatusColor` and/or `getStatusLabel` from the new module in `apps/web/components/user-profile-popover.tsx`, `apps/web/components/layout/member-list.tsx`, and `apps/web/components/profile/profile-panel.tsx`.  
- Left audit recommendations and drop-in code snippets for further extractions (webhook helpers, role-mutation guard, call-media hook, report-status constants) to guide subsequent refactors.

### Testing

- Ran type checking with `npm run -w @vortex/web type-check`, which completed successfully (no TypeScript errors).  
- Attempted to run `jscpd` clone detection (`npx --yes jscpd --min-lines 5 --min-tokens 50 ...`) but it failed to install due to npm registry policy (`403 Forbidden`), so automated clone scan is blocked in this environment.  
- Verified builds/edits are limited to the UI utilities and docs and the change is small and type-checked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0658e79e0832583a33b2762181690)