### PR TITLE
Fix hydration error from invalid paragraph nesting in message rendering

### DIFF
--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -773,12 +773,12 @@ export const MessageItem = memo(function MessageItem({
                   )}
 
                   {messageBodyContent && (
-                    <p
+                    <div
                       className="text-sm leading-relaxed message-content break-words"
                       style={{ color: "var(--theme-text-normal)" }}
                     >
                       {renderContent(messageBodyContent)}
-                    </p>
+                    </div>
                   )}
 
                   {embeddableGiphyUrl && (


### PR DESCRIPTION
### Motivation
- Replace the message body wrapper to avoid nesting block-level nodes inside a `<p>`, which can produce invalid HTML and cause React hydration errors (minified error #418) when server-rendered content contains block elements like blockquotes or code blocks.

### Description
- Changed the message body wrapper in `apps/web/components/chat/message-item.tsx` from a `<p>` to a `<div>` so `renderContent(...)` can emit block-level nodes without creating invalid paragraph nesting.

### Testing
- Ran TypeScript checks with `pnpm -C apps/web exec tsc --noEmit --pretty false`, which succeeded; and ran `pnpm -C apps/web lint`, which failed due to pre-existing `style-guardrails` violations unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e091f7c08325bd52772c76544c1e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined message rendering for improved layout consistency in chat messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->