### PR TITLE
Fix server members list fetching when RLS narrows member rows

### DIFF
--- a/apps/web/app/api/servers/[serverId]/members/route.ts
+++ b/apps/web/app/api/servers/[serverId]/members/route.ts
@@ -32,7 +32,9 @@ export async function GET(
   try {
     adminSupabase = await createServiceRoleClient()
   } catch (error) {
-    console.error("Failed to initialize service-role Supabase client for member list", error)
+    const errorId = crypto.randomUUID()
+    const errorName = error instanceof Error ? error.name : "UnknownError"
+    console.error(`[${errorId}] Failed to initialize service-role Supabase client for member list (${errorName})`)
     return NextResponse.json({ error: "Failed to initialize member list service" }, { status: 500 })
   }
 
@@ -67,6 +69,8 @@ export async function GET(
       )
     `)
     .eq("server_id", params.serverId)
+    .order("nickname", { ascending: true, nullsFirst: false })
+    .order("user_id", { ascending: true })
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 })


### PR DESCRIPTION
### Motivation
- The server member list could appear empty or incomplete when Row-Level Security (RLS) policies restrict `server_members` reads to only the requester row. 
- The endpoint must still enforce that the caller is a member while returning the full membership payload for the UI.

### Description
- Updated `GET /api/servers/[serverId]/members` (`apps/web/app/api/servers/[serverId]/members/route.ts`) to import and use `createServiceRoleClient` and fetch the full member list with the service-role Supabase client. 
- Kept the existing membership gate that verifies the requester is a server member using the requester-authenticated client before calling the service-role client. 
- The change ensures the endpoint returns `user:users(*)` and `roles:member_roles(role_id, roles(*))` for all members even when RLS would limit member-token reads.

### Testing
- Ran `npm run -w apps/web type-check` and it completed successfully. 
- Ran `npm run -w apps/web lint` which failed due to pre-existing repository-wide style-guardrail violations unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a08c390934832595763618cf56782d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed member list retrieval to return complete member profiles, including usernames, display names, avatars, status/bio, role assignments and role metadata.
  * Improved error handling to surface a clear server error if member list retrieval fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->