### PR TITLE
fix(a11y): focus rings, aria-labels, emoji keyboard nav, contrast, sk…

### DIFF
--- a/apps/web/app/channels/[serverId]/layout.tsx
+++ b/apps/web/app/channels/[serverId]/layout.tsx
@@ -47,7 +47,9 @@ export default async function ServerLayout({ children, params: paramsPromise }: 
           isOwner={server.owner_id === user.id}
           userRoles={userRoles}
         />
-        {children}
+        <main id="main-content" className="flex flex-1 overflow-hidden">
+          {children}
+        </main>
         <MemberList serverId={params.serverId} />
       </div>
     </ServerEmojiProvider>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -45,7 +45,7 @@
     --theme-text-normal: #d6defc;
     --theme-text-secondary: #b6c0dd;
     --theme-text-muted: #8f9bbf;
-    --theme-text-faint: #6b7392;
+    --theme-text-faint: #8690b2;
     --theme-text-bright: #f4f7ff;
     --theme-accent: #00e5ff;
     --theme-accent-secondary: #f92aad;
@@ -92,6 +92,28 @@
 }
 
 @layer utilities {
+  .skip-nav-link {
+    position: absolute;
+    left: -9999px;
+    top: 0;
+    z-index: 9999;
+    padding: 8px 16px;
+    background: var(--theme-accent);
+    color: var(--theme-bg-primary);
+    font-weight: 600;
+    font-size: 14px;
+    text-decoration: none;
+    border-radius: 0 0 4px 4px;
+    white-space: nowrap;
+  }
+
+  .skip-nav-link:focus {
+    left: 50%;
+    transform: translateX(-50%);
+    outline: 2px solid var(--theme-bg-primary);
+    outline-offset: 2px;
+  }
+
   .motion-interactive {
     transition-property: background-color, color, border-color, opacity, transform, box-shadow;
     transition-duration: var(--motion-duration-standard);
@@ -360,7 +382,7 @@
   --theme-text-normal: #dcddde;
   --theme-text-secondary: #b5bac1;
   --theme-text-muted: #949ba4;
-  --theme-text-faint: #4e5058;
+  --theme-text-faint: #959ca6;
   --theme-text-bright: #dbdee1;
   --theme-accent: #5865f2;
   --theme-accent-secondary: #eb459e;
@@ -410,7 +432,7 @@
   --theme-text-normal: #d6defc;
   --theme-text-secondary: #b6c0dd;
   --theme-text-muted: #8f9bbf;
-  --theme-text-faint: #6b7392;
+  --theme-text-faint: #8690b2;
   --theme-text-bright: #f4f7ff;
   --theme-accent: #00e5ff;
   --theme-accent-secondary: #f92aad;
@@ -460,7 +482,7 @@
   --theme-text-normal: #e9dcff;
   --theme-text-secondary: #cab7e8;
   --theme-text-muted: #a990d0;
-  --theme-text-faint: #7f6aa8;
+  --theme-text-faint: #a088c8;
   --theme-text-bright: #fff7ff;
   --theme-accent: #f92aad;
   --theme-accent-secondary: #00e5ff;
@@ -510,7 +532,7 @@
   --theme-text-normal: #d5d9df;
   --theme-text-secondary: #b5bcc6;
   --theme-text-muted: #98a0ab;
-  --theme-text-faint: #6b737f;
+  --theme-text-faint: #858c99;
   --theme-text-bright: #f5f7fa;
   --theme-accent: #3ba55c;
   --theme-accent-secondary: #5db3ff;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -37,6 +37,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body className={`${inter.variable} ${spaceGrotesk.variable} font-sans`} style={{ background: 'var(--theme-bg-primary)' }}>
+        <a href="#main-content" className="skip-nav-link">Skip to main content</a>
         {children}
         <Toaster />
       </body>

--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -33,6 +33,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
   const [uploadProgress, setUploadProgress] = useState<number | null>(null)
   const [sendError, setSendError] = useState<string | null>(null)
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
+  const emojiGridRef = useRef<HTMLDivElement>(null)
   const [showPollCreator, setShowPollCreator] = useState(false)
   const [pollQuestion, setPollQuestion] = useState("")
   const [pollOptions, setPollOptions] = useState(["", ""])
@@ -275,6 +276,64 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
     setCursorPosition(e.currentTarget.selectionStart)
   }
 
+  function handleEmojiGridKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    const arrows = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"]
+    if (!arrows.includes(e.key)) return
+    const gridEl = emojiGridRef.current
+    if (!gridEl) return
+    const buttons = Array.from(gridEl.querySelectorAll<HTMLButtonElement>("[data-emoji-btn]"))
+    if (buttons.length === 0) return
+    const activeEl = document.activeElement as HTMLButtonElement
+    let currentIdx = buttons.indexOf(activeEl)
+    if (currentIdx === -1) {
+      e.preventDefault()
+      buttons[0].focus()
+      return
+    }
+    e.preventDefault()
+    let cols = 9
+    if (buttons.length >= 2) {
+      const r0 = buttons[0].getBoundingClientRect()
+      let c = 1
+      for (let i = 1; i < buttons.length; i++) {
+        if (buttons[i].getBoundingClientRect().top > r0.bottom) break
+        c++
+      }
+      if (c > 0) cols = c
+    }
+    let nextIdx = currentIdx
+    if (e.key === "ArrowRight") nextIdx = Math.min(buttons.length - 1, currentIdx + 1)
+    else if (e.key === "ArrowLeft") nextIdx = Math.max(0, currentIdx - 1)
+    else if (e.key === "ArrowDown") nextIdx = Math.min(buttons.length - 1, currentIdx + cols)
+    else if (e.key === "ArrowUp") nextIdx = Math.max(0, currentIdx - cols)
+    if (nextIdx !== currentIdx) {
+      buttons[nextIdx].focus()
+      buttons[nextIdx].scrollIntoView({ block: "nearest" })
+    }
+  }
+
+  function handleGifGridKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    const arrows = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"]
+    if (!arrows.includes(e.key)) return
+    e.preventDefault()
+    const grid = e.currentTarget
+    const buttons = Array.from(grid.querySelectorAll<HTMLButtonElement>("button"))
+    if (buttons.length === 0) return
+    const activeEl = document.activeElement as HTMLButtonElement
+    const currentIdx = buttons.indexOf(activeEl)
+    if (currentIdx === -1) return
+    const cols = 3
+    let nextIdx = currentIdx
+    if (e.key === "ArrowRight") nextIdx = Math.min(buttons.length - 1, currentIdx + 1)
+    else if (e.key === "ArrowLeft") nextIdx = Math.max(0, currentIdx - 1)
+    else if (e.key === "ArrowDown") nextIdx = Math.min(buttons.length - 1, currentIdx + cols)
+    else if (e.key === "ArrowUp") nextIdx = Math.max(0, currentIdx - cols)
+    if (nextIdx !== currentIdx) {
+      buttons[nextIdx].focus()
+      buttons[nextIdx].scrollIntoView({ block: "nearest" })
+    }
+  }
+
   const canInsertPoll = pollQuestion.trim().length > 0 && pollOptions.filter((option) => option.trim().length > 0).length >= 2
 
   function resetPollDraftToBlank() {
@@ -333,7 +392,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
           <span className="truncate flex-1" style={{ color: "var(--theme-text-muted)" }}>
             {replyTo.content}
           </span>
-          <button onClick={onCancelReply} style={{ color: "var(--theme-text-muted)" }}>
+          <button onClick={onCancelReply} aria-label="Cancel reply" className="focus-ring rounded" style={{ color: "var(--theme-text-muted)" }}>
             <X className="w-3 h-3 hover:text-white" />
           </button>
         </div>
@@ -420,7 +479,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
         >
           <div className="flex items-center justify-between">
             <p className="text-xs font-semibold" style={{ color: "var(--theme-text-primary)" }}>Create poll</p>
-            <button type="button" onClick={() => {
+            <button type="button" aria-label="Close poll creator" className="focus-ring rounded" onClick={() => {
               setShowPollCreator(false)
               resetPollDraftToBlank()
             }} style={{ color: "var(--theme-text-muted)" }}>
@@ -454,7 +513,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
                   type="button"
                   onClick={() => removePollOption(index)}
                   disabled={pollOptions.length <= 2}
-                  className="px-2 py-1 rounded text-xs disabled:opacity-50"
+                  className="px-2 py-1 rounded text-xs disabled:opacity-50 focus-ring"
                   style={{ color: "var(--theme-text-muted)", border: "1px solid var(--theme-bg-tertiary)" }}
                   aria-label={`Remove option ${index + 1}`}
                 >
@@ -498,7 +557,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
           <button
             type="button"
             onClick={() => fileRef.current?.click()}
-            className="motion-interactive motion-press flex-shrink-0 hover:text-white"
+            className="motion-interactive motion-press flex-shrink-0 hover:text-white focus-ring rounded"
             style={{ color: "var(--theme-text-secondary)" }}
             title="Attach"
             aria-label="Attach file"
@@ -513,10 +572,11 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
               }
               setShowPollCreator((prev) => !prev)
             }}
