### PR TITLE
Add user connections: DB, API, Steam OpenID flow, and UI connections tab

### DIFF
--- a/apps/web/app/api/users/connections/route.ts
+++ b/apps/web/app/api/users/connections/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+
+const MANUAL_PROVIDERS = ["github", "x", "twitch", "youtube", "reddit", "website"] as const
+type ManualProvider = (typeof MANUAL_PROVIDERS)[number]
+const MANUAL_PROVIDER_SET = new Set<string>(MANUAL_PROVIDERS)
+
+function normalizeProviderUserId(provider: string, value: string) {
+  return provider === "website" ? value.trim().toLowerCase() : value.trim().toLowerCase().replace(/^@/, "")
+}
+
+export async function GET() {
+  const supabase = await createServerSupabaseClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { data, error } = await supabase
+    .from("user_connections")
+    .select("id, provider, provider_user_id, username, display_name, profile_url, metadata, created_at")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: true })
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ connections: data ?? [] })
+}
+
+export async function POST(request: Request) {
+  const supabase = await createServerSupabaseClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const body = (await request.json().catch(() => ({}))) as {
+    provider?: string
+    username?: string
+    profile_url?: string
+    display_name?: string
+  }
+
+  const providerRaw = (body.provider ?? "").trim().toLowerCase()
+  if (!MANUAL_PROVIDER_SET.has(providerRaw)) {
+    return NextResponse.json({ error: "Unsupported provider" }, { status: 422 })
+  }
+
+  const provider = providerRaw as ManualProvider
+
+  const profileUrl = (body.profile_url ?? "").trim()
+  if (!profileUrl) return NextResponse.json({ error: "profile_url is required" }, { status: 422 })
+
+  const providerUserId = normalizeProviderUserId(provider, body.username || profileUrl)
+  if (!providerUserId) return NextResponse.json({ error: "username is required" }, { status: 422 })
+
+  const { data, error } = await supabase
+    .from("user_connections")
+    .upsert({
+      user_id: user.id,
+      provider,
+      provider_user_id: providerUserId,
+      username: body.username?.trim() || providerUserId,
+      display_name: body.display_name?.trim() || null,
+      profile_url: profileUrl,
+      metadata: {},
+    }, { onConflict: "user_id,provider" })
+    .select("id, provider, provider_user_id, username, display_name, profile_url, metadata, created_at")
+    .single()
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ connection: data })
+}
+
+export async function DELETE(request: Request) {
+  const supabase = await createServerSupabaseClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get("id")
+  if (!id) return NextResponse.json({ error: "id is required" }, { status: 422 })
+
+  const { error } = await supabase
+    .from("user_connections")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id)
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/app/api/users/connections/steam/callback/route.ts
+++ b/apps/web/app/api/users/connections/steam/callback/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+
+async function verifySteamAssertion(searchParams: URLSearchParams) {
+  const verificationParams = new URLSearchParams(searchParams)
+  verificationParams.set("openid.mode", "check_authentication")
+
+  const response = await fetch("https://steamcommunity.com/openid/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: verificationParams.toString(),
+    cache: "no-store",
+  })
+
+  if (!response.ok) return false
+  const body = await response.text()
+  return body.includes("is_valid:true")
+}
+
+function extractSteamId(claimedId: string | null) {
+  if (!claimedId) return null
+  const match = claimedId.match(/\/id\/(\d+)$/)
+  return match?.[1] ?? null
+}
+
+function buildRedirect(base: URL, nextPath: string, status: string) {
+  const target = new URL(nextPath, base.origin)
+  target.searchParams.set("connections", status)
+  return target
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const nextPath = url.searchParams.get("next") || "/"
+  const state = url.searchParams.get("state")
+
+  const supabase = await createServerSupabaseClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return NextResponse.redirect(buildRedirect(url, nextPath, "steam_auth_required"))
+  }
+
+  const cookieStore = await cookies()
+  const expectedState = cookieStore.get("steam_oauth_state")?.value
+
+  if (!state || !expectedState || state !== expectedState) {
+    return NextResponse.redirect(buildRedirect(url, nextPath, "steam_state_invalid"))
+  }
+
+  const isValid = await verifySteamAssertion(url.searchParams)
+  if (!isValid) {
+    return NextResponse.redirect(buildRedirect(url, nextPath, "steam_verification_failed"))
+  }
+
+  const steamId = extractSteamId(url.searchParams.get("openid.claimed_id"))
+  if (!steamId) {
+    return NextResponse.redirect(buildRedirect(url, nextPath, "steam_missing_id"))
+  }
+
+  const { error } = await supabase
+    .from("user_connections")
+    .upsert({
+      user_id: user.id,
+      provider: "steam",
+      provider_user_id: steamId,
+      username: steamId,
+      display_name: `Steam #${steamId}`,
+      profile_url: `https://steamcommunity.com/profiles/${steamId}`,
+      metadata: { linked_via: "openid" },
+    }, { onConflict: "user_id,provider" })
+
+  const response = NextResponse.redirect(buildRedirect(url, nextPath, error ? "steam_save_failed" : "steam_linked"))
+  response.cookies.delete("steam_oauth_state")
+  return response
+}

