### PR TITLE
perf: move initial data fetches to server layout SSR

### DIFF
--- a/apps/signal/package.json
+++ b/apps/signal/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/node": "^20",
+    "pino-pretty": "^13.1.3",
     "tsx": "^4.19.2",
     "typescript": "^5.4.5"
   }

--- a/apps/signal/src/index.ts
+++ b/apps/signal/src/index.ts
@@ -68,6 +68,7 @@ const io = new Server(httpServer, {
   },
   pingTimeout: 60000,
   pingInterval: 25000,
+  perMessageDeflate: true,
 })
 
 const rooms = new RoomManager()

--- a/apps/web/app/api/appeals/route.ts
+++ b/apps/web/app/api/appeals/route.ts
@@ -18,7 +18,9 @@ export async function GET() {
     .order("submitted_at", { ascending: false })
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
-  return NextResponse.json(data ?? [])
+  return NextResponse.json(data ?? [], {
+    headers: { "Cache-Control": "private, max-age=30" },
+  })
 }
 
 export async function POST(req: NextRequest) {

--- a/apps/web/app/api/channels/[channelId]/docs/route.ts
+++ b/apps/web/app/api/channels/[channelId]/docs/route.ts
@@ -16,7 +16,7 @@ export async function GET(_: NextRequest, { params }: { params: Promise<{ channe
 
   const { data, error } = await supabase
     .from("channel_docs")
-    .select("*")
+    .select("id, title, content, channel_id, server_id, created_by, updated_by, created_at, updated_at")
     .eq("channel_id", channelId)
     .order("updated_at", { ascending: false })
 
@@ -47,7 +47,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ cha
     content: body.content || "",
     created_by: user.id,
     updated_by: user.id,
-  }).select("*").single()
+  }).select("id, title, content, channel_id, server_id, created_by, updated_by, created_at, updated_at").single()
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
   return NextResponse.json({ doc: data }, { status: 201 })

--- a/apps/web/app/api/channels/[channelId]/route.ts
+++ b/apps/web/app/api/channels/[channelId]/route.ts
@@ -25,12 +25,26 @@ export async function PATCH(
   }
 
   // Permission check: must be server owner or have MANAGE_CHANNELS
-  const { data: server } = await supabase
-    .from("servers")
-    .select("owner_id")
-    .eq("id", channel.server_id)
-    .single()
+  const [serverResult, memberRolesResult, defaultRoleResult] = await Promise.all([
+    supabase
+      .from("servers")
+      .select("owner_id")
+      .eq("id", channel.server_id)
+      .single(),
+    supabase
+      .from("member_roles")
+      .select("role_id, roles(permissions)")
+      .eq("server_id", channel.server_id)
+      .eq("user_id", user.id),
+    supabase
+      .from("roles")
+      .select("permissions")
+      .eq("server_id", channel.server_id)
+      .eq("is_default", true)
+      .single(),
+  ])
 
+  const server = serverResult.data
   if (!server) {
     return NextResponse.json({ error: "Server not found" }, { status: 404 })
   }