-            className="motion-interactive motion-press flex-shrink-0 hover:text-white"
+            className="motion-interactive motion-press flex-shrink-0 hover:text-white focus-ring rounded"
             style={{ color: showPollCreator ? "var(--theme-accent)" : "var(--theme-text-secondary)" }}
             title="Poll"
             aria-label="Create poll"
+            aria-pressed={showPollCreator}
           >
             <BarChart3 className="w-4 h-4" />
           </button>
@@ -527,10 +587,11 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
               setPickerTab("emoji")
               setShowEmojiPicker((prev) => !prev || pickerTab !== "emoji")
             }}
-            className="motion-interactive motion-press hover:text-white"
+            className="motion-interactive motion-press hover:text-white focus-ring rounded"
             style={{ color: pickerTab === "emoji" && showEmojiPicker ? "var(--theme-accent)" : "var(--theme-text-secondary)" }}
             title="Emoji"
             aria-label="Insert emoji"
+            aria-pressed={pickerTab === "emoji" && showEmojiPicker}
           >
             <Smile className="w-4 h-4" />
           </button>
@@ -540,10 +601,11 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
               setPickerTab("gif")
               setShowEmojiPicker(true)
             }}
-            className="motion-interactive motion-press hover:text-white"
+            className="motion-interactive motion-press hover:text-white focus-ring rounded"
             style={{ color: pickerTab === "gif" && showEmojiPicker ? "var(--theme-accent)" : "var(--theme-text-secondary)" }}
             title="GIF"
             aria-label="Insert GIF"
