### PR TITLE
chore: replace remaining hardcoded colors with theme tokens (layer 1 cleanup)

### DIFF
--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -386,14 +386,14 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
         >
           <Reply className="w-3 h-3 -scale-x-100" style={{ color: "var(--theme-text-muted)" }} />
           <span style={{ color: "var(--theme-text-muted)" }}>Replying to</span>
-          <span className="font-semibold text-white">
+          <span className="font-semibold" style={{ color: "var(--theme-text-bright)" }}>
             {replyTo.author?.display_name || replyTo.author?.username}
           </span>
           <span className="truncate flex-1" style={{ color: "var(--theme-text-muted)" }}>
             {replyTo.content}
           </span>
           <button onClick={onCancelReply} aria-label="Cancel reply" className="focus-ring rounded" style={{ color: "var(--theme-text-muted)" }}>
-            <X className="w-3 h-3 hover:text-white" />
+            <X className="w-3 h-3" />
           </button>
         </div>
       )}
@@ -435,7 +435,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
                 style={{ background: "var(--theme-danger)" }}
                 aria-label={`Remove ${file.name}`}
               >
-                <X className="w-3 h-3 text-white" />
+                <X className="w-3 h-3" style={{ color: "var(--theme-text-bright)" }} />
               </button>
             </div>
           ))}
@@ -454,7 +454,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
                 <button
                   type="button"
                   onClick={handleCancelUpload}
-                  className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] hover:bg-white/10"
+                  className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] surface-hover-md"
                   style={{ color: "var(--theme-danger)" }}
                   title="Cancel upload"
                   aria-label="Cancel upload"
@@ -557,8 +557,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
           <button
             type="button"
             onClick={() => fileRef.current?.click()}
-            className="motion-interactive motion-press flex-shrink-0 hover:text-white focus-ring rounded"
-            style={{ color: "var(--theme-text-secondary)" }}
+            className="motion-interactive motion-press flex-shrink-0 text-muted-interactive focus-ring rounded"
             title="Attach"
             aria-label="Attach file"
           >
@@ -572,7 +571,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
               }
               setShowPollCreator((prev) => !prev)
             }}
-            className="motion-interactive motion-press flex-shrink-0 hover:text-white focus-ring rounded"
+            className="motion-interactive motion-press flex-shrink-0 focus-ring rounded"
             style={{ color: showPollCreator ? "var(--theme-accent)" : "var(--theme-text-secondary)" }}
             title="Poll"
             aria-label="Create poll"
@@ -587,7 +586,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
               setPickerTab("emoji")
               setShowEmojiPicker((prev) => !prev || pickerTab !== "emoji")
             }}
-            className="motion-interactive motion-press hover:text-white focus-ring rounded"
+            className="motion-interactive motion-press focus-ring rounded"
             style={{ color: pickerTab === "emoji" && showEmojiPicker ? "var(--theme-accent)" : "var(--theme-text-secondary)" }}
             title="Emoji"
             aria-label="Insert emoji"
@@ -601,7 +600,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
               setPickerTab("gif")
               setShowEmojiPicker(true)
             }}
-            className="motion-interactive motion-press hover:text-white focus-ring rounded"
+            className="motion-interactive motion-press focus-ring rounded"
             style={{ color: pickerTab === "gif" && showEmojiPicker ? "var(--theme-accent)" : "var(--theme-text-secondary)" }}
             title="GIF"
             aria-label="Insert GIF"
@@ -863,7 +862,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
             onClick={handleSend}
             disabled={sending}
             aria-label="Send message"
-            className="motion-interactive motion-press flex-shrink-0 mb-1 hover:text-white focus-ring rounded"
+            className="motion-interactive motion-press flex-shrink-0 mb-1 focus-ring rounded"
             style={{ color: "var(--theme-accent)" }}
             title="Send Message"
           >

