### PR TITLE
Fix chat scroll-to-latest reliability in virtualized message list

### DIFF
--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -96,6 +96,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
   const lastJumpMessageIdRef = useRef<string | null>(null)
   const jumpSignatureRef = useRef<string | null>(null)
   const paginationRequestRef = useRef<Promise<unknown> | null>(null)
+  const shouldAutoScrollToLatestRef = useRef(true)
   const messagesRef = useRef<MessageWithAuthor[]>(initialMessages)
   const reconnectCycleRef = useRef(0)
   const liveAnnouncementCounterRef = useRef(0)
@@ -449,7 +450,29 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     setAnimatedMessageIds(new Set())
     setIsPaginating(false)
     paginationRequestRef.current = null
+    shouldAutoScrollToLatestRef.current = true
   }, [initialMessages])
+
+  const scrollToLatest = useCallback((behavior: "auto" | "smooth" = "auto") => {
+    const container = messageScrollerRef.current
+    if (!container) return
+
+    const lastIndex = messagesRef.current.length - 1
+    if (lastIndex >= 0) {
+      virtualizer.scrollToIndex(lastIndex, { align: "end", behavior })
+    } else {
+      bottomRef.current?.scrollIntoView({ behavior })
+    }
+
+    requestAnimationFrame(() => {
+      const scroller = messageScrollerRef.current
+      if (!scroller) return
+      const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight)
+      if (maxScrollTop - scroller.scrollTop > 2) {
+        scroller.scrollTop = maxScrollTop
+      }
+    })
+  }, [virtualizer])
 
   useEffect(() => {
     return () => {
@@ -687,17 +710,13 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     flushOutbox()
   }, [isOnline, channel.id, flushOutbox])
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
+    if (!shouldAutoScrollToLatestRef.current) return
     if (jumpToMessageId || openThreadId) return
-    requestAnimationFrame(() => {
-      if (messages.length > 0) {
-        virtualizer.scrollToIndex(messages.length - 1, { align: "end", behavior: "auto" })
-      } else {
-        bottomRef.current?.scrollIntoView({ behavior: "auto" })
-      }
-    })
-  }, [channel.id])
+    if (messages.length === 0) return
+    shouldAutoScrollToLatestRef.current = false
+    scrollToLatest("auto")
+  }, [jumpToMessageId, messages.length, openThreadId, scrollToLatest])
 
   useEffect(() => {
     const newestMessage = messages[messages.length - 1]
@@ -707,7 +726,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     if (!hasNewMessages || !newestMessage) return
 
     if (isAtBottom || newestMessage.author_id === currentUserId) {
-      virtualizer.scrollToIndex(messages.length - 1, { align: "end", behavior: "smooth" })
+      scrollToLatest("smooth")
       return
     }
 
@@ -822,17 +841,13 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
   }, [ensureMessageLoaded, jumpToMessageId, loadMessageContextWindow, messageIndexMap, openThreadId, returnScrollStorageKey])
 
   const jumpToLatest = useCallback(() => {
-    if (messages.length > 0) {
-      virtualizer.scrollToIndex(messages.length - 1, { align: "end", behavior: "smooth" })
-    } else {
-      bottomRef.current?.scrollIntoView({ behavior: "smooth" })
-    }
+    scrollToLatest("smooth")
     setPendingNewMessageCount(0)
     setUnreadAnchorMessageId(null)
     if (typeof window !== "undefined") {
       window.sessionStorage.removeItem(unreadAnchorStorageKey)
     }
-  }, [messages.length, unreadAnchorStorageKey, virtualizer])
+  }, [scrollToLatest, unreadAnchorStorageKey])
 
   const returnToContext = useCallback(() => {
     const container = messageScrollerRef.current


### PR DESCRIPTION
### Motivation
- The chat view sometimes failed to reach the true bottom: initial load/return-to-channel didn't show the last message and the "Jump to latest" action or new-message auto-scroll could leave the viewport short of the newest item.
- The virtualized list measurements could lag the DOM position and the existing `virtualizer.scrollToIndex` paths were inconsistent, causing flaky user-visible scrolling behavior.

### Description
- Added a one-time auto-scroll flag `shouldAutoScrollToLatestRef` and reset it when `initialMessages` change to ensure the initial arrival at the latest message happens exactly once.
- Introduced a single `scrollToLatest` helper that calls `virtualizer.scrollToIndex` and also applies a DOM fallback (`scrollTop = maxScrollTop`) on the next animation frame to handle measurement lag.
- Routed all “go to latest” pathways (initial auto-scroll, incoming-message-at-bottom, and the Jump-to-latest button) through `scrollToLatest` for consistent behavior.
- Minor type adjustment for the helper signature to satisfy the type checker (`(behavior: "auto" | "smooth")`).
- Modified file: `apps/web/components/chat/chat-area.tsx`.

### Testing
- Ran `npm run -w apps/web type-check` and it succeeded (`tsc --noEmit` passed). 
- Ran `npm run -w apps/web lint` which reported pre-existing style-guardrail violations unrelated to this change (lint failed overall, but failures are from existing tokens across the repo and not introduced here). 
- Started the dev server and executed a Playwright script to capture a screenshot, which produced an artifact at `browser:/tmp/codex_browser_invocations/120a4bb5aa34ce18/artifacts/artifacts/chat-scroll-fix.png`, noting that full interactive validation was limited by missing Supabase env vars in the run environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d7f04dbc832587e7690176e0d67e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined chat message scrolling behavior to ensure consistent automatic positioning when navigating conversations and viewing new messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->