--- a/apps/web/app/api/users/connections/steam/start/route.ts
+++ b/apps/web/app/api/users/connections/steam/start/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server"
+import { randomBytes } from "crypto"
+
+const STEAM_OPENID_URL = "https://steamcommunity.com/openid/login"
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const origin = url.origin
+  const next = url.searchParams.get("next") || "/"
+  const callbackUrl = `${origin}/api/users/connections/steam/callback`
+
+  const state = randomBytes(16).toString("hex")
+
+  const authUrl = new URL(STEAM_OPENID_URL)
+  authUrl.searchParams.set("openid.ns", "http://specs.openid.net/auth/2.0")
+  authUrl.searchParams.set("openid.mode", "checkid_setup")
+  authUrl.searchParams.set("openid.return_to", `${callbackUrl}?next=${encodeURIComponent(next)}&state=${state}`)
+  authUrl.searchParams.set("openid.realm", origin)
+  authUrl.searchParams.set("openid.identity", "http://specs.openid.net/auth/2.0/identifier_select")
+  authUrl.searchParams.set("openid.claimed_id", "http://specs.openid.net/auth/2.0/identifier_select")
+
+  const response = NextResponse.redirect(authUrl.toString())
+  response.cookies.set("steam_oauth_state", state, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: origin.startsWith("https://"),
+    path: "/",
+    maxAge: 60 * 10,
+  })
+
+  return response
+}

--- a/apps/web/components/modals/profile-settings-modal.tsx
+++ b/apps/web/components/modals/profile-settings-modal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useMemo, useRef, useEffect, useCallback } from "react"
-import { Loader2, Upload, LogOut, ShieldCheck, ShieldOff, Copy, Check, KeyRound, Trash2, Pencil, Lock, RefreshCw, Eye, EyeOff } from "lucide-react"
+import { Loader2, Upload, LogOut, ShieldCheck, ShieldOff, Copy, Check, KeyRound, Trash2, Pencil, Lock, RefreshCw, Eye, EyeOff, Link2, ExternalLink } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
@@ -148,7 +148,7 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
   const [bannerColor, setBannerColor] = useState(user.banner_color ?? "#5865f2")
   const [avatarPreview, setAvatarPreview] = useState<string | null>(user.avatar_url)
   const [avatarFile, setAvatarFile] = useState<File | null>(null)
-  const [activeTab, setActiveTab] = useState<"profile" | "security" | "appearance">("profile")
+  const [activeTab, setActiveTab] = useState<"profile" | "security" | "connections" | "appearance">("profile")
   const avatarRef = useRef<HTMLInputElement>(null)
   const supabase = useMemo(() => createClientSupabaseClient(), [])
   const toSettingsPayload = useAppearanceStore((s) => s.toSettingsPayload)
@@ -265,6 +265,10 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
       title: "Security",
       subtitle: "Manage login methods, recovery controls, and high-risk account actions.",
     },
+    connections: {
+      title: "Connections",
+      subtitle: "Link Steam and social profiles to show your gaming and creator identity.",
+    },
     appearance: {
       title: "Appearance",
       subtitle: "Adjust chat readability and visual comfort settings.",
@@ -277,7 +281,7 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
         className="max-w-2xl max-h-[90vh] overflow-hidden p-0"
         style={{ background: "var(--theme-bg-primary)", borderColor: "var(--theme-bg-tertiary)" }}
       >
-        <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as "profile" | "security" | "appearance")} orientation="vertical" className="flex h-[80vh]">
+        <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as "profile" | "security" | "connections" | "appearance")} orientation="vertical" className="flex h-[80vh]">
           {/* Settings nav */}
           <div className="w-52 flex-shrink-0 p-4 flex flex-col" style={{ background: "var(--theme-bg-secondary)" }}>
             <h3 className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: "var(--theme-text-muted)" }}>
@@ -288,8 +292,11 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
               <TabsTrigger value="profile" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: "var(--theme-text-secondary)" }}>
                 My Account
               </TabsTrigger>
-                <TabsTrigger value="security" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: "var(--theme-text-secondary)" }}>
+              <TabsTrigger value="security" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: "var(--theme-text-secondary)" }}>
                 Security
+              </TabsTrigger>
+              <TabsTrigger value="connections" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: "var(--theme-text-secondary)" }}>
+                Connections
               </TabsTrigger>
               <TabsTrigger value="appearance" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: "var(--theme-text-secondary)" }}>
                 Appearance
