### PR TITLE
docs: add initial software design analysis

### DIFF
--- a/docs/initial-software-design-analysis.md
+++ b/docs/initial-software-design-analysis.md
@@ -1,6 +1,7 @@
 # Initial Software Design Analysis
 
 ## Scope & Method
+- Re-verified each finding against the current `HEAD` code before applying edits to this report.
 - Reviewed monorepo/workspace boundaries and package wiring (`package.json`, `turbo.json`, app package manifests).
 - Read key orchestration paths for web request handling and UI composition:
   - `apps/web/app/api/messages/route.ts`
@@ -47,16 +48,18 @@
 
 **What would prove it fully:** a complete static import graph (e.g., madge/dependency-cruiser) run across `apps/web`, `apps/signal`, and `packages/shared` with cycle reporting committed to CI.
 
-### 5) Modularity rating
+### 5) Modularity rating (qualitative score)
 **Rating: 6.5 / 10**
 
-**Justification:**
-- **+2.5:** Clear workspace/service boundaries (`apps/web`, `apps/signal`, `packages/shared`).
-- **+1.5:** Shared abstractions exist for permissions/types (`packages/shared`, `apps/web/lib/permissions.ts`).
-- **+1.0:** Utility modules exist (`lib/*`) rather than only page-level code.
-- **-2.0:** Oversized orchestration modules (`messages/route.ts`, `chat-area.tsx`) reduce replaceability/test isolation.
-- **-1.0:** Query/DTO hydration logic appears duplicated across endpoints/pages.
-- **-0.5:** No enforced cycle checks in lint config.
+**Scoring method:** This is a qualitative reviewer judgement (not a strict arithmetic formula). The bullets below are weighted observations that informed the final 6.5 score.
+
+**Weighted observations:**
+- Clear workspace/service boundaries (`apps/web`, `apps/signal`, `packages/shared`).
+- Shared abstractions exist for permissions/types (`packages/shared`, `apps/web/lib/permissions.ts`).
+- Utility modules exist (`lib/*`) rather than only page-level code.
+- Oversized orchestration modules (`messages/route.ts`, `chat-area.tsx`) reduce replaceability/test isolation.
+- Query/DTO hydration logic appears duplicated across endpoints/pages.
+- No enforced cycle checks in lint config.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Provide an actionable architecture assessment of the monorepo focused on separation of concerns, god modules, dependency flow, and remediation with precise file citations.
- Surface concrete, minimal drop-in fixes and CI/tooling checks to reduce risk in core message and voice subsystems.

### Description
- Add `docs/initial-software-design-analysis.md` containing a structured review, Mermaid architecture diagram, prioritized findings (F1–F5), and exact evidence references such as `apps/web/app/api/messages/route.ts`, `apps/web/components/chat/chat-area.tsx`, `apps/signal/src/index.ts`, and `packages/shared/src/index.ts`. 
- Include code-level remediation snippets and recommendations (examples: extract `withReplyTo`/`MESSAGE_PROJECTION` into `apps/web/lib/messages/hydration.ts`, split `ChatArea` concerns into `apps/web/components/chat/hooks/*`, and defer voice-state DB writes to `apps/signal/src/voice-state-sync.ts`).
- Document verification gaps and constraints encountered during analysis, including inability to run some external dependency tooling in this environment.

### Testing
- Confirmed the new file exists at `docs/initial-software-design-analysis.md` and contains the architecture report. 
- Attempted a dependency-cycle scan with `npx madge --circular apps/web --extensions ts,tsx`, which failed due to npm registry access (HTTP 403), and this failure is recorded in the report. 
- No unit tests were changed and no other automated test failures were introduced by this documentation addition.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a074e7faf48325a7e31528eba49ad1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive software design analysis documentation providing architectural assessment, module boundary evaluation, bottleneck identification, anti-pattern detection, and concrete remediation proposals for improved system design and modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->