@@ -38,20 +52,8 @@ export async function PATCH(
   const isOwner = server.owner_id === user.id
 
   if (!isOwner) {
-    // Check role permissions
-    const { data: memberRoles } = await supabase
-      .from("member_roles")
-      .select("role_id, roles(permissions)")
-      .eq("server_id", channel.server_id)
-      .eq("user_id", user.id)
-
-    // Also get @everyone role permissions
-    const { data: defaultRole } = await supabase
-      .from("roles")
-      .select("permissions")
-      .eq("server_id", channel.server_id)
-      .eq("is_default", true)
-      .single()
+    const memberRoles = memberRolesResult.data
+    const defaultRole = defaultRoleResult.data
 
     const roleBitmasks = [
       ...(memberRoles ?? []).map((r) => (r.roles as unknown as { permissions: number })?.permissions ?? 0),

--- a/apps/web/app/api/channels/[channelId]/tasks/route.ts
+++ b/apps/web/app/api/channels/[channelId]/tasks/route.ts
@@ -51,7 +51,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ cha
   }
   if (!payload.title) return NextResponse.json({ error: "title required" }, { status: 400 })
 
-  const { data, error } = await supabase.from("channel_tasks").insert(payload).select("*").single()
+  const { data, error } = await supabase.from("channel_tasks").insert(payload).select("id, title, description, status, due_date, assignee_id, channel_id, server_id, source_message_id, created_by, updated_by, created_at, updated_at").single()
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
   return NextResponse.json({ task: data }, { status: 201 })
 }

--- a/apps/web/app/api/dm/channels/[channelId]/route.ts
+++ b/apps/web/app/api/dm/channels/[channelId]/route.ts
@@ -23,23 +23,25 @@ export async function GET(
 
   if (!membership) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
 
-  // Fetch channel info (flat, no joins)
-  const { data: channel, error: channelError } = await supabase
-    .from("dm_channels")
-    .select("id, name, icon_url, is_group, owner_id, updated_at, is_encrypted, encryption_key_version, encryption_membership_epoch")
-    .eq("id", channelId)
-    .maybeSingle()
-  if (channelError) return NextResponse.json({ error: channelError.message }, { status: 500 })
-  if (!channel) return NextResponse.json({ error: "DM channel not found" }, { status: 404 })
+  // Fetch channel info and member user_ids in parallel
+  const [channelResult, memberRowsResult] = await Promise.all([
+    supabase
+      .from("dm_channels")
+      .select("id, name, icon_url, is_group, owner_id, updated_at, is_encrypted, encryption_key_version, encryption_membership_epoch")
+      .eq("id", channelId)
+      .maybeSingle(),
+    supabase
+      .from("dm_channel_members")
+      .select("user_id")
+      .eq("dm_channel_id", channelId),
+  ])
 
-  // Fetch member user_ids
-  const { data: memberRows, error: memberRowsError } = await supabase
-    .from("dm_channel_members")
-    .select("user_id")
-    .eq("dm_channel_id", channelId)
-  if (memberRowsError) return NextResponse.json({ error: memberRowsError.message }, { status: 500 })
+  if (channelResult.error) return NextResponse.json({ error: channelResult.error.message }, { status: 500 })
+  if (!channelResult.data) return NextResponse.json({ error: "DM channel not found" }, { status: 404 })
+  if (memberRowsResult.error) return NextResponse.json({ error: memberRowsResult.error.message }, { status: 500 })
 
-  const memberIds = memberRows?.map((r) => r.user_id) ?? []
+  const channel = channelResult.data
+  const memberIds = memberRowsResult.data?.map((r) => r.user_id) ?? []
 
   // Fetch user profiles for members
   const { data: memberUsers, error: memberUsersError } = memberIds.length

--- a/apps/web/app/api/dm/channels/route.ts
+++ b/apps/web/app/api/dm/channels/route.ts
@@ -18,21 +18,38 @@ export async function GET() {
   const channelIds = memberships?.map((m) => m.dm_channel_id) ?? []
   if (!channelIds.length) return NextResponse.json([])
 
-  // 2. Fetch channel metadata
-  const { data: channelRows, error: channelRowsError } = await supabase
-    .from("dm_channels")
-    .select("id, name, icon_url, is_group, owner_id, updated_at, is_encrypted, encryption_key_version, encryption_membership_epoch")
-    .in("id", channelIds)
-  if (channelRowsError) return NextResponse.json({ error: channelRowsError.message }, { status: 500 })
+  // 2-6. Fetch channel metadata, members, latest messages, and read states in parallel
+  const [channelResult, memberResult, latestResult, readsResult] = await Promise.all([
+    supabase
+      .from("dm_channels")
+      .select("id, name, icon_url, is_group, owner_id, updated_at, is_encrypted, encryption_key_version, encryption_membership_epoch")
+      .in("id", channelIds),
+    supabase
+      .from("dm_channel_members")
+      .select("dm_channel_id, user_id")
+      .in("dm_channel_id", channelIds),
+    supabase
+      .from("direct_messages")
+      .select("dm_channel_id, content, created_at, sender_id")
+      .in("dm_channel_id", channelIds)
+      .is("deleted_at", null)
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("dm_read_states")
+      .select("dm_channel_id, last_read_at")
+      .eq("user_id", user.id)
+      .in("dm_channel_id", channelIds),
+  ])
 
-  // 3. Fetch all members across these channels
-  const { data: allMemberRows, error: allMemberRowsError } = await supabase
-    .from("dm_channel_members")
-    .select("dm_channel_id, user_id")
-    .in("dm_channel_id", channelIds)
-  if (allMemberRowsError) return NextResponse.json({ error: allMemberRowsError.message }, { status: 500 })
+  if (channelResult.error) return NextResponse.json({ error: channelResult.error.message }, { status: 500 })
+  if (memberResult.error) return NextResponse.json({ error: memberResult.error.message }, { status: 500 })
+  if (latestResult.error) return NextResponse.json({ error: latestResult.error.message }, { status: 500 })
+  if (readsResult.error) return NextResponse.json({ error: readsResult.error.message }, { status: 500 })
 
-  // 4. Fetch user profiles for all unique member IDs
+  const channelRows = channelResult.data
+  const allMemberRows = memberResult.data
+
+  // Fetch user profiles for all unique member IDs
   const allUserIds = Array.from(new Set((allMemberRows ?? []).map((m) => m.user_id)))
   const userRowsQuery = allUserIds.length
     ? await supabase
@@ -53,32 +70,15 @@ export async function GET() {
     if (u) membersByChannel[row.dm_channel_id]!.push(u)
   }
 
-  // 5. Get latest message per channel
-  const { data: latest, error: latestError } = await supabase
-    .from("direct_messages")
-    .select("dm_channel_id, content, created_at, sender_id")
-    .in("dm_channel_id", channelIds)
-    .is("deleted_at", null)
-    .order("created_at", { ascending: false })
-  if (latestError) return NextResponse.json({ error: latestError.message }, { status: 500 })
-
   const latestMessages: Record<string, any> = {}
-  for (const msg of latest ?? []) {
+  for (const msg of latestResult.data ?? []) {
     if (msg.dm_channel_id && !latestMessages[msg.dm_channel_id]) {
       latestMessages[msg.dm_channel_id] = msg
     }
   }
 
-  // 6. Get read states
-  const { data: reads, error: readsError } = await supabase
-    .from("dm_read_states")
-    .select("dm_channel_id, last_read_at")
-    .eq("user_id", user.id)
-    .in("dm_channel_id", channelIds)
-  if (readsError) return NextResponse.json({ error: readsError.message }, { status: 500 })
-
   const readStates: Record<string, string> = {}
-  for (const r of reads ?? []) {
+  for (const r of readsResult.data ?? []) {
     readStates[r.dm_channel_id] = r.last_read_at
   }
 
@@ -107,7 +107,9 @@ export async function GET() {
 
   channels.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
 
-  return NextResponse.json(channels)
+  return NextResponse.json(channels, {
+    headers: { "Cache-Control": "private, max-age=5" },
+  })
 }
 
 // POST /api/dm/channels — open/create a DM channel

--- a/apps/web/app/api/messages/route.ts
+++ b/apps/web/app/api/messages/route.ts
@@ -326,9 +326,11 @@ async function runServerAutomodChecks({
     },
   })
 
-  for (const violation of violations) {
-    await (supabase as any).rpc("increment_automod_rule_hit", { p_rule_id: violation.rule_id })
-  }
+  await Promise.all(
+    violations.map((violation) =>
+      (supabase as any).rpc("increment_automod_rule_hit", { p_rule_id: violation.rule_id })
+    )
+  )
 
   const timeoutDuration = getTimeoutDuration(violations)
   if (timeoutDuration && !dryRun) {

--- a/apps/web/app/api/reports/route.ts
+++ b/apps/web/app/api/reports/route.ts
@@ -180,7 +180,9 @@ export async function GET(req: NextRequest) {
 
     const { data: reports, error } = await query
     if (error) return NextResponse.json({ error: error.message }, { status: 500 })
-    return NextResponse.json(reports)
+    return NextResponse.json(reports, {
+      headers: { "Cache-Control": "private, max-age=30" },
+    })
   }
 
   // No server_id — return caller's own reports
@@ -193,7 +195,9 @@ export async function GET(req: NextRequest) {
     .limit(50)
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
-  return NextResponse.json(reports)
+  return NextResponse.json(reports, {
+    headers: { "Cache-Control": "private, max-age=30" },
+  })
 }
 
 /**

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -190,5 +190,7 @@ export async function GET(req: NextRequest) {
     ...(docs ?? []).map((d) => ({ type: "doc", ...d })),
   ]
 
-  return NextResponse.json({ results, total: results.length })
+  return NextResponse.json({ results, total: results.length }, {
+    headers: { "Cache-Control": "private, max-age=5, stale-while-revalidate=15" },
+  })
 }

--- a/apps/web/app/api/servers/[serverId]/events/route.ts
+++ b/apps/web/app/api/servers/[serverId]/events/route.ts
@@ -18,7 +18,7 @@ export async function GET(
 
   let query = db
     .from("events")
-    .select("*, event_hosts(user_id), event_rsvps(user_id,status,waitlist_position)")
+    .select("id, server_id, title, description, linked_channel_id, voice_channel_id, thread_id, start_at, end_at, timezone, recurrence, recurrence_until, capacity, create_voice_channel, post_event_thread, created_by, created_at, updated_at, event_hosts(user_id), event_rsvps(user_id,status)")
     .eq("server_id", params.serverId)
     .order("start_at", { ascending: true })
 

--- a/apps/web/app/api/servers/[serverId]/members/route.ts
+++ b/apps/web/app/api/servers/[serverId]/members/route.ts
@@ -77,7 +77,9 @@ export async function GET(
     return NextResponse.json({ error: error.message }, { status: 500 })
   }
 
-  return NextResponse.json(members)
+  return NextResponse.json(members, {
+    headers: { "Cache-Control": "private, max-age=10, stale-while-revalidate=30" },
+  })
 }
 
 export async function DELETE(

--- a/apps/web/app/api/threads/route.ts
+++ b/apps/web/app/api/threads/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: Request) {
 
   const { data: threads, error } = await supabase
     .from("threads")
-    .select("*")
+    .select("id, parent_channel_id, starter_message_id, owner_id, name, archived, message_count, created_at, updated_at")
     .eq("parent_channel_id", channelId)
     .eq("archived", archived)
     .order("updated_at", { ascending: false })
@@ -83,7 +83,7 @@ export async function POST(request: Request) {
     const { data: thread, error } = await supabase
       .from("threads")
       .insert({ parent_channel_id: channelId, owner_id: user.id, name: name.trim() })
-      .select("*")
+      .select("id, parent_channel_id, starter_message_id, owner_id, name, archived, message_count, created_at, updated_at")
       .single()
     if (error) return NextResponse.json({ error: error.message }, { status: 500 })
     return NextResponse.json(thread, { status: 201 })

--- a/apps/web/app/channels/[serverId]/[channelId]/page.tsx
+++ b/apps/web/app/channels/[serverId]/[channelId]/page.tsx
@@ -6,6 +6,8 @@ import { AnnouncementChannel } from "@/components/channels/announcement-channel"
 import { ForumChannel } from "@/components/channels/forum-channel"
 import { MediaChannel } from "@/components/channels/media-channel"
 import { hydrateReplyTo, MESSAGE_PROJECTION } from "@/lib/messages/hydration"
+import { computePermissions, hasPermission } from "@vortex/shared"
+import type { RoleRow } from "@/types/database"
 
 interface Props {
   params: Promise<{ serverId: string; channelId: string }>
@@ -28,8 +30,8 @@ export default async function ChannelPage({ params: paramsPromise }: Props) {
 
   if (error || !user) redirect("/login")
 
-  // Fetch channel, messages, and read-state in parallel (all inputs known upfront)
-  const [{ data: channel }, { data: messagesData }, { data: readState }] = await Promise.all([
+  // Fetch channel, messages, read-state, server ownership, and member roles in parallel
+  const [{ data: channel }, { data: messagesData }, { data: readState }, { data: server }, { data: memberRoles }] = await Promise.all([
     supabase
       .from("channels")
       .select("*")
@@ -49,9 +51,27 @@ export default async function ChannelPage({ params: paramsPromise }: Props) {
       .eq("user_id", user.id)
       .eq("channel_id", params.channelId)
       .maybeSingle(),
+    supabase
+      .from("servers")
+      .select("owner_id")
+      .eq("id", params.serverId)
+      .single(),
+    supabase
+      .from("member_roles")
+      .select("role_id, roles(*)")
+      .eq("server_id", params.serverId)
+      .eq("user_id", user.id),
   ])
 
   if (!channel) notFound()
+
+  // Compute canManageMessages server-side (avoids 2 client-side Supabase queries)
+  const isOwner = server?.owner_id === user.id
+  type MemberRoleWithRole = { role_id: string; roles: RoleRow | null }
+  const roleBitmasks = ((memberRoles ?? []) as unknown as MemberRoleWithRole[])
+    .map((mr) => mr.roles?.permissions ?? 0)
+  const effectivePerms = computePermissions(roleBitmasks)
+  const canManageMessages = isOwner || hasPermission(effectivePerms, "MANAGE_MESSAGES")
 
   // Filter messages to only text-based channel types
   let messages: any[] = []
@@ -128,6 +148,7 @@ export default async function ChannelPage({ params: paramsPromise }: Props) {
         currentUserId={user.id}
         serverId={params.serverId}
         initialLastReadAt={initialLastReadAt}
+        canManageMessages={canManageMessages}
       />
     </div>
   )

--- a/apps/web/app/channels/[serverId]/layout.tsx
+++ b/apps/web/app/channels/[serverId]/layout.tsx
@@ -1,9 +1,11 @@
 import { redirect, notFound } from "next/navigation"
-import { createServerSupabaseClient, getAuthUser } from "@/lib/supabase/server"
+import { createServerSupabaseClient, createServiceRoleClient, getAuthUser } from "@/lib/supabase/server"
 import { ChannelSidebar } from "@/components/layout/channel-sidebar"
+import type { VoiceParticipant } from "@/components/layout/channel-sidebar"
 import { MemberList } from "@/components/layout/member-list"
 import { ServerEmojiProvider } from "@/components/chat/server-emoji-context"
 import type { RoleRow } from "@/types/database"
+import type { MemberData } from "@/components/layout/member-list"
 
 interface Props {
   children: React.ReactNode
@@ -37,20 +39,158 @@ export default async function ServerLayout({ children, params: paramsPromise }: 
     .map((mr) => mr.roles)
     .filter((r): r is RoleRow => r !== null)
 
+  // Compute text channel IDs for unread queries
+  const allChannels = channels ?? []
+  const textChannelIds = allChannels
+    .filter((c) => c.type === "text")
+    .map((c) => c.id)
+
+  // Fetch 5 additional data sources in parallel for SSR hydration
+  const adminSupabase = await createServiceRoleClient()
+
+  const [
+    { data: rawMembers },
+    { data: emojis },
+    { data: threadCountRows },
+    { data: voiceStateRows },
+    { data: readStates },
+    { data: latestMessages },
+  ] = await Promise.all([
+    // Members (via service role to bypass RLS)
+    adminSupabase
+      .from("server_members")
+      .select(`
+        server_id,
+        user_id,
+        nickname,
+        user:users!server_members_user_id_fkey(
+          id,
+          username,
+          display_name,
+          avatar_url,
+          status_message,
+          bio,
+          banner_color,
+          custom_tag,
+          created_at
+        ),
+        roles:member_roles(
+          role_id,
+          roles(
+            id,
+            server_id,
+            name,
+            color,
+            permissions,
+            position,
+            created_at
+          )
+        )
+      `)
+      .eq("server_id", params.serverId)
+      .order("nickname", { ascending: true, nullsFirst: false })
+      .order("user_id", { ascending: true }),
+    // Emojis
+    supabase
+      .from("server_emojis")
+      .select("id, name, image_url")
+      .eq("server_id", params.serverId)
+      .order("name"),
+    // Thread counts
+    supabase.rpc("get_thread_counts_by_channel", { p_server_id: params.serverId }),
+    // Voice states
+    supabase
+      .from("voice_states")
+      .select("user_id, channel_id, muted, deafened, users(id, username, display_name, avatar_url)")
+      .eq("server_id", params.serverId),
+    // Read states
+    textChannelIds.length > 0
+      ? supabase
+          .from("read_states")
+          .select("channel_id, last_read_at, mention_count")
+          .eq("user_id", user.id)
+          .in("channel_id", textChannelIds)
+      : Promise.resolve({ data: [] as { channel_id: string; last_read_at: string; mention_count: number }[] }),
+    // Latest messages per text channel
+    textChannelIds.length > 0
+      ? supabase
+          .from("messages")
+          .select("channel_id, created_at")
+          .in("channel_id", textChannelIds)
+          .is("deleted_at", null)
+          .order("created_at", { ascending: false })
+      : Promise.resolve({ data: [] as { channel_id: string; created_at: string }[] }),
+  ])
+
+  // Normalize members: flatten nested roles
+  type ApiRoleEntry = { role_id: string; roles: RoleRow | null }
+  type ApiMember = Omit<MemberData, "roles"> & { roles?: ApiRoleEntry[] }
+  const initialMembers: MemberData[] = ((rawMembers ?? []) as unknown as ApiMember[]).map((m) => ({
+    ...m,
+    roles: (m.roles ?? [])
+      .map((entry) => entry.roles)
+      .filter((role): role is RoleRow => Boolean(role)),
+  }))
+
+  // Normalize thread counts: RPC returns { parent_channel_id, count }[]
+  const initialThreadCounts: Record<string, number> = {}
+  for (const row of (threadCountRows ?? []) as { parent_channel_id: string; count: number }[]) {
+    initialThreadCounts[row.parent_channel_id] = Number(row.count)
+  }
+
+  // Normalize voice states
+  const initialVoiceParticipants: VoiceParticipant[] = (voiceStateRows ?? []).map((d: any) => ({
+    user_id: d.user_id,
+    channel_id: d.channel_id,
+    muted: d.muted,
+    deafened: d.deafened,
+    user: d.users ?? null,
+  }))
+
+  // Compute unread channels and mention counts
+  const readMap: Record<string, string> = {}
+  const initialMentionCounts: Record<string, number> = {}
+  for (const rs of (readStates ?? []) as { channel_id: string; last_read_at: string; mention_count: number }[]) {
+    readMap[rs.channel_id] = rs.last_read_at
+    if (rs.mention_count > 0) initialMentionCounts[rs.channel_id] = rs.mention_count
+  }
+
+  const initialUnreadChannelIds: string[] = []
+  if (Object.keys(readMap).length > 0) {
+    const latestPerChannel: Record<string, string> = {}
+    for (const msg of (latestMessages ?? []) as { channel_id: string; created_at: string }[]) {
+      if (!latestPerChannel[msg.channel_id]) {
+        latestPerChannel[msg.channel_id] = msg.created_at
+      }
+    }
+    for (const channelId of Object.keys(readMap)) {
+      const latest = latestPerChannel[channelId]
+      const lastRead = readMap[channelId]
+      if (latest && latest > lastRead) {
+        initialUnreadChannelIds.push(channelId)
+      }
+    }
+  }
+
   return (
-    <ServerEmojiProvider serverId={params.serverId}>
+    <ServerEmojiProvider serverId={params.serverId} initialEmojis={emojis ?? []}>
       <div className="flex flex-1 overflow-hidden">
         <ChannelSidebar
+          key={`sidebar-${params.serverId}`}
           server={server}
-          channels={channels ?? []}
+          channels={allChannels}
           currentUserId={user.id}
           isOwner={server.owner_id === user.id}
           userRoles={userRoles}
+          initialThreadCounts={initialThreadCounts}
+          initialVoiceParticipants={initialVoiceParticipants}
+          initialUnreadChannelIds={initialUnreadChannelIds}
+          initialMentionCounts={initialMentionCounts}
         />
         <main id="main-content" className="flex flex-1 overflow-hidden">
           {children}
         </main>
-        <MemberList serverId={params.serverId} />
+        <MemberList key={`members-${params.serverId}`} serverId={params.serverId} initialMembers={initialMembers} />
       </div>
     </ServerEmojiProvider>
   )

--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -41,6 +41,7 @@ interface Props {
   currentUserId: string
   serverId: string
   initialLastReadAt: string | null
+  canManageMessages: boolean
 }
 
 function isDuplicateInsertError(error: { code?: string } | null): boolean {
@@ -68,7 +69,7 @@ function sortMessagesChronologically(items: MessageWithAuthor[]): MessageWithAut
 }
 
 /** Primary text channel view with message list, outbox queue, real-time updates, thread panel, unread markers, and infinite scroll. */
-export function ChatArea({ channel, initialMessages, currentUserId, serverId, initialLastReadAt }: Props) {
+export function ChatArea({ channel, initialMessages, currentUserId, serverId, initialLastReadAt, canManageMessages }: Props) {
   const { setActiveServer, setActiveChannel, memberListOpen, toggleMemberList, currentUser, workspaceOpen, toggleWorkspacePanel, threadPanelOpen, toggleThreadPanel, setThreadPanelOpen } = useAppStore(
     useShallow((s) => ({ setActiveServer: s.setActiveServer, setActiveChannel: s.setActiveChannel, memberListOpen: s.memberListOpen, toggleMemberList: s.toggleMemberList, currentUser: s.currentUser, workspaceOpen: s.workspaceOpen, toggleWorkspacePanel: s.toggleWorkspacePanel, threadPanelOpen: s.threadPanelOpen, toggleThreadPanel: s.toggleThreadPanel, setThreadPanelOpen: s.setThreadPanelOpen }))
   )
@@ -89,7 +90,6 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
   const [animatedMessageIds, setAnimatedMessageIds] = useState<Set<string>>(new Set())
   const [showSummary, setShowSummary] = useState(false)
   const [showPinnedPanel, setShowPinnedPanel] = useState(false)
-  const [canManageMessages, setCanManageMessages] = useState(false)
   const bottomRef = useRef<HTMLDivElement>(null)
   const messageScrollerRef = useRef<HTMLDivElement>(null)
   const previousLastMessageIdRef = useRef<string | null>(initialMessages[initialMessages.length - 1]?.id ?? null)
@@ -112,42 +112,6 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
   const jumpToMessageId = searchParams.get("message")
   const openThreadId = searchParams.get("thread")
   const createThreadParam = searchParams.get("createThread")
-
-  // ── Permission check ──────────────────────────────────────────────────────
-  // Determine once if the current user can manage messages in this channel
-  useEffect(() => {
-    let cancelled = false
-    ;(async () => {
-      try {
-        const { data: serverRow } = await supabase
-          .from("servers")
-          .select("owner_id")
-          .eq("id", serverId)
-          .single()
-        const { data: memberRow } = await (supabase
-          .from("server_members")
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .select("member_roles(roles(permissions))" as any)
-          .eq("server_id", serverId)
-          .eq("user_id", currentUserId)
-          .maybeSingle() as any)
-        if (cancelled) return
-        const isOwner = serverRow?.owner_id === currentUserId
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const perms: number = (memberRow as any)?.member_roles?.reduce(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (acc: number, mr: any) => acc | (mr?.roles?.permissions ?? 0),
-          0
-        ) ?? 0
-        const ADMINISTRATOR = 1 << 7
-        const MANAGE_MESSAGES = 1 << 2
-        setCanManageMessages(isOwner || !!(perms & ADMINISTRATOR) || !!(perms & MANAGE_MESSAGES))
-      } catch {
-        // Non-critical: default stays false
-      }
-    })()
-    return () => { cancelled = true }
-  }, [supabase, serverId, currentUserId])
 
   // ── Virtual list ──────────────────────────────────────────────────────────
   // O(1) lookup of message index by ID for virtualizer scrollToIndex

--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -154,7 +154,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
         const endpoint = gifQuery.trim()
           ? `${GIPHY_API_BASE}/search?api_key=${apiKey}&q=${encodeURIComponent(gifQuery)}&limit=12&rating=pg-13`
           : `${GIPHY_API_BASE}/trending?api_key=${apiKey}&limit=12&rating=pg-13`
-        const res = await fetch(endpoint, { signal: controller.signal })
+        const res = await fetch(endpoint, { signal: controller.signal, keepalive: true })
         const json = await res.json()
         setGifResults((json.data ?? []).map((gif: any) => ({
           id: gif.id,
@@ -168,7 +168,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
       } finally {
         setGifLoading(false)
       }
-    }, 250)
+    }, 400)
 
     return () => {
       clearTimeout(timeout)

--- a/apps/web/components/chat/server-emoji-context.tsx
+++ b/apps/web/components/chat/server-emoji-context.tsx
@@ -25,27 +25,17 @@ export function useServerEmojis() {
   return useContext(ServerEmojiContext)
 }
 
+export type { ServerEmoji }
+
 /** Fetches and caches server custom emojis, providing a context for child components to resolve :emoji: tokens. */
-export function ServerEmojiProvider({ serverId, children }: { serverId: string; children: React.ReactNode }) {
-  const [emojis, setEmojis] = useState<ServerEmoji[]>([])
+export function ServerEmojiProvider({ serverId, initialEmojis, children }: { serverId: string; initialEmojis?: ServerEmoji[]; children: React.ReactNode }) {
+  const [emojis, setEmojis] = useState<ServerEmoji[]>(initialEmojis ?? [])
   const controllerRef = useRef<AbortController | null>(null)
 
+  // When serverId changes (navigating between servers), reset to SSR-provided data
   useEffect(() => {
-    controllerRef.current?.abort()
-    const controller = new AbortController()
-    controllerRef.current = controller
-    fetch(`/api/servers/${serverId}/emojis`, { signal: controller.signal })
-      .then((res) => res.ok ? res.json() : [])
-      .then((data) => {
-        if (!controller.signal.aborted) {
-          setEmojis(data)
-        }
-      })
-      .catch((err) => {
-        if (err.name !== "AbortError") console.error("Failed to load emojis", err)
-      })
-    return () => controller.abort()
-  }, [serverId])
+    setEmojis(initialEmojis ?? [])
+  }, [serverId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const reload = useCallback(async () => {
     controllerRef.current?.abort()

--- a/apps/web/components/dm/dm-list.tsx
+++ b/apps/web/components/dm/dm-list.tsx
@@ -71,6 +71,9 @@ export function DMList({ onNavigate }: { onNavigate?: () => void } = {}) {
     if (res.ok) {
       const data = await res.json()
       setChannels(data)
+      // Push DM unread count to store (consumed by useTabUnreadTitle)
+      const unread = (data as DMChannel[]).filter((ch) => ch.is_unread).length
+      useAppStore.getState().setDmUnreadCount(unread)
     }
     setLoading(false)
   }, [])

--- a/apps/web/components/layout/channel-sidebar.tsx
+++ b/apps/web/components/layout/channel-sidebar.tsx
@@ -36,13 +36,15 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem, ContextMenuSeparator } from "@/components/ui/context-menu"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog"
 import { useToast } from "@/components/ui/use-toast"
-import { CreateChannelModal } from "@/components/modals/create-channel-modal"
-import { EditChannelModal } from "@/components/modals/edit-channel-modal"
-import { ServerSettingsModal } from "@/components/modals/server-settings-modal"
+import dynamic from "next/dynamic"
 import { UserPanel } from "@/components/layout/user-panel"
-import { QuickSwitcherModal } from "@/components/modals/quickswitcher-modal"
-import { SearchModal } from "@/components/modals/search-modal"
-import { KeyboardShortcutsModal } from "@/components/modals/keyboard-shortcuts-modal"
+
+const CreateChannelModal = dynamic(() => import("@/components/modals/create-channel-modal").then((m) => ({ default: m.CreateChannelModal })))
+const EditChannelModal = dynamic(() => import("@/components/modals/edit-channel-modal").then((m) => ({ default: m.EditChannelModal })))
+const ServerSettingsModal = dynamic(() => import("@/components/modals/server-settings-modal").then((m) => ({ default: m.ServerSettingsModal })))
+const QuickSwitcherModal = dynamic(() => import("@/components/modals/quickswitcher-modal").then((m) => ({ default: m.QuickSwitcherModal })))
+const SearchModal = dynamic(() => import("@/components/modals/search-modal").then((m) => ({ default: m.SearchModal })))
+const KeyboardShortcutsModal = dynamic(() => import("@/components/modals/keyboard-shortcuts-modal").then((m) => ({ default: m.KeyboardShortcutsModal })))
 import { PERMISSIONS, hasPermission } from "@vortex/shared"
 import { useUnreadChannels } from "@/hooks/use-unread-channels"
 import { useNotificationSound } from "@/hooks/use-notification-sound"
@@ -50,7 +52,7 @@ import { useKeyboardShortcuts, type ShortcutHandlers } from "@/hooks/use-keyboar
 
 const NO_CATEGORY = "__no_category__"
 
-interface VoiceParticipant {
+export interface VoiceParticipant {
   user_id: string
   channel_id: string
   muted: boolean
@@ -70,6 +72,10 @@ interface Props {
   currentUserId: string
   isOwner: boolean
   userRoles: RoleRow[]
+  initialThreadCounts?: Record<string, number>
+  initialVoiceParticipants?: VoiceParticipant[]
+  initialUnreadChannelIds?: string[]
+  initialMentionCounts?: Record<string, number>
 }
 
 type GroupedChannels = {
@@ -141,7 +147,7 @@ function mergeItemsPreservingOrder(
   return merged
 }
 
-function normalizeVoiceParticipants(rows: any[]): VoiceParticipant[] {
+export function normalizeVoiceParticipants(rows: any[]): VoiceParticipant[] {
   return rows.map((d: any) => ({
     user_id: d.user_id,
     channel_id: d.channel_id,
@@ -159,7 +165,7 @@ async function fetchThreadCounts(serverId: string, signal: AbortSignal) {
 }
 
 /** Server channel sidebar with drag-and-drop reordering, category grouping, voice state indicators, and unread tracking. */
-export function ChannelSidebar({ server, channels: initialChannels, currentUserId, isOwner, userRoles }: Props) {
+export function ChannelSidebar({ server, channels: initialChannels, currentUserId, isOwner, userRoles, initialThreadCounts, initialVoiceParticipants, initialUnreadChannelIds, initialMentionCounts }: Props) {
   const { activeChannelId, voiceChannelId, setVoiceChannel, channels: storeChannels, setChannels, addChannel, updateChannel, removeChannel, toggleMemberList, toggleThreadPanel, toggleWorkspacePanel, setServerHasUnread } = useAppStore(
     useShallow((s) => ({ activeChannelId: s.activeChannelId, voiceChannelId: s.voiceChannelId, setVoiceChannel: s.setVoiceChannel, channels: s.channels, setChannels: s.setChannels, addChannel: s.addChannel, updateChannel: s.updateChannel, removeChannel: s.removeChannel, toggleMemberList: s.toggleMemberList, toggleThreadPanel: s.toggleThreadPanel, toggleWorkspacePanel: s.toggleWorkspacePanel, setServerHasUnread: s.setServerHasUnread }))
   )
@@ -177,7 +183,7 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
   const [quickSwitcherOpen, setQuickSwitcherOpen] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false)
-  const [activeThreadCounts, setActiveThreadCounts] = useState<Record<string, number>>({})
+  const [activeThreadCounts, setActiveThreadCounts] = useState<Record<string, number>>(initialThreadCounts ?? {})
   const router = useRouter()
   const { toast } = useToast()
 
@@ -216,7 +222,10 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
       }
     }
 
-    void loadThreadCounts()
+    // Skip the immediate fetch if SSR data was provided — the 30s poll will pick up changes
+    if (!initialThreadCounts) {
+      void loadThreadCounts()
+    }
     const interval = window.setInterval(() => {
       void loadThreadCounts()
     }, 30000)
@@ -224,7 +233,7 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
       controller.abort()
       window.clearInterval(interval)
     }
-  }, [server.id])
+  }, [server.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Sync items on channel changes.
   // During an active drag, merge instead of replacing so realtime inserts/deletes
@@ -263,7 +272,7 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
   }, [server.id, addChannel, updateChannel, removeChannel])
 
   // Voice participants per channel
-  const [voiceParticipants, setVoiceParticipants] = useState<VoiceParticipant[]>([])
+  const [voiceParticipants, setVoiceParticipants] = useState<VoiceParticipant[]>(initialVoiceParticipants ?? [])
 
   useEffect(() => {
     const supabase = createClientSupabaseClient()
@@ -284,7 +293,10 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
       debounceTimer = setTimeout(fetchVoiceParticipants, 300)
     }
 
-    fetchVoiceParticipants()
+    // Skip initial fetch if SSR data was provided — real-time subscription handles updates
+    if (!initialVoiceParticipants) {
+      fetchVoiceParticipants()
+    }
 
     const subscription = supabase
       .channel(`voice-states:${server.id}`)
@@ -300,7 +312,7 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
       if (debounceTimer) clearTimeout(debounceTimer)
       supabase.removeChannel(subscription)
     }
-  }, [server.id])
+  }, [server.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Pre-group voice participants by channel to avoid per-item filtering
   const voiceParticipantsByChannel = useMemo(() => {
@@ -320,12 +332,16 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
   // Track unread state for all text channels in this server
   const textChannelIds = useMemo(() => channels.filter((c) => c.type === "text").map((c) => c.id), [channels])
   const { playNotification } = useNotificationSound()
+  const unreadInitialData = initialUnreadChannelIds
+    ? { unreadChannelIds: initialUnreadChannelIds, mentionCounts: initialMentionCounts ?? {} }
+    : undefined
   const { unreadChannelIds, mentionCounts, markRead } = useUnreadChannels(
     server.id,
     textChannelIds,
     currentUserId,
     activeChannelId,
-    playNotification
+    playNotification,
+    unreadInitialData
   )
 
   // Keep the server-level unread indicator in the app store in sync so the

--- a/apps/web/components/layout/member-list.tsx
+++ b/apps/web/components/layout/member-list.tsx
@@ -22,13 +22,14 @@ import { cn } from "@/lib/utils/cn"
 
 interface Props {
   serverId: string
+  initialMembers?: MemberData[]
 }
 
 interface PresenceState {
   [userId: string]: { status: string; speaking?: boolean; voice_channel_id?: string }
 }
 
-interface MemberData {
+export interface MemberData {
   server_id: string
   user_id: string
   nickname: string | null
@@ -48,26 +49,42 @@ interface MemberData {
 
 
 /** Collapsible member list panel showing server members grouped by role with real-time presence indicators. */
-export function MemberList({ serverId }: Props) {
+export function MemberList({ serverId, initialMembers }: Props) {
   const { memberListOpen, currentUser } = useAppStore(
     useShallow((s) => ({ memberListOpen: s.memberListOpen, currentUser: s.currentUser }))
   )
-  const [members, setMembers] = useState<MemberData[]>([])
+  const [members, setMembers] = useState<MemberData[]>(initialMembers ?? [])
   const [presence, setPresence] = useState<PresenceState>({})
   const [recentlyActiveUserIds, setRecentlyActiveUserIds] = useState<Set<string>>(new Set())
   const recentActivityTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
   const previousPresenceRef = useRef<PresenceState>({})
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null)
-  const [loadingMembers, setLoadingMembers] = useState(true)
+  const [loadingMembers, setLoadingMembers] = useState(!initialMembers?.length)
   const channelRef = useRef<RealtimeChannel | null>(null)
   const memberFetchControllerRef = useRef<AbortController | null>(null)
   const supabase = useMemo(() => createClientSupabaseClient(), [])
+
+  // Sync SSR-provided members to the app store for mention autocomplete
+  useEffect(() => {
+    if (initialMembers?.length) {
+      useAppStore.getState().setMembers(serverId, initialMembers.map((m) => ({
+        user_id: m.user_id,
+        username: m.user?.username ?? "",
+        display_name: m.user?.display_name ?? null,
+        avatar_url: m.user?.avatar_url ?? null,
+        nickname: m.nickname,
+      })))
+    }
+  }, [serverId, initialMembers])
 
   useEffect(() => {
     setSelectedMemberId(null)
   }, [serverId])
 
+  // Fetch members from API (skipped when SSR data provided)
   useEffect(() => {
+    if (initialMembers) return
+
     async function fetchMembers() {
       memberFetchControllerRef.current?.abort()
       const controller = new AbortController()
@@ -79,7 +96,6 @@ export function MemberList({ serverId }: Props) {
         const response = await fetch(`/api/servers/${encodedServerId}/members`, {
           method: "GET",
           credentials: "include",
-          cache: "no-store",
           signal: controller.signal,
         })
 
@@ -125,6 +141,14 @@ export function MemberList({ serverId }: Props) {
 
     fetchMembers()
 
+    return () => {
+      memberFetchControllerRef.current?.abort()
+      memberFetchControllerRef.current = null
+    }
+  }, [serverId, initialMembers])
+
+  // Presence subscription (always runs regardless of SSR data)
+  useEffect(() => {
     const channel = supabase.channel(`presence:${serverId}`)
     channelRef.current = channel
     channel
@@ -188,8 +212,6 @@ export function MemberList({ serverId }: Props) {
       })
 
     return () => {
-      memberFetchControllerRef.current?.abort()
-      memberFetchControllerRef.current = null
       channelRef.current = null
       supabase.removeChannel(channel)
       for (const timer of recentActivityTimersRef.current.values()) {

--- a/apps/web/components/modals/search-modal.tsx
+++ b/apps/web/components/modals/search-modal.tsx
@@ -48,6 +48,7 @@ export function SearchModal({ serverId, onClose, onJumpToMessage }: Props) {
   const [total, setTotal] = useState(0)
   const inputRef = useRef<HTMLInputElement>(null)
   const debounceRef = useRef<NodeJS.Timeout | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
 
   useEffect(() => { inputRef.current?.focus() }, [])
   useEffect(() => {
@@ -59,20 +60,28 @@ export function SearchModal({ serverId, onClose, onJumpToMessage }: Props) {
   const search = useCallback(async (t: string, f: ActiveFilters) => {
     const q = buildQueryString(t, f)
     if (!q.trim()) return setResults([])
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
     setLoading(true)
     try {
-      const res = await fetch(`/api/search?q=${encodeURIComponent(q)}&serverId=${serverId}&limit=40`)
+      const res = await fetch(`/api/search?q=${encodeURIComponent(q)}&serverId=${serverId}&limit=40`, { signal: controller.signal })
       if (res.ok) {
         const data = await res.json()
         setResults(data.results ?? [])
         setTotal(data.total ?? 0)
       }
-    } finally { setLoading(false) }
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") return
+      throw e
+    } finally {
+      if (!controller.signal.aborted) setLoading(false)
+    }
   }, [serverId])
 
   const scheduleSearch = useCallback((t: string, f: ActiveFilters) => {
     if (debounceRef.current) clearTimeout(debounceRef.current)
-    debounceRef.current = setTimeout(() => search(t, f), 250)
+    debounceRef.current = setTimeout(() => search(t, f), 300)
   }, [search])
 
   function handleTextInput(e: React.ChangeEvent<HTMLInputElement>) {

--- a/apps/web/components/notifications/notification-bell.tsx
+++ b/apps/web/components/notifications/notification-bell.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { Bell, Check, CheckCheck, Hash, AtSign, UserPlus, X } from "lucide-react"
 import { createClientSupabaseClient } from "@/lib/supabase/client"
+import { useAppStore } from "@/lib/stores/app-store"
 import { format } from "date-fns"
 
 interface Notification {
@@ -73,6 +74,11 @@ export function NotificationBell({ userId, variant = "icon" }: Props) {
       .subscribe()
     return () => { supabase.removeChannel(ch) }
   }, [userId, supabase])
+
+  // Sync unread count to Zustand store (consumed by useTabUnreadTitle)
+  useEffect(() => {
+    useAppStore.getState().setNotificationUnreadCount(unreadCount)
+  }, [unreadCount])
 
   // Close on outside click
   useEffect(() => {

--- a/apps/web/hooks/use-presence-sync.ts
+++ b/apps/web/hooks/use-presence-sync.ts
@@ -105,7 +105,12 @@ export function usePresenceSync(userId: string | null, status?: PresenceStatus) 
         }
       })
 
+    let lastActivityTime = 0
+    const ACTIVITY_THROTTLE_MS = 3000
     const onActivity = () => {
+      const now = Date.now()
+      if (now - lastActivityTime < ACTIVITY_THROTTLE_MS) return
+      lastActivityTime = now
       if (currentStatusRef.current === "idle" && !isIdleExplicitRef.current) {
         persistStatus("online", { persistUserRecord: false, rememberExplicit: false })
       }

--- a/apps/web/hooks/use-tab-unread-title.ts
+++ b/apps/web/hooks/use-tab-unread-title.ts
@@ -1,49 +1,25 @@
 "use client"
 
-import { useEffect, useMemo } from "react"
-import { createClientSupabaseClient } from "@/lib/supabase/client"
+import { useEffect } from "react"
+import { useAppStore } from "@/lib/stores/app-store"
+import { useShallow } from "zustand/react/shallow"
 
 const BASE_TITLE = "VortexChat — Chat, Hang Out, Belong"
 
 export function useTabUnreadTitle(userId: string | null) {
-  const supabase = useMemo(() => createClientSupabaseClient(), [])
+  const { notificationUnreadCount, dmUnreadCount } = useAppStore(
+    useShallow((s) => ({
+      notificationUnreadCount: s.notificationUnreadCount,
+      dmUnreadCount: s.dmUnreadCount,
+    }))
+  )
 
   useEffect(() => {
-    if (!userId) return
-    const currentUserId = userId
-
-    let cancelled = false
-    async function refresh() {
-      const [{ count }, dmUnread] = await Promise.all([
-        supabase
-          .from("notifications")
-          .select("id", { count: "exact", head: true })
-          .eq("user_id", currentUserId)
-          .eq("read", false),
-        fetch("/api/dm/channels")
-          .then(async (res) => {
-            if (!res.ok) return 0
-            const channels = await res.json() as Array<{ is_unread?: boolean }>
-            return channels.filter((channel) => channel.is_unread).length
-          })
-          .catch(() => 0),
-      ])
-
-      if (cancelled) return
-      const unread = (count ?? 0) + dmUnread
-      document.title = unread > 0 ? `(${unread}) VortexChat` : BASE_TITLE
-    }
-
-    refresh()
-    const interval = window.setInterval(refresh, 30000)
-    const onFocus = () => refresh()
-    window.addEventListener("focus", onFocus)
-
-    return () => {
-      cancelled = true
-      window.clearInterval(interval)
-      window.removeEventListener("focus", onFocus)
+    if (!userId) {
       document.title = BASE_TITLE
+      return
     }
-  }, [supabase, userId])
+    const unread = notificationUnreadCount + dmUnreadCount
+    document.title = unread > 0 ? `(${unread}) VortexChat` : BASE_TITLE
+  }, [userId, notificationUnreadCount, dmUnreadCount])
 }

--- a/apps/web/hooks/use-unread-channels.ts
+++ b/apps/web/hooks/use-unread-channels.ts
@@ -18,15 +18,21 @@ export function useUnreadChannels(
   channelIds: string[],
   currentUserId: string,
   activeChannelId: string | null,
-  onNewUnread?: () => void
+  onNewUnread?: () => void,
+  initialData?: { unreadChannelIds: string[]; mentionCounts: Record<string, number> }
 ) {
   const onNewUnreadRef = useRef(onNewUnread)
   onNewUnreadRef.current = onNewUnread
   const supabase = useMemo(() => createClientSupabaseClient(), [])
-  const [unreadChannelIds, setUnreadChannelIds] = useState<Set<string>>(new Set())
-  const [mentionCounts, setMentionCounts] = useState<Record<string, number>>({})
+  const [unreadChannelIds, setUnreadChannelIds] = useState<Set<string>>(
+    () => new Set(initialData?.unreadChannelIds ?? [])
+  )
+  const [mentionCounts, setMentionCounts] = useState<Record<string, number>>(
+    initialData?.mentionCounts ?? {}
+  )
   const activeChannelRef = useRef(activeChannelId)
   activeChannelRef.current = activeChannelId
+  const markReadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Mark active channel as read in DB + clear local unread
   const markRead = useCallback(
@@ -52,6 +58,7 @@ export function useUnreadChannels(
   // Load initial unread state
   useEffect(() => {
     if (channelIds.length === 0) return
+    if (initialData) return
 
     async function loadInitialUnread() {
       // 1. Fetch this user's read_states for these channels
@@ -104,10 +111,23 @@ export function useUnreadChannels(
     loadInitialUnread()
   }, [serverId, currentUserId])
 
-  // Mark currently active channel as read on activation
+  // Mark currently active channel as read after 500ms debounce (avoids rapid-switch RPC calls)
   useEffect(() => {
+    if (markReadTimerRef.current) {
+      clearTimeout(markReadTimerRef.current)
+      markReadTimerRef.current = null
+    }
     if (activeChannelId) {
-      markRead(activeChannelId)
+      markReadTimerRef.current = setTimeout(() => {
+        markRead(activeChannelId)
+        markReadTimerRef.current = null
+      }, 500)
+    }
+    return () => {
+      if (markReadTimerRef.current) {
+        clearTimeout(markReadTimerRef.current)
+        markReadTimerRef.current = null
+      }
     }
   }, [activeChannelId, markRead])
 
@@ -123,12 +143,10 @@ export function useUnreadChannels(
           event: "INSERT",
           schema: "public",
           table: "messages",
+          filter: `channel_id=in.(${channelIds.join(",")})`,
         },
         (payload) => {
           const msg = payload.new as { channel_id: string; author_id: string }
-
-          // Only care about channels in this server
-          if (!channelIds.includes(msg.channel_id)) return
 
           // Don't mark as unread if it's own message or if channel is active
           if (msg.author_id === currentUserId) return

--- a/apps/web/lib/stores/app-store.ts
+++ b/apps/web/lib/stores/app-store.ts
@@ -96,6 +96,12 @@ interface AppState {
   serverHasUnread: Record<string, boolean>
   setServerHasUnread: (serverId: string, hasUnread: boolean) => void
 
+  // Notification + DM unread counts (shared between NotificationBell, DMList, and useTabUnreadTitle)
+  notificationUnreadCount: number
+  setNotificationUnreadCount: (count: number) => void
+  dmUnreadCount: number
+  setDmUnreadCount: (count: number) => void
+
   // Voice state
   voiceChannelId: string | null
   voiceServerId: string | null
@@ -193,6 +199,11 @@ export const useAppStore = create<AppState>((set) => ({
       if (state.serverHasUnread[serverId] === hasUnread) return state
       return { serverHasUnread: { ...state.serverHasUnread, [serverId]: hasUnread } }
     }),
+
+  notificationUnreadCount: 0,
+  setNotificationUnreadCount: (count) => set({ notificationUnreadCount: count }),
+  dmUnreadCount: 0,
+  setDmUnreadCount: (count) => set({ dmUnreadCount: count }),
 
   voiceChannelId: null,
   voiceServerId: null,

--- a/apps/web/lib/webrtc/use-voice.ts
+++ b/apps/web/lib/webrtc/use-voice.ts
@@ -336,69 +336,70 @@ export function useVoice(channelId: string, userId: string, serverId?: string | 
       let availableBitrate: number | null = null
       let candidatePairCount = 0
 
-      for (const [peerId, pc] of pcs) {
-        if (pc.connectionState === "closed" || pc.connectionState === "failed") continue
-        try {
-          const stats = await pc.getStats()
-          stats.forEach((report) => {
-            if (report.type === "candidate-pair" && report.state === "succeeded") {
-              const rtt = report.currentRoundTripTime
-              if (typeof rtt === "number") {
-                totalRtt += rtt * 1000 // convert seconds to ms
-                candidatePairCount++
-              }
-              if (typeof report.availableOutgoingBitrate === "number") {
-                availableBitrate = (availableBitrate ?? 0) + report.availableOutgoingBitrate / 1000 // bps to kbps
+      const activePcs = pcs.filter(([, pc]) => pc.connectionState !== "closed" && pc.connectionState !== "failed")
+      const statsResults = await Promise.allSettled(
+        activePcs.map(async ([peerId, pc]) => ({ peerId, stats: await pc.getStats() }))
+      )
+
+      for (const result of statsResults) {
+        if (result.status !== "fulfilled") continue
+        const { peerId, stats } = result.value
+        stats.forEach((report) => {
+          if (report.type === "candidate-pair" && report.state === "succeeded") {
+            const rtt = report.currentRoundTripTime
+            if (typeof rtt === "number") {
+              totalRtt += rtt * 1000 // convert seconds to ms
+              candidatePairCount++
+            }
+            if (typeof report.availableOutgoingBitrate === "number") {
+              availableBitrate = (availableBitrate ?? 0) + report.availableOutgoingBitrate / 1000 // bps to kbps
+            }
+          }
+          if (report.type === "outbound-rtp" && report.kind === "audio") {
+            const prevEntry = prevStatsRef.current.get(peerId)
+            const packetsSent = report.packetsSent ?? 0
+            if (prevEntry) {
+              const deltaPackets = packetsSent - prevEntry.packetsSent
+              if (deltaPackets > 0) {
+                totalPacketsSent += deltaPackets
               }
             }
-            if (report.type === "outbound-rtp" && report.kind === "audio") {
-              const prevEntry = prevStatsRef.current.get(peerId)
-              const packetsSent = report.packetsSent ?? 0
-              if (prevEntry) {
-                const deltaPackets = packetsSent - prevEntry.packetsSent
-                if (deltaPackets > 0) {
-                  totalPacketsSent += deltaPackets
-                }
-              }
-              prevStatsRef.current.set(peerId, {
-                timestamp: report.timestamp,
-                packetsSent,
-                packetsLost: prevStatsRef.current.get(peerId)?.packetsLost ?? 0,
-              })
+            prevStatsRef.current.set(peerId, {
+              timestamp: report.timestamp,
+              packetsSent,
+              packetsLost: prevStatsRef.current.get(peerId)?.packetsLost ?? 0,
+            })
+          }
+          if (report.type === "remote-inbound-rtp" && report.kind === "audio") {
+            const packetsLost = report.packetsLost ?? 0
+            const prevEntry = prevStatsRef.current.get(peerId)
+            if (prevEntry) {
+              const deltaLost = packetsLost - prevEntry.packetsLost
+              totalPacketsLost += Math.max(0, deltaLost)
             }
-            if (report.type === "remote-inbound-rtp" && report.kind === "audio") {
-              const packetsLost = report.packetsLost ?? 0
-              const prevEntry = prevStatsRef.current.get(peerId)
-              if (prevEntry) {
-                const deltaLost = packetsLost - prevEntry.packetsLost
-                totalPacketsLost += Math.max(0, deltaLost)
-              }
-              if (prevEntry) {
-                prevStatsRef.current.set(peerId, { ...prevEntry, packetsLost })
-              }
+            if (prevEntry) {
+              prevStatsRef.current.set(peerId, { ...prevEntry, packetsLost })
             }
-            if (report.type === "inbound-rtp" && report.kind === "audio") {
-              const jitter = report.jitter
-              if (typeof jitter === "number") {
-                totalJitter = Math.max(totalJitter, jitter * 1000) // worst-case jitter
-              }
-              // Also capture inbound packet loss
-              const lost = report.packetsLost
-              const received = report.packetsReceived
-              if (typeof lost === "number" && typeof received === "number" && received > 0) {
-                const total = lost + received
-                const lossPct = (lost / total) * 100
-                // Use inbound loss if it's worse
-                if (lossPct > (totalPacketsSent > 0 ? (totalPacketsLost / totalPacketsSent) * 100 : 0)) {
-                  totalPacketsLost = lost
-                  totalPacketsSent = total
-                }
+          }
+          if (report.type === "inbound-rtp" && report.kind === "audio") {
+            const jitter = report.jitter
+            if (typeof jitter === "number") {
+              totalJitter = Math.max(totalJitter, jitter * 1000) // worst-case jitter
+            }
+            // Also capture inbound packet loss
+            const lost = report.packetsLost
+            const received = report.packetsReceived
+            if (typeof lost === "number" && typeof received === "number" && received > 0) {
+              const total = lost + received
+              const lossPct = (lost / total) * 100
+              // Use inbound loss if it's worse
+              if (lossPct > (totalPacketsSent > 0 ? (totalPacketsLost / totalPacketsSent) * 100 : 0)) {
+                totalPacketsLost = lost
+                totalPacketsSent = total
               }
             }
-          })
-        } catch {
-          // getStats can fail on closed connections
-        }
+          }
+        })
       }
 
       const rttMs = candidatePairCount > 0 ? Math.round(totalRtt / candidatePairCount) : 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       },
       "devDependencies": {
         "@types/node": "^20",
+        "pino-pretty": "^13.1.3",
         "tsx": "^4.19.2",
         "typescript": "^5.4.5"
       }
@@ -595,6 +596,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -704,6 +706,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -933,6 +936,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -2232,7 +2236,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -2466,6 +2469,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2487,6 +2491,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.5.1.tgz",
       "integrity": "sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -2499,6 +2504,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.1.tgz",
       "integrity": "sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2922,6 +2928,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.1.tgz",
       "integrity": "sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2938,6 +2945,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.1.tgz",
       "integrity": "sha512-iZH3Gw8cxQn0gjpOjJMmKLd9GIaNh/E3v3ST67vyzLSxHBs14HsG4dy7jMYyC5WXGdBVEcM7U/XTF5hCQxjDMw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.1",
         "@opentelemetry/resources": "2.5.1",
@@ -2955,6 +2963,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -4301,6 +4310,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5257,6 +5267,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.97.0.tgz",
       "integrity": "sha512-kTD91rZNO4LvRUHv4x3/4hNmsEd2ofkYhuba2VMUPRVef1RCmnHtm7rIws38Fg0yQnOSZOplQzafn0GSiy6GVg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.97.0",
         "@supabase/functions-js": "2.97.0",
@@ -5373,7 +5384,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -5384,7 +5394,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -5481,6 +5490,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5491,6 +5501,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5568,6 +5579,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -6077,6 +6089,7 @@
       "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.36.3.tgz",
       "integrity": "sha512-wxo1ei4OHDHm4UGMgrNVz9QUEela9N/Iwi4p1JlHNSowQiPi+eljlGnfbZVkV0V4PIrjGtGFJt5GjWM5k28enA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
@@ -6111,7 +6124,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -6121,29 +6133,25 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -6154,15 +6162,13 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -6175,7 +6181,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -6185,7 +6190,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -6194,15 +6198,13 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -6219,7 +6221,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -6233,7 +6234,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -6246,7 +6246,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -6261,7 +6260,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -6271,15 +6269,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -6299,6 +6295,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6320,7 +6317,6 @@
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -6369,7 +6365,6 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -6387,7 +6382,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6403,8 +6397,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -6857,6 +6850,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6881,8 +6875,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -7071,7 +7064,6 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -7126,6 +7118,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -7285,6 +7284,16 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -7435,6 +7444,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/engine.io": {
       "version": "6.6.5",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.5.tgz",
@@ -7499,7 +7518,6 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
       "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.3.0"
@@ -7762,6 +7780,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7907,6 +7926,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8153,6 +8173,13 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
+      "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8203,6 +8230,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -8217,8 +8251,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -8531,8 +8564,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/globals": {
       "version": "14.0.0",
@@ -8581,8 +8613,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/hark": {
       "version": "1.2.3",
@@ -8684,6 +8715,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -9300,7 +9338,6 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -9315,7 +9352,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -9331,6 +9367,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9342,6 +9379,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -9386,8 +9433,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -9564,7 +9610,6 @@
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -9715,8 +9760,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -9877,14 +9921,14 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/next": {
       "version": "15.5.12",
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.12.tgz",
       "integrity": "sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.12",
         "@swc/helpers": "0.5.15",
@@ -10165,6 +10209,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10383,6 +10437,44 @@
         "split2": "^4.0.0"
       }
     },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
@@ -10427,6 +10519,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10669,6 +10762,17 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10722,7 +10826,6 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -10732,6 +10835,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10741,6 +10845,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10903,7 +11008,6 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10976,6 +11080,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11149,7 +11254,6 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -11186,7 +11290,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -11198,8 +11301,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/sdp": {
       "version": "3.2.1",
@@ -11216,6 +11318,23 @@
         "sdp-verify": "checker.js"
       }
     },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -11230,7 +11349,6 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -11524,7 +11642,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11543,7 +11660,6 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -11835,6 +11951,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -11909,7 +12026,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -11923,7 +12039,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -11942,7 +12057,6 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
       "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -11976,8 +12090,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -12067,6 +12180,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12399,6 +12513,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12598,7 +12713,6 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
       "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -12637,7 +12751,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.3.tgz",
       "integrity": "sha512-LLBBA4oLmT7sZdHiYE/PeVuifOxYyE2uL/V+9VQP7YSYdJU7bSf7H8bZRRxW8kEPMkmVjnrXmoR3oejIdX0xbg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -12686,7 +12799,6 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
       "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -12695,15 +12807,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -12717,7 +12827,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -12880,6 +12989,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.19.0",
@@ -13138,6 +13254,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13151,6 +13268,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13226,6 +13344,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",


### PR DESCRIPTION
Eliminate ~8-10 client-side requests on server navigation by fetching members, emojis, thread counts, voice states, and unread data in the layout's SSR Promise.all. Components receive data as props for instant hydration while keeping real-time subscriptions for live updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Message management UI now respects user permissions
  * Global unread tracking for notifications and direct messages

* **Performance**
  * Parallelized data fetching for faster load times
  * Server-side pre-loading reduces initial client requests
  * Added HTTP caching on API responses
  * Improved voice call quality monitoring resilience
  * Search requests now cancel previous queries

* **Bug Fixes**
  * Activity throttling prevents excessive presence updates
  * Enhanced error handling for voice statistics collection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->