@@ -565,6 +572,10 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
                   <TwoFactorSection supabase={supabase} toast={toast} />
                 </TabsContent>
 
+                <TabsContent value="connections" className="mt-0 space-y-8">
+                  <ConnectionsSection />
+                </TabsContent>
+
                 <TabsContent value="appearance" className="mt-0">
                   <AppearanceTab onSave={handleSave} saving={loading} />
                 </TabsContent>
@@ -572,6 +583,126 @@ export function ProfileSettingsModal({ open, onClose, user }: Props) {
         </Tabs>
       </DialogContent>
     </Dialog>
+  )
+}
+
+type ConnectionRow = {
+  id: string
+  provider: string
+  provider_user_id: string
+  username: string | null
+  display_name: string | null
+  profile_url: string | null
+  created_at: string
+}
+
+function ConnectionsSection() {
+  const { toast } = useToast()
+  const [connections, setConnections] = useState<ConnectionRow[]>([])
+  const [loading, setLoading] = useState(false)
+  const [provider, setProvider] = useState("github")
+  const [username, setUsername] = useState("")
+  const [profileUrl, setProfileUrl] = useState("")
+
+  const loadConnections = useCallback(async () => {
+    const res = await fetch("/api/users/connections", { cache: "no-store" })
+    const payload = await res.json().catch(() => ({}))
+    if (res.ok) setConnections(payload.connections ?? [])
+  }, [])
+
+  useEffect(() => {
+    loadConnections()
+  }, [loadConnections])
+
+  async function connectSteam() {
+    const next = window.location.pathname + window.location.search
+    window.location.href = `/api/users/connections/steam/start?next=${encodeURIComponent(next)}`
+  }
+
+  async function addManualConnection(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    const res = await fetch("/api/users/connections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider, username, profile_url: profileUrl }),
+    })
+    const payload = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      toast({ variant: "destructive", title: "Failed to add connection", description: payload.error || "Please try again" })
+      setLoading(false)
+      return
+    }
+    setUsername("")
+    setProfileUrl("")
+    setConnections((prev) => {
+      const others = prev.filter((item) => item.provider !== payload.connection.provider)
+      return [...others, payload.connection]
+    })
+    setLoading(false)
+  }
+
+  async function removeConnection(id: string) {
+    const res = await fetch(`/api/users/connections?id=${id}`, { method: "DELETE" })
+    if (!res.ok) {
+      toast({ variant: "destructive", title: "Failed to remove connection" })
+      return
+    }
+    setConnections((prev) => prev.filter((item) => item.id !== id))
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg p-4 space-y-3" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
+        <h3 className="text-base font-semibold text-white">Steam</h3>
+        <p className="text-sm" style={{ color: "var(--theme-text-muted)" }}>Link your Steam account using official OpenID sign-in. We only store your Steam ID and profile URL.</p>
+        <Button type="button" onClick={connectSteam} style={{ background: "var(--theme-accent)" }}>
+          <Link2 className="w-4 h-4 mr-2" /> Connect Steam
+        </Button>
+      </div>
+
+      <div className="rounded-lg p-4 space-y-3" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
+        <h3 className="text-base font-semibold text-white">Social Links</h3>
+        <form onSubmit={addManualConnection} className="grid grid-cols-1 md:grid-cols-[160px_1fr_1fr_auto] gap-2">
+          <select
+            value={provider}
+            onChange={(e) => setProvider(e.target.value)}
+            className="rounded px-2 py-2 text-sm"
+            style={{ background: "var(--theme-bg-tertiary)", border: "1px solid var(--theme-bg-tertiary)", color: "var(--theme-text-primary)" }}
+          >
+            <option value="github">GitHub</option>
+            <option value="x">X / Twitter</option>
+            <option value="twitch">Twitch</option>
+            <option value="youtube">YouTube</option>
+            <option value="reddit">Reddit</option>
+            <option value="website">Website</option>
+          </select>
+          <Input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="username" />
+          <Input value={profileUrl} onChange={(e) => setProfileUrl(e.target.value)} placeholder="https://..." required />
+          <Button type="submit" disabled={loading}>{loading ? "Adding..." : "Add"}</Button>
+        </form>
+      </div>
+
+      <div className="space-y-2">
+        {connections.map((connection) => (
+          <div key={connection.id} className="rounded-lg p-3 flex items-center justify-between gap-3" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
+            <div className="min-w-0">
+              <p className="text-sm text-white capitalize">{connection.provider}</p>
+              <p className="text-xs truncate" style={{ color: "var(--theme-text-muted)" }}>{connection.display_name || connection.username || connection.provider_user_id}</p>
+            </div>
+            <div className="flex items-center gap-2">
+              {connection.profile_url && (
+                <a href={connection.profile_url} target="_blank" rel="noreferrer" className="text-xs px-2 py-1 rounded" style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-secondary)" }}>
+                  <ExternalLink className="w-3.5 h-3.5" />
+                </a>
+              )}
+              <Button type="button" size="sm" variant="ghost" onClick={() => removeConnection(connection.id)} style={{ color: "var(--theme-danger)" }}>Remove</Button>
+            </div>
+          </div>
+        ))}
+        {connections.length === 0 && <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>No connections yet.</p>}
+      </div>
+    </div>
   )
 }
 