+            aria-pressed={pickerTab === "gif" && showEmojiPicker}
           >
             <Sticker className="w-4 h-4" />
           </button>
@@ -597,17 +659,23 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
             className="panel-surface-motion absolute bottom-14 right-4 p-2 rounded-lg shadow-xl z-50"
             style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)", width: "320px" }}
           >
-              <div className="mb-2 flex items-center gap-2">
+              <div className="mb-2 flex items-center gap-2" role="tablist" aria-label="Picker type">
                 <button
+                  role="tab"
+                  aria-selected={pickerTab === "emoji"}
+                  aria-controls="emoji-tab-panel"
                   onClick={() => setPickerTab("emoji")}
-                  className="px-2 py-1 rounded text-xs font-medium"
+                  className="px-2 py-1 rounded text-xs font-medium focus-ring"
                   style={{ background: pickerTab === "emoji" ? "var(--theme-accent)" : "transparent", color: "var(--theme-text-primary)" }}
                 >
                   Emoji
                 </button>
                 <button
+                  role="tab"
+                  aria-selected={pickerTab === "gif"}
+                  aria-controls="gif-tab-panel"
                   onClick={() => setPickerTab("gif")}
-                  className="px-2 py-1 rounded text-xs font-medium"
+                  className="px-2 py-1 rounded text-xs font-medium focus-ring"
                   style={{ background: pickerTab === "gif" ? "var(--theme-accent)" : "transparent", color: "var(--theme-text-primary)" }}
                 >
                   GIFs
