### PR TITLE
Use explicit server-loading state for server-sidebar skeleton

### DIFF
--- a/apps/web/components/layout/app-provider.tsx
+++ b/apps/web/components/layout/app-provider.tsx
@@ -17,8 +17,8 @@ interface AppProviderProps {
 
 /** Root client-side provider that seeds Zustand stores, syncs presence, applies appearance settings, and registers push notifications. */
 export function AppProvider({ user, servers, children }: AppProviderProps) {
-  const { setCurrentUser, setServers } = useAppStore(
-    useShallow((s) => ({ setCurrentUser: s.setCurrentUser, setServers: s.setServers }))
+  const { setCurrentUser, setServers, setIsLoadingServers } = useAppStore(
+    useShallow((s) => ({ setCurrentUser: s.setCurrentUser, setServers: s.setServers, setIsLoadingServers: s.setIsLoadingServers }))
   )
   const { messageDisplay, fontScale, saturation, themePreset, customCss, hydrateFromSettings } = useAppearanceStore(
     useShallow((s) => ({ messageDisplay: s.messageDisplay, fontScale: s.fontScale, saturation: s.saturation, themePreset: s.themePreset, customCss: s.customCss, hydrateFromSettings: s.hydrateFromSettings }))
@@ -27,8 +27,9 @@ export function AppProvider({ user, servers, children }: AppProviderProps) {
   useEffect(() => {
     setCurrentUser(user)
     setServers(servers)
+    setIsLoadingServers(false)
     hydrateFromSettings(user?.appearance_settings as Parameters<typeof hydrateFromSettings>[0], user?.id ?? null)
-  }, [user, servers, setCurrentUser, setServers, hydrateFromSettings])
+  }, [user, servers, setCurrentUser, setServers, setIsLoadingServers, hydrateFromSettings])
 
   // Apply appearance data-attributes to <html> so CSS selectors can pick them up
   useEffect(() => {

--- a/apps/web/components/layout/server-sidebar.tsx
+++ b/apps/web/components/layout/server-sidebar.tsx
@@ -20,8 +20,8 @@ import { Skeleton } from "@/components/ui/skeleton"
 
 /** Vertical icon strip listing joined servers, DM shortcut, and create/discover actions. */
 export function ServerSidebar() {
-  const { servers, activeServerId, setActiveServer, removeServer, currentUser, channels } = useAppStore(
-    useShallow((s) => ({ servers: s.servers, activeServerId: s.activeServerId, setActiveServer: s.setActiveServer, removeServer: s.removeServer, currentUser: s.currentUser, channels: s.channels }))
+  const { servers, isLoadingServers, activeServerId, setActiveServer, removeServer, currentUser, channels } = useAppStore(
+    useShallow((s) => ({ servers: s.servers, isLoadingServers: s.isLoadingServers, activeServerId: s.activeServerId, setActiveServer: s.setActiveServer, removeServer: s.removeServer, currentUser: s.currentUser, channels: s.channels }))
   )
   const [showCreateServer, setShowCreateServer] = useState(false)
   const { toast } = useToast()
@@ -110,7 +110,7 @@ export function ServerSidebar() {
         <Separator className="w-8 my-1" style={{ background: 'var(--theme-surface-elevated)' }} />
 
         {/* Server list */}
-        {servers.length === 0 && !currentUser && (
+        {servers.length === 0 && isLoadingServers && (
           <div className="w-full flex flex-col items-center gap-2 py-1">
             {Array.from({ length: 6 }).map((_, index) => (
               <Skeleton key={index} className="h-12 w-12 rounded-2xl" />

--- a/apps/web/lib/stores/app-store.ts
+++ b/apps/web/lib/stores/app-store.ts
@@ -58,6 +58,8 @@ interface AppState {
 
   // Servers
   servers: ServerRow[]
+  isLoadingServers: boolean
+  setIsLoadingServers: (isLoading: boolean) => void
   setServers: (servers: ServerRow[]) => void
   addServer: (server: ServerRow) => void
   updateServer: (id: string, updates: Partial<ServerRow>) => void
@@ -101,6 +103,8 @@ export const useAppStore = create<AppState>((set) => ({
   setCurrentUser: (user) => set({ currentUser: user }),
 
   servers: [],
+  isLoadingServers: true,
+  setIsLoadingServers: (isLoadingServers) => set({ isLoadingServers }),
   setServers: (servers) => set({ servers }),
   addServer: (server) => set((state) => ({ servers: [...state.servers, server] })),
   updateServer: (id, updates) =>


### PR DESCRIPTION
### Motivation

- The server sidebar rendered skeleton placeholders when `servers.length === 0 && !currentUser`, which showed placeholders for unauthenticated users and failed to reflect actual server-loading state.

### Description

- Add `isLoadingServers` and `setIsLoadingServers` to the app Zustand store so server-list loading is represented explicitly (`apps/web/lib/stores/app-store.ts`).
- Initialize `isLoadingServers` to `true` and expose a setter to update loading state in the client store (`useAppStore`).
- Wire `AppProvider` to call `setIsLoadingServers(false)` after seeding `servers` and `currentUser` into the client store so loading completes once server data is available (`apps/web/components/layout/app-provider.tsx`).
- Update `ServerSidebar` to select `isLoadingServers` from the store and change the skeleton render condition to `servers.length === 0 && isLoadingServers` so placeholders display only while servers are actually loading (`apps/web/components/layout/server-sidebar.tsx`).

### Testing

- Ran `npm run type-check` and the TypeScript checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a228a969e88325be869a3c4b8ede81)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server sidebar now displays a loading skeleton while servers are being loaded, providing improved visual feedback during the loading process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->