--- a/apps/web/types/database.ts
+++ b/apps/web/types/database.ts
@@ -66,6 +66,53 @@ export type Database = {
         }
         Relationships: []
       }
+      user_connections: {
+        Row: {
+          id: string
+          user_id: string
+          provider: 'steam' | 'github' | 'x' | 'twitch' | 'youtube' | 'reddit' | 'website'
+          provider_user_id: string
+          username: string | null
+          display_name: string | null
+          profile_url: string | null
+          metadata: Json
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          provider: 'steam' | 'github' | 'x' | 'twitch' | 'youtube' | 'reddit' | 'website'
+          provider_user_id: string
+          username?: string | null
+          display_name?: string | null
+          profile_url?: string | null
+          metadata?: Json
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          provider?: 'steam' | 'github' | 'x' | 'twitch' | 'youtube' | 'reddit' | 'website'
+          provider_user_id?: string
+          username?: string | null
+          display_name?: string | null
+          profile_url?: string | null
+          metadata?: Json
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'user_connections_user_id_fkey'
+            columns: ['user_id']
+            isOneToOne: false
+            referencedRelation: 'users'
+            referencedColumns: ['id']
+          },
+        ]
+      }
       servers: {
         Row: {
           id: string

--- a/supabase/migrations/00033_user_connections.sql
+++ b/supabase/migrations/00033_user_connections.sql
@@ -1,0 +1,52 @@
+create table if not exists public.user_connections (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  provider text not null,
+  provider_user_id text not null,
+  username text,
+  display_name text,
+  profile_url text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint user_connections_provider_check check (provider in ('steam', 'github', 'x', 'twitch', 'youtube', 'reddit', 'website'))
+);
+
+create unique index if not exists user_connections_user_provider_unique
+  on public.user_connections(user_id, provider);
+
+create unique index if not exists user_connections_provider_user_unique
+  on public.user_connections(provider, provider_user_id);
+
+create index if not exists user_connections_user_id_idx
+  on public.user_connections(user_id);
+
+create or replace function public.set_user_connections_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists set_user_connections_updated_at_trigger on public.user_connections;
+create trigger set_user_connections_updated_at_trigger
+before update on public.user_connections
+for each row execute function public.set_user_connections_updated_at();
+
+alter table public.user_connections enable row level security;
+
+drop policy if exists "Users can view own connections" on public.user_connections;
+create policy "Users can view own connections"
+on public.user_connections
+for select
+using (auth.uid() = user_id);
+
+drop policy if exists "Users can manage own connections" on public.user_connections;
+create policy "Users can manage own connections"
+on public.user_connections
+for all
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);


### PR DESCRIPTION
### Motivation

- Provide a way for users to link external accounts and social profiles (Steam, GitHub, X, Twitch, YouTube, Reddit, Website) and surface them in the profile settings UI.  
- Persist connections in a dedicated `user_connections` table with proper constraints and RLS so each user can manage their own links.  

### Description

- Add a new Supabase migration `00033_user_connections.sql` that creates `public.user_connections` with indexes, uniqueness constraints, an `updated_at` trigger, and row-level security policies for per-user access.  
- Extend database typings in `apps/web/types/database.ts` to include the `user_connections` table shape for `Row`, `Insert`, and `Update`.  
- Implement server API handlers at `apps/web/app/api/users/connections/route.ts` providing `GET`, `POST`, and `DELETE` to list, upsert (manual providers), and remove connections with provider normalization and validation.  
- Add Steam OpenID sign-in flow with a start route (`steam/start/route.ts`) that seeds a state cookie and redirects to Steam, and a callback route (`steam/callback/route.ts`) that verifies the OpenID assertion, extracts the Steam ID, and upserts the connection.  
- Update the profile settings UI in `profile-settings-modal.tsx` to add a new `Connections` tab and `ConnectionsSection` component allowing users to connect Steam, add manual social links, list existing connections, open profile URLs, and remove connections.  

### Testing

- Ran a TypeScript type check (`tsc`) against the workspace and it completed successfully.  
- Performed a Next.js production build (`next build`) to validate compile-time integration of new routes and UI changes and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8804ab0308325bb43050dce64332a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added account connections management in profile settings
  * Users can now link social accounts (Steam, GitHub, X, Twitch, YouTube, Reddit, website)
  * Added secure Steam OpenID authentication flow for account linking
  * Users can view, add, and remove connected accounts with toast notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->