### PR TITLE
Switch channel AI summaries from Anthropic to Gemini

### DIFF
--- a/apps/web/app/api/servers/[serverId]/channels/[channelId]/summarize/route.ts
+++ b/apps/web/app/api/servers/[serverId]/channels/[channelId]/summarize/route.ts
@@ -1,14 +1,23 @@
 import { NextRequest, NextResponse } from "next/server"
 import { requireServerPermission } from "@/lib/server-auth"
-import Anthropic from "@anthropic-ai/sdk"
 
 type Params = { params: Promise<{ serverId: string; channelId: string }> }
+
+type GeminiResponse = {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{
+        text?: string
+      }>
+    }
+  }>
+}
 
 /**
  * POST /api/servers/[serverId]/channels/[channelId]/summarize
  *
  * AI-powered channel catch-up summary.
- * Fetches recent messages and summarises them with Claude.
+ * Fetches recent messages and summarises them with Gemini.
  * Requires VIEW_CHANNELS permission.
  */
 export async function POST(req: NextRequest, { params }: Params) {
@@ -89,18 +98,20 @@ export async function POST(req: NextRequest, { params }: Params) {
     })
     .join("\n")
 
-  const apiKey = process.env.ANTHROPIC_API_KEY
+  const apiKey = process.env.GEMINI_API_KEY
   if (!apiKey) {
-    return NextResponse.json({ error: "AI summarization is not configured (missing ANTHROPIC_API_KEY)" }, { status: 503 })
+    return NextResponse.json({ error: "AI summarization is not configured (missing GEMINI_API_KEY)" }, { status: 503 })
   }
 
-  const client = new Anthropic({ apiKey })
-
   try {
-    const response = await client.messages.create({
-      model: "claude-haiku-4-5-20251001",
-      max_tokens: 512,
-      system: `You are a helpful assistant that summarizes chat channel conversations.
+    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        systemInstruction: {
+          parts: [
+            {
+              text: `You are a helpful assistant that summarizes chat channel conversations.
 Return your response as JSON with this exact shape:
 {
   "summary": "2-4 sentence overview of what was discussed",
@@ -108,15 +119,35 @@ Return your response as JSON with this exact shape:
   "topics": ["topic1", "topic2"]
 }
 Be concise and factual. Only include information from the conversation.`,
-      messages: [
-        {
-          role: "user",
-          content: `Summarize this conversation from the #${channel.name} channel (${chronological.length} messages):\n\n${transcript}`,
+            },
+          ],
         },
-      ],
+        contents: [
+          {
+            role: "user",
+            parts: [
+              {
+                text: `Summarize this conversation from the #${channel.name} channel (${chronological.length} messages):\n\n${transcript}`,
+              },
+            ],
+          },
+        ],
+        generationConfig: {
+          maxOutputTokens: 512,
+          responseMimeType: "application/json",
+        },
+      }),
     })
 
-    const text = response.content[0]?.type === "text" ? response.content[0].text : "{}"
+    if (!response.ok) {
+      const errorBody = await response.text()
+      console.error("Gemini API request failed", response.status, errorBody)
+      return NextResponse.json({ error: "AI summarization failed" }, { status: 500 })
+    }
+
+    const result = await response.json() as GeminiResponse
+    const text = result.candidates?.[0]?.content?.parts?.[0]?.text ?? "{}"
+
     let parsed: { summary: string; highlights: string[]; topics: string[] }
     try {
       parsed = JSON.parse(text)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,6 @@
     "lint:style-guardrails": "node scripts/style-guardrails.mjs"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.78.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
       "name": "@vortex/web",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.78.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -152,26 +151,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.78.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
-      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -206,15 +185,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -7285,19 +7255,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -9735,12 +9692,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",


### PR DESCRIPTION
### Motivation
- Replace Anthropic/Claude usage for channel summarization with Google Gemini to standardize AI provider and use Gemini for summaries.

### Description
- Replaced Anthropic SDK usage in the channel summarize API route with a direct Gemini REST call to the Generative Language `generateContent` endpoint and switched prompts to Gemini-friendly payloads.
- Changed configuration to use `GEMINI_API_KEY` and target model `gemini-2.5-flash`, with preserved JSON response contract (`summary`, `highlights`, `topics`) and fallback parsing for non-JSON text.
- Added explicit non-2xx handling and logging for provider errors and removed the `@anthropic-ai/sdk` dependency from `apps/web` (lockfile updated accordingly).

### Testing
- Ran `npm run -w apps/web type-check` and it completed successfully (no TypeScript errors). 
- Ran `npm run -w apps/web lint` which failed due to pre-existing `style-guardrails` violations across the repo and not caused by this change. 
- Attempted to install `@google/genai` but the registry returned `403`, so the implementation uses the Gemini REST API call instead (installation attempt failed in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5de488abc8325986cc1063ff9827d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the backend infrastructure for channel message summarization while preserving all existing functionality and response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->