@@ -615,120 +683,140 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
               </div>
 
               {pickerTab === "emoji" ? (
-                <EmojiPicker.Root
-                  onEmojiSelect={({ emoji }) => {
-                    const textarea = textareaRef.current
-                    const start = textarea ? textarea.selectionStart ?? content.length : content.length
-                    const end = textarea ? textarea.selectionEnd ?? start : start
-                    const next = content.slice(0, start) + emoji + content.slice(end)
-                    setContent(next)
-                    setCursorPosition(start + emoji.length)
-                    onDraftChange(next)
-                    setShowEmojiPicker(false)
-                    requestAnimationFrame(() => {
-                      if (textarea) {
-                        textarea.focus()
-                        textarea.setSelectionRange(start + emoji.length, start + emoji.length)
-                      }
-                    })
-                  }}
-                  style={{ display: "flex", flexDirection: "column", height: "320px" }}
+                <div
+                  id="emoji-tab-panel"
+                  role="tabpanel"
+                  ref={emojiGridRef}
+                  onKeyDown={handleEmojiGridKeyDown}
+                  style={{ display: "flex", flexDirection: "column", flex: 1, overflow: "hidden" }}
                 >
-                  <div style={{ padding: "6px 6px 4px" }}>
-                    <EmojiPicker.Search
-                      className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--theme-accent)]"
-                      style={{
-                        display: "block",
-                        width: "100%",
-                        padding: "5px 10px",
-                        borderRadius: "6px",
-                        fontSize: "13px",
-                        boxSizing: "border-box",
-                        background: "var(--theme-bg-tertiary)",
-                        color: "var(--theme-text-normal)",
-                        border: "none",
-                        outline: "none",
-                      }}
-                      placeholder="Search emoji…"
-                    />
-                  </div>
-                  <EmojiPicker.Viewport style={{ flex: 1, overflow: "hidden auto" }}>
-                    <EmojiPicker.Loading>
-                      <div style={{ padding: "12px", color: "var(--theme-text-muted)", fontSize: "12px" }}>Loading…</div>
-                    </EmojiPicker.Loading>
-                    <EmojiPicker.Empty>
-                      {({ search }) => (
-                        <div style={{ padding: "12px", color: "var(--theme-text-muted)", fontSize: "12px" }}>
-                          No emoji found for &ldquo;{search}&rdquo;
-                        </div>
-                      )}
-                    </EmojiPicker.Empty>
-                    <EmojiPicker.List
-                      components={{
-                        CategoryHeader: ({ category, ...props }) => (
-                          <div
-                            {...props}
-                            style={{
-                              padding: "3px 8px",
-                              fontSize: "10px",
-                              fontWeight: 600,
-                              textTransform: "uppercase",
-                              letterSpacing: "0.06em",
-                              color: "var(--theme-text-muted)",
-                              background: "var(--theme-bg-secondary)",
-                              position: "sticky",
-                              top: 0,
-                            }}
-                          >
-                            {category.label}
+                  <EmojiPicker.Root
+                    onEmojiSelect={({ emoji }) => {
+                      const textarea = textareaRef.current
+                      const start = textarea ? textarea.selectionStart ?? content.length : content.length
+                      const end = textarea ? textarea.selectionEnd ?? start : start
+                      const next = content.slice(0, start) + emoji + content.slice(end)
+                      setContent(next)
+                      setCursorPosition(start + emoji.length)
+                      onDraftChange(next)
+                      setShowEmojiPicker(false)
+                      requestAnimationFrame(() => {
+                        if (textarea) {
+                          textarea.focus()
+                          textarea.setSelectionRange(start + emoji.length, start + emoji.length)
+                        }
+                      })
+                    }}
+                    style={{ display: "flex", flexDirection: "column", flex: 1, overflow: "hidden" }}
+                  >
+                    <div style={{ padding: "6px 6px 4px" }}>
+                      <EmojiPicker.Search
+                        className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--theme-accent)]"
+                        style={{
+                          display: "block",
+                          width: "100%",
+                          padding: "5px 10px",
+                          borderRadius: "6px",
+                          fontSize: "13px",
+                          boxSizing: "border-box",
+                          background: "var(--theme-bg-tertiary)",
+                          color: "var(--theme-text-normal)",
+                          border: "none",
+                          outline: "none",
+                        }}
+                        placeholder="Search emoji…"
+                        onKeyDown={(e) => {
+                          if ((e.key === "Tab" && !e.shiftKey) || e.key === "ArrowDown") {
+                            const firstBtn = emojiGridRef.current?.querySelector<HTMLButtonElement>("[data-emoji-btn]")
+                            if (firstBtn) {
+                              e.preventDefault()
+                              firstBtn.focus()
+                            }
+                          }
+                        }}
+                      />
+                    </div>
+                    <EmojiPicker.Viewport style={{ flex: 1, overflow: "hidden auto" }}>
+                      <EmojiPicker.Loading>
+                        <div style={{ padding: "12px", color: "var(--theme-text-muted)", fontSize: "12px" }}>Loading…</div>
+                      </EmojiPicker.Loading>
+                      <EmojiPicker.Empty>
+                        {({ search }) => (
+                          <div style={{ padding: "12px", color: "var(--theme-text-muted)", fontSize: "12px" }}>
+                            No emoji found for &ldquo;{search}&rdquo;
                           </div>
-                        ),
-                        Emoji: ({ emoji, ...props }) => (
-                          <button
-                            type="button"
-                            {...props}
-                            style={{
-                              display: "flex",
-                              alignItems: "center",
-                              justifyContent: "center",
-                              fontSize: "18px",
-                              width: "100%",
-                              aspectRatio: "1",
-                              borderRadius: "4px",
-                              cursor: "pointer",
-                              border: "none",
-                              background: emoji.isActive ? "var(--theme-surface-elevated)" : "transparent",
-                              fontFamily: "var(--frimousse-emoji-font)",
-                            }}
-                          >
-                            {emoji.emoji}
-                          </button>
-                        ),
-                      }}
-                    />
-                  </EmojiPicker.Viewport>
-                  <div style={{ padding: "4px 8px 6px", display: "flex", alignItems: "center", justifyContent: "flex-end", borderTop: "1px solid var(--theme-bg-tertiary)" }}>
-                    <EmojiPicker.SkinToneSelector
-                      style={{
-                        all: "unset",
-                        cursor: "pointer",
-                        fontSize: "16px",
-                        padding: "2px 6px",
-                        borderRadius: "4px",
-                        border: "1px solid var(--theme-bg-tertiary)",
-                        background: "var(--theme-bg-tertiary)",
-                      }}
-                      aria-label="Change skin tone"
-                    />
-                  </div>
-                </EmojiPicker.Root>
+                        )}
+                      </EmojiPicker.Empty>
+                      <EmojiPicker.List
+                        components={{
+                          CategoryHeader: ({ category, ...props }) => (
+                            <div
+                              {...props}
+                              style={{
+                                padding: "3px 8px",
+                                fontSize: "10px",
+                                fontWeight: 600,
+                                textTransform: "uppercase",
+                                letterSpacing: "0.06em",
+                                color: "var(--theme-text-muted)",
+                                background: "var(--theme-bg-secondary)",
+                                position: "sticky",
+                                top: 0,
+                              }}
+                            >
+                              {category.label}
+                            </div>
+                          ),
+                          Emoji: ({ emoji, ...props }) => (
+                            <button
+                              type="button"
+                              {...props}
+                              data-emoji-btn=""
+                              tabIndex={-1}
+                              style={{
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                fontSize: "18px",
+                                width: "100%",
+                                aspectRatio: "1",
+                                borderRadius: "4px",
+                                cursor: "pointer",
+                                border: "none",
+                                background: emoji.isActive ? "var(--theme-surface-elevated)" : "transparent",
+                                fontFamily: "var(--frimousse-emoji-font)",
+                              }}
+                            >
+                              {emoji.emoji}
+                            </button>
+                          ),
+                        }}
+                      />
+                    </EmojiPicker.Viewport>
+                    <div style={{ padding: "4px 8px 6px", display: "flex", alignItems: "center", justifyContent: "flex-end", borderTop: "1px solid var(--theme-bg-tertiary)" }}>
+                      <EmojiPicker.SkinToneSelector
+                        style={{
+                          all: "unset",
+                          cursor: "pointer",
+                          fontSize: "16px",
+                          padding: "2px 6px",
+                          borderRadius: "4px",
+                          border: "1px solid var(--theme-bg-tertiary)",
+                          background: "var(--theme-bg-tertiary)",
+                        }}
+                        aria-label="Change skin tone"
+                      />
+                    </div>
+                  </EmojiPicker.Root>
+                </div>
               ) : (
-                <div className="space-y-2">
+                <div id="gif-tab-panel" role="tabpanel" className="space-y-2">
                   <input
                     value={gifQuery}
                     onChange={(e) => setGifQuery(e.target.value)}
                     placeholder="Search GIFs"
-                    className="w-full px-2 py-1.5 rounded text-xs focus:outline-none"
+                    aria-label="Search GIFs"
+                    className="w-full px-2 py-1.5 rounded text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--theme-accent)]"
                     style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-normal)" }}
                   />
                   {!process.env.NEXT_PUBLIC_GIPHY_API_KEY ? (
@@ -738,7 +826,10 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
                   ) : gifLoading ? (
                     <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>Loading GIFs…</p>
                   ) : (
-                    <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
+                    <div
+                      className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto"
+                      onKeyDown={handleGifGridKeyDown}
+                    >
                       {gifResults.map((gif) => (
                         <button
                           key={gif.id}
@@ -751,8 +842,9 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
                             setShowEmojiPicker(false)
                             textareaRef.current?.focus()
                           }}
-                          className="rounded overflow-hidden hover:opacity-90"
+                          className="rounded overflow-hidden hover:opacity-90 focus-ring"
                           title={gif.title}
+                          aria-label={gif.title}
                         >
                           <img src={gif.previewUrl} alt={gif.title} className="w-full h-16 object-cover" />
                           <span className="block px-1 py-0.5 text-[10px] truncate text-left" style={{ color: "var(--theme-text-secondary)", background: "var(--theme-bg-tertiary)" }}>{gif.title || "GIF"}</span>
@@ -770,7 +862,8 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
           <button
             onClick={handleSend}
             disabled={sending}
-            className="motion-interactive motion-press flex-shrink-0 mb-1 hover:text-white"
+            aria-label="Send message"
+            className="motion-interactive motion-press flex-shrink-0 mb-1 hover:text-white focus-ring rounded"
             style={{ color: "var(--theme-accent)" }}
             title="Send Message"
           >

--- a/apps/web/components/dm/me-shell.tsx
+++ b/apps/web/components/dm/me-shell.tsx
@@ -35,9 +35,9 @@ export function MeShell({ children }: { children: React.ReactNode }) {
       <div className="flex flex-1 overflow-hidden">
         <DMListPanel />
         <MobileOverlay />
-        <div className="flex flex-1 overflow-hidden min-w-0">
+        <main id="main-content" className="flex flex-1 overflow-hidden min-w-0">
           {children}
-        </div>
+        </main>
       </div>
     </MobileNavProvider>
   )

--- a/apps/web/components/layout/server-sidebar.tsx
+++ b/apps/web/components/layout/server-sidebar.tsx
@@ -87,7 +87,7 @@ export function ServerSidebar() {
               onClick={() => setActiveServer(null)}
               aria-label="Direct Messages"
               className={cn(
-                "w-12 h-12 flex items-center justify-center cursor-pointer transition-all duration-200",
+                "w-12 h-12 flex items-center justify-center cursor-pointer transition-all duration-200 focus-ring",
                 activeServerId === null
                   ? "rounded-2xl"
                   : "rounded-full hover:rounded-2xl"
@@ -136,7 +136,8 @@ export function ServerSidebar() {
           <TooltipTrigger asChild>
             <button
               onClick={() => setShowCreateServer(true)}
-              className="w-12 h-12 rounded-full hover:rounded-2xl flex items-center justify-center cursor-pointer transition-all duration-200 group"
+              aria-label="Add a Server"
+              className="w-12 h-12 rounded-full hover:rounded-2xl flex items-center justify-center cursor-pointer transition-all duration-200 group focus-ring"
               style={{ background: 'var(--theme-bg-primary)' }}
             >
               <Plus className="w-6 h-6 transition-colors" style={{ color: 'var(--theme-success)' }} />
@@ -149,7 +150,8 @@ export function ServerSidebar() {
         <Tooltip>
           <TooltipTrigger asChild>
             <button
-              className="w-12 h-12 rounded-full hover:rounded-2xl flex items-center justify-center cursor-pointer transition-all duration-200"
+              aria-label="Explore Public Servers"
+              className="w-12 h-12 rounded-full hover:rounded-2xl flex items-center justify-center cursor-pointer transition-all duration-200 focus-ring"
               style={{ background: 'var(--theme-bg-primary)' }}
             >
               <Compass className="w-6 h-6" style={{ color: 'var(--theme-success)' }} />
@@ -201,7 +203,7 @@ function ServerIcon({
       <Tooltip>
         <TooltipTrigger asChild>
           <ContextMenuTrigger asChild>
-            <div className="relative group cursor-pointer" role="button" tabIndex={0} onClick={onClick} onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onClick() }}>
+            <div className="relative group cursor-pointer focus-ring rounded-full" role="button" tabIndex={0} aria-label={server.name} onClick={onClick} onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onClick() }}>
               {/* Active indicator */}
               <div
                 className={cn(

--- a/apps/web/components/layout/user-panel.tsx
+++ b/apps/web/components/layout/user-panel.tsx
@@ -103,7 +103,7 @@ export function UserPanel() {
     >
       <ContextMenu>
         <ContextMenuTrigger asChild>
-          <div className="flex items-center gap-2 flex-1 min-w-0 cursor-pointer" role="button" tabIndex={0} onClick={() => setShowProfileSettings(true)} onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setShowProfileSettings(true) }}>
+          <div className="flex items-center gap-2 flex-1 min-w-0 cursor-pointer focus-ring rounded" role="button" tabIndex={0} aria-label="Open profile settings" onClick={() => setShowProfileSettings(true)} onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setShowProfileSettings(true) }}>
             {/* Avatar with status */}
             <div className="relative flex-shrink-0">
               <Avatar className="w-8 h-8">
@@ -193,7 +193,8 @@ export function UserPanel() {
                     toast({ variant: "destructive", title: "Failed to disconnect", description: error.message })
                   }
                 }}
-                className="w-7 h-7 rounded flex items-center justify-center hover:bg-red-500/20 transition-colors"
+                aria-label="Disconnect from voice"
+                className="w-7 h-7 rounded flex items-center justify-center hover:bg-red-500/20 transition-colors focus-ring"
                 style={{ color: 'var(--theme-danger)' }}
               >
                 <PhoneOff className="w-4 h-4" />
@@ -207,7 +208,9 @@ export function UserPanel() {
           <TooltipTrigger asChild>
             <button
               onClick={() => setMuted(!muted)}
-              className="w-7 h-7 rounded flex items-center justify-center hover:bg-white/10 transition-colors"
+              aria-label={muted ? "Unmute microphone" : "Mute microphone"}
+              aria-pressed={muted}
+              className="w-7 h-7 rounded flex items-center justify-center hover:bg-white/10 transition-colors focus-ring"
               style={{ color: muted ? 'var(--theme-danger)' : 'var(--theme-text-muted)' }}
             >
               {muted ? <MicOff className="w-4 h-4" /> : <Mic className="w-4 h-4" />}
@@ -220,7 +223,9 @@ export function UserPanel() {
           <TooltipTrigger asChild>
             <button
               onClick={() => setDeafened(!deafened)}
-              className="w-7 h-7 rounded flex items-center justify-center hover:bg-white/10 transition-colors"
+              aria-label={deafened ? "Undeafen" : "Deafen"}
+              aria-pressed={deafened}
+              className="w-7 h-7 rounded flex items-center justify-center hover:bg-white/10 transition-colors focus-ring"
               style={{ color: deafened ? 'var(--theme-danger)' : 'var(--theme-text-muted)' }}
             >
               <Headphones className="w-4 h-4" />
@@ -233,7 +238,8 @@ export function UserPanel() {
           <TooltipTrigger asChild>
             <button
               onClick={() => setShowProfileSettings(true)}
-              className="w-7 h-7 rounded flex items-center justify-center hover:bg-white/10 transition-colors"
+              aria-label="User Settings"
+              className="w-7 h-7 rounded flex items-center justify-center hover:bg-white/10 transition-colors focus-ring"
               style={{ color: 'var(--theme-text-muted)' }}
             >
               <Settings className="w-4 h-4" />


### PR DESCRIPTION
…ip nav

5.1 — Focus Ring Consistency
- user-panel.tsx: add focus-ring to mute, deafen, disconnect, settings, and profile trigger buttons
- server-sidebar.tsx: add focus-ring to home link, Add Server, Explore, and ServerIcon role=button div
- message-input.tsx: add focus-ring to attach, poll, emoji, GIF, send, cancel-reply, GIF grid items, and emoji picker tab buttons

5.2 — Aria-Labels for Icon Buttons
- user-panel.tsx: add aria-label + aria-pressed to mute, deafen buttons; aria-label to disconnect and settings buttons; aria-label to profile div

5.3 — Emoji Picker Keyboard Navigation
- Wrap EmojiPicker.Root in a div with onKeyDown + ref for arrow-key nav
- Arrow keys move focus between emoji buttons in the grid; ArrowDown from the search input jumps to the first emoji
- Set tabIndex={-1} + data-emoji-btn="" on individual emoji buttons (roving-tabindex pattern); Tab key leaves the grid naturally
- GIF grid: add onKeyDown with arrow-key nav (fixed 3-column layout)
- Picker tab buttons get role=tablist/tab + aria-selected + aria-controls

5.4 — Color Contrast on Tertiary Text
- Raise --theme-text-faint in all four theme presets and :root to values that meet WCAG 2.1 AA (≥ 4.5:1) against each theme's primary background: :root / midnight-neon  #6b7392 → #8690b2  (~5.0:1)
    discord                #4e5058 → #959ca6  (~4.7:1)
    synthwave              #7f6aa8 → #a088c8  (~5.3:1)
    carbon                 #6b737f → #858c99  (~5.1:1)

5.5 — Skip Navigation Link
- Add visually-hidden "Skip to main content" <a> as first focusable element in root layout.tsx; becomes visible on :focus
- Add id="main-content" to <main> wrapper in server channel layout and the DMs MeShell so the skip link has a valid target

https://claude.ai/code/session_011LPUPaAdSZtZCzLPKvYumh