--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -525,7 +525,7 @@ export const MessageItem = memo(function MessageItem({
               <button
                 type="button"
                 onClick={() => onReplyJump(message.reply_to_id!)}
-                className="w-full text-left flex items-center gap-2 mb-1 ml-10 text-xs tertiary-metadata rounded px-1 py-0.5 hover:bg-white/5 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--theme-accent)]"
+                className="w-full text-left flex items-center gap-2 mb-1 ml-10 text-xs tertiary-metadata rounded px-1 py-0.5 surface-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--theme-accent)]"
                 aria-label="Jump to replied message"
               >
                 <Reply className="w-3 h-3 -scale-x-100" />
@@ -602,7 +602,7 @@ export const MessageItem = memo(function MessageItem({
                     side="right"
                     align="start"
                   >
-                    <span className="font-semibold text-white hover:underline cursor-pointer">
+                    <span className="font-semibold hover:underline cursor-pointer" style={{ color: "var(--theme-text-bright)" }}>
                       {displayName}
                     </span>
                   </UserProfilePopover>
@@ -672,7 +672,7 @@ export const MessageItem = memo(function MessageItem({
                               type="button"
                               key={`poll-option-${message.id}-${index}`}
                               onClick={() => onReaction(emoji)}
-                              className="w-full flex items-center justify-between rounded px-2 py-1.5 text-sm hover:bg-white/5"
+                              className="w-full flex items-center justify-between rounded px-2 py-1.5 text-sm surface-hover"
                               style={{ border: "1px solid var(--theme-bg-tertiary)", color: "var(--theme-text-normal)" }}
                             >
                               <span className="truncate text-left">{emoji} {option}</span>
@@ -785,7 +785,7 @@ export const MessageItem = memo(function MessageItem({
             >
               <button
                 onClick={() => setShowEmojiPicker(!showEmojiPicker)}
-                className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-white/10 focus-ring"
+                className="motion-interactive motion-press w-8 h-8 flex items-center justify-center surface-hover-md focus-ring"
                 style={{ color: showEmojiPicker ? "var(--theme-accent)" : "var(--theme-text-secondary)" }}
                 title="Add Reaction"
                 aria-label="Add reaction"
@@ -797,7 +797,7 @@ export const MessageItem = memo(function MessageItem({
 
               <button
                 onClick={onReply}
-                className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-white/10 focus-ring"
+                className="motion-interactive motion-press w-8 h-8 flex items-center justify-center surface-hover-md focus-ring"
                 style={{ color: "var(--theme-text-secondary)" }}
                 title="Reply"
                 aria-label="Reply to message"
@@ -810,7 +810,7 @@ export const MessageItem = memo(function MessageItem({
               {onThreadCreated && (
                 <button
                   onClick={() => setShowCreateThread(true)}
-                  className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-white/10 focus-ring"
+                  className="motion-interactive motion-press w-8 h-8 flex items-center justify-center surface-hover-md focus-ring"
                   style={{ color: "var(--theme-text-secondary)" }}
                   title="Create Thread"
                   aria-label="Create thread from message"
@@ -824,7 +824,7 @@ export const MessageItem = memo(function MessageItem({
               {isOwn && (
                 <button
                   onClick={() => setIsEditing(true)}
-                  className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-white/10 focus-ring"
+                  className="motion-interactive motion-press w-8 h-8 flex items-center justify-center surface-hover-md focus-ring"
                   style={{ color: "var(--theme-text-secondary)" }}
                   title="Edit"
                   aria-label="Edit message"
@@ -838,7 +838,7 @@ export const MessageItem = memo(function MessageItem({
               {sendState === "failed" && onRetry && (
                 <button
                   onClick={onRetry}
-                  className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-white/10 focus-ring"
+                  className="motion-interactive motion-press w-8 h-8 flex items-center justify-center surface-hover-md focus-ring"
                   style={{ color: "var(--theme-warning)" }}
                   title="Retry send"
                   aria-label="Retry sending message"
@@ -1110,8 +1110,8 @@ function AttachmentGallery({ attachments }: { attachments: AttachmentRow[] }) {
                   )}
                   {imageIndexes.length > 1 && (
                     <span>
-                      <button type="button" className="px-2 py-1 rounded hover:bg-white/10" onClick={() => move(-1)} aria-label="Previous image">← Prev</button>
-                      <button type="button" className="px-2 py-1 rounded hover:bg-white/10 ml-2" onClick={() => move(1)} aria-label="Next image">Next →</button>
+                      <button type="button" className="px-2 py-1 rounded surface-hover-md" onClick={() => move(-1)} aria-label="Previous image">← Prev</button>
+                      <button type="button" className="px-2 py-1 rounded surface-hover-md ml-2" onClick={() => move(1)} aria-label="Next image">Next →</button>
                     </span>
                   )}
                 </div>
@@ -1147,19 +1147,19 @@ function AttachmentDisplay({ attachment, onOpenImage }: { attachment: Attachment
       href={attachment.url}
       target="_blank"
       rel="noopener noreferrer"
-      className="motion-interactive flex items-center gap-3 p-3 rounded max-w-sm hover:bg-white/5"
+      className="motion-interactive flex items-center gap-3 p-3 rounded max-w-sm surface-hover"
       style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}
     >
       <div
         className="w-10 h-10 rounded flex items-center justify-center flex-shrink-0"
         style={{ background: "var(--theme-accent)" }}
       >
-        <span className="text-white text-xs font-bold">
+        <span className="text-xs font-bold" style={{ color: "var(--theme-text-bright)" }}>
           {attachment.filename.split(".").pop()?.toUpperCase().slice(0, 4)}
         </span>
       </div>
       <div className="min-w-0">
-        <div className="text-sm font-medium text-white truncate">
+        <div className="text-sm font-medium truncate" style={{ color: "var(--theme-text-bright)" }}>
           {attachment.filename}
         </div>
         <div className="text-xs" style={{ color: "var(--theme-text-muted)" }}>

--- a/apps/web/components/layout/channel-sidebar.tsx
+++ b/apps/web/components/layout/channel-sidebar.tsx
@@ -847,11 +847,11 @@ function CategoryHeader({
   return (
     <div
       ref={sortable.setNodeRef}
-      style={style}
-      className={cn(
-        "flex items-center justify-between px-2 py-1 group rounded mx-1 motion-interactive",
-        isDragOver && "bg-white/5"
-      )}
+      style={{
+        ...style,
+        ...(isDragOver ? { background: "color-mix(in srgb, var(--theme-text-primary) 5%, transparent)" } : {}),
+      }}
+      className="flex items-center justify-between px-2 py-1 group rounded mx-1 motion-interactive"
     >
       <button
         ref={setNodeRef}
@@ -884,7 +884,7 @@ function CategoryHeader({
               <button
                 type="button"
                 onClick={(e) => { e.stopPropagation(); onAddChannel() }}
-                className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-white motion-interactive focus-ring rounded-sm tertiary-metadata" aria-label={`Create channel in ${category.name}`}
+                className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-muted-interactive motion-interactive focus-ring rounded-sm" aria-label={`Create channel in ${category.name}`}
               >
                 <Plus className="w-4 h-4" />
               </button>
@@ -1025,12 +1025,12 @@ function SortableChannelItem({
                 </Tooltip>
               )}
               {isVoiceActive && (
-                <span className="w-2 h-2 rounded-full bg-green-500 inline-block animate-pulse" />
+                <span className="w-2 h-2 rounded-full inline-block animate-pulse" style={{ background: "var(--theme-success)" }} />
               )}
               {showBadge && (mentionCount ?? 0) > 0 ? (
                 <span
-                  className="min-w-[18px] h-[18px] rounded-full flex items-center justify-center text-[11px] font-bold text-white px-1"
-                  style={{ background: "var(--theme-danger)" }}
+                  className="min-w-[18px] h-[18px] rounded-full flex items-center justify-center text-[11px] font-bold px-1"
+                  style={{ background: "var(--theme-danger)", color: "var(--theme-text-bright)" }}
                 >
                   {(mentionCount ?? 0) > 99 ? "99+" : mentionCount}
                 </span>
@@ -1081,7 +1081,7 @@ function SortableChannelItem({
             return (
               <div
                 key={participant.user_id}
-                className="flex items-center gap-2 px-2 py-1 rounded text-xs hover:bg-white/5"
+                className="flex items-center gap-2 px-2 py-1 rounded text-xs surface-hover"
                 style={{ color: "var(--theme-text-secondary)" }}
               >
                 <Avatar className="w-5 h-5 flex-shrink-0">


### PR DESCRIPTION
Sweep three files for bg-white/*, text-white, bg-green-500 stragglers:

channel-sidebar.tsx (5 instances):
- CategoryHeader drag-over bg-white/5 → inline color-mix via --theme-text-primary
- "+ add channel" button hover:text-white → text-muted-interactive
- Voice-active dot bg-green-500 animate-pulse → --theme-success
- Mention badge text-white → --theme-text-bright
- Voice participant rows hover:bg-white/5 → surface-hover

message-input.tsx (6 instances):
- Reply author name text-white → --theme-text-bright
- Cancel-reply X icon hover:text-white → removed (parent button handles color)
- Remove-file X icon text-white → --theme-text-bright
- Cancel upload button hover:bg-white/10 → surface-hover-md
- FileUp toolbar button hover:text-white → text-muted-interactive class
- BarChart3/Smile/Sticker/Send toolbar buttons hover:text-white → removed

message-item.tsx (12 instances):
- Reply-jump button hover:bg-white/5 → surface-hover
- Author display name text-white → --theme-text-bright
- Poll vote row hover:bg-white/5 → surface-hover
- 5 action rail buttons (react/reply/thread/edit/retry) hover:bg-white/10 → surface-hover-md
- Lightbox prev/next buttons hover:bg-white/10 → surface-hover-md
- File attachment link hover:bg-white/5 → surface-hover
- Attachment filename and extension badge text-white (×2) → --theme-text-bright

https://claude.ai/code/session_011HRUPZRGd8NK9h3NWcJhjQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated hover states and interactive element styling across chat and channel sidebar components.
  * Refined text colors and background styling for improved visual consistency.
  * Enhanced theme color application throughout messaging interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->