### PR TITLE
Add stage channel YouTube stream URL (DB, API, UI, embed)

### DIFF
--- a/apps/web/app/api/channels/[channelId]/route.ts
+++ b/apps/web/app/api/channels/[channelId]/route.ts
@@ -16,7 +16,7 @@ export async function PATCH(
   // Fetch channel to get server_id
   const { data: channel, error: channelError } = await supabase
     .from("channels")
-    .select("id, server_id, type, name, topic, nsfw, slowmode_delay, forum_guidelines")
+    .select("id, server_id, type, name, topic, nsfw, slowmode_delay, forum_guidelines, stream_url")
     .eq("id", channelId)
     .single()
 
@@ -113,6 +113,30 @@ export async function PATCH(
       return NextResponse.json({ error: "Guidelines must be 2000 characters or fewer" }, { status: 400 })
     }
     update.forum_guidelines = guidelines || null
+  }
+
+  if (typeof body.stream_url === "string" || body.stream_url === null) {
+    if (channel.type !== "stage") {
+      return NextResponse.json({ error: "Stream URL is only available for stage channels" }, { status: 400 })
+    }
+    const streamUrl = typeof body.stream_url === "string" ? body.stream_url.trim() : null
+    if (streamUrl && streamUrl.length > 2048) {
+      return NextResponse.json({ error: "Stream URL must be 2048 characters or fewer" }, { status: 400 })
+    }
+    if (streamUrl) {
+      let parsed: URL
+      try {
+        parsed = new URL(streamUrl)
+      } catch {
+        return NextResponse.json({ error: "Stream URL must be a valid URL" }, { status: 400 })
+      }
+      const host = parsed.hostname.replace(/^www\./, "")
+      const isYouTubeHost = host === "youtube.com" || host === "m.youtube.com" || host === "youtu.be"
+      if (!isYouTubeHost) {
+        return NextResponse.json({ error: "Only YouTube URLs are currently supported" }, { status: 400 })
+      }
+    }
+    update.stream_url = streamUrl || null
   }
 
   if (Object.keys(update).length === 0) {

--- a/apps/web/app/api/servers/[serverId]/channels/[channelId]/route.ts
+++ b/apps/web/app/api/servers/[serverId]/channels/[channelId]/route.ts
@@ -9,7 +9,7 @@ const MAX_SLOWMODE_SECONDS = 21600
 /**
  * PATCH /api/servers/[serverId]/channels/[channelId]
  *
- * Editable fields: name, topic, nsfw, slowmode_delay
+ * Editable fields: name, topic, nsfw, slowmode_delay, stream_url (stage-only)
  * Requires MANAGE_CHANNELS permission.
  */
 export async function PATCH(req: NextRequest, { params }: Params) {
@@ -27,7 +27,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
   // Verify the channel belongs to this server
   const { data: channel } = await supabase
     .from("channels")
-    .select("id, server_id, name, topic, nsfw, slowmode_delay")
+    .select("id, server_id, type, name, topic, nsfw, slowmode_delay, stream_url")
     .eq("id", channelId)
     .eq("server_id", serverId)
     .single()
@@ -84,6 +84,35 @@ export async function PATCH(req: NextRequest, { params }: Params) {
     }
     updates.slowmode_delay = slowmode
     changes.slowmode_delay = { old: channel.slowmode_delay, new: slowmode }
+  }
+
+  if ("stream_url" in body) {
+    if (channel.type !== "stage") {
+      return NextResponse.json({ error: "stream_url can only be edited for stage channels" }, { status: 400 })
+    }
+    const raw = body.stream_url
+    if (raw !== null && typeof raw !== "string") {
+      return NextResponse.json({ error: "stream_url must be a string or null" }, { status: 400 })
+    }
+    const sanitized = typeof raw === "string" ? raw.trim() : null
+    if (sanitized && sanitized.length > 2048) {
+      return NextResponse.json({ error: "stream_url must be 2048 characters or fewer" }, { status: 400 })
+    }
+    if (sanitized) {
+      let parsed: URL
+      try {
+        parsed = new URL(sanitized)
+      } catch {
+        return NextResponse.json({ error: "stream_url must be a valid URL" }, { status: 400 })
+      }
+      const host = parsed.hostname.replace(/^www\./, "")
+      const isYouTubeHost = host === "youtube.com" || host === "m.youtube.com" || host === "youtu.be"
+      if (!isYouTubeHost) {
+        return NextResponse.json({ error: "Only YouTube URLs are currently supported" }, { status: 400 })
+      }
+    }
+    updates.stream_url = sanitized
+    changes.stream_url = { old: channel.stream_url, new: sanitized }
   }
 
   if (Object.keys(updates).length === 0)

--- a/apps/web/app/channels/[serverId]/[channelId]/page.tsx
+++ b/apps/web/app/channels/[serverId]/[channelId]/page.tsx
@@ -89,6 +89,8 @@ export default async function ChannelPage({ params: paramsPromise }: Props) {
           channelName={channel.name}
           serverId={params.serverId}
           currentUserId={user.id}
+          isStage={channel.type === "stage"}
+          stageStreamUrl={channel.stream_url}
         />
       </div>
     )

--- a/apps/web/components/modals/edit-channel-modal.tsx
+++ b/apps/web/components/modals/edit-channel-modal.tsx
@@ -30,6 +30,7 @@ export function EditChannelModal({ open, onClose, channel }: Props) {
   const [nsfw, setNsfw] = useState(channel.nsfw)
   const [slowmodeDelay, setSlowmodeDelay] = useState(channel.slowmode_delay)
   const [forumGuidelines, setForumGuidelines] = useState(channel.forum_guidelines ?? "")
+  const [streamUrl, setStreamUrl] = useState(channel.stream_url ?? "")
 
   // Reset form when channel changes or modal opens
   useEffect(() => {
@@ -39,6 +40,7 @@ export function EditChannelModal({ open, onClose, channel }: Props) {
     setNsfw(channel.nsfw)
     setSlowmodeDelay(channel.slowmode_delay)
     setForumGuidelines(channel.forum_guidelines ?? "")
+    setStreamUrl(channel.stream_url ?? "")
   }, [channel, open])
 
   async function handleSave() {
@@ -54,6 +56,10 @@ export function EditChannelModal({ open, onClose, channel }: Props) {
 
       if (channel.type === "forum") {
         body.forum_guidelines = forumGuidelines.trim() || null
+      }
+
+      if (channel.type === "stage") {
+        body.stream_url = streamUrl.trim() || null
       }
 
       const res = await fetch(`/api/channels/${channel.id}`, {
@@ -146,6 +152,24 @@ export function EditChannelModal({ open, onClose, channel }: Props) {
               />
               <p className="text-xs mt-1" style={{ color: forumGuidelines.length > 1900 ? "var(--theme-warning)" : "var(--theme-text-faint)" }}>
                 {forumGuidelines.length}/2000
+              </p>
+            </div>
+          )}
+
+          {channel.type === "stage" && (
+            <div>
+              <Label className="text-xs font-semibold uppercase tracking-wide" style={{ color: "var(--theme-text-secondary)" }}>
+                YouTube Stream URL
+              </Label>
+              <Input
+                value={streamUrl}
+                onChange={(e) => setStreamUrl(e.target.value)}
+                placeholder="https://www.youtube.com/watch?v=..."
+                className="mt-1"
+                style={{ background: "var(--theme-bg-tertiary)", color: "var(--theme-text-primary)", border: "none" }}
+              />
+              <p className="text-xs mt-1" style={{ color: "var(--theme-text-faint)" }}>
+                Members will see this embedded player in the Stage channel.
               </p>
             </div>
           )}

--- a/apps/web/components/voice/voice-channel.tsx
+++ b/apps/web/components/voice/voice-channel.tsx
@@ -78,6 +78,33 @@ interface Props {
   channelName: string
   serverId: string
   currentUserId: string
+  isStage?: boolean
+  stageStreamUrl?: string | null
+}
+
+function toYoutubeEmbedUrl(rawUrl: string | null | undefined): string | null {
+  if (!rawUrl) return null
+  const trimmed = rawUrl.trim()
+  if (!trimmed) return null
+
+  try {
+    const parsed = new URL(trimmed)
+    const host = parsed.hostname.replace(/^www\./, "")
+    if (host === "youtube.com" || host === "m.youtube.com") {
+      const videoId = parsed.searchParams.get("v")
+      if (!videoId) return null
+      return `https://www.youtube.com/embed/${videoId}?autoplay=0&controls=1&rel=0`
+    }
+    if (host === "youtu.be") {
+      const videoId = parsed.pathname.split("/").filter(Boolean)[0]
+      if (!videoId) return null
+      return `https://www.youtube.com/embed/${videoId}?autoplay=0&controls=1&rel=0`
+    }
+  } catch {
+    return null
+  }
+
+  return null
 }
 
 const MAX_REMOTE_GAIN = 2
@@ -95,7 +122,7 @@ function markCustomSettings(settings: VoiceAudioSettings, partial: Partial<Voice
 }
 
 /** Main voice channel view with participant grid, spotlight mode, and media controls. */
-export function VoiceChannel({ channelId, channelName, serverId, currentUserId }: Props) {
+export function VoiceChannel({ channelId, channelName, serverId, currentUserId, isStage = false, stageStreamUrl = null }: Props) {
   const { currentUser, setVoiceChannel, channels } = useAppStore(
     useShallow((s) => ({ currentUser: s.currentUser, setVoiceChannel: s.setVoiceChannel, channels: s.channels }))
   )
@@ -277,6 +304,7 @@ export function VoiceChannel({ channelId, channelName, serverId, currentUserId }
   }, [spotlightUserId, currentUserId, screenSharing, participantsByUserId, peers])
   const sessionState = getVoiceSessionState(peerArray.length, speaking && !muted, Boolean(audioInitError))
   const activeTone = TONE_STYLES[sessionState.tone]
+  const stageEmbedUrl = useMemo(() => toYoutubeEmbedUrl(stageStreamUrl), [stageStreamUrl])
 
   const isLocalSpotlight = spotlightUserId === currentUserId
   const spotlightPeer = spotlightUserId && !isLocalSpotlight
@@ -334,6 +362,30 @@ export function VoiceChannel({ channelId, channelName, serverId, currentUserId }
             {audioInitError && <span className="text-xs" style={{ color: "var(--theme-warning)" }}>{audioInitError}</span>}
           </div>
         </div>
+
+        {isStage && (
+          <div className="px-4 py-3 border-b" style={{ borderColor: "var(--theme-bg-tertiary)", background: "var(--theme-bg-secondary)" }}>
+            <p className="text-xs font-semibold uppercase tracking-wide" style={{ color: "var(--theme-text-secondary)" }}>
+              Stage Stream
+            </p>
+            {stageEmbedUrl ? (
+              <div className="mt-2 rounded-md overflow-hidden border" style={{ borderColor: "var(--theme-bg-tertiary)" }}>
+                <iframe
+                  title="Stage YouTube stream"
+                  src={stageEmbedUrl}
+                  className="w-full"
+                  style={{ height: 220 }}
+                  allow="autoplay; encrypted-media; picture-in-picture"
+                  allowFullScreen
+                />
+              </div>
+            ) : (
+              <p className="text-sm mt-1" style={{ color: "var(--theme-text-muted)" }}>
+                No YouTube stream is configured for this Stage channel yet.
+              </p>
+            )}
+          </div>
+        )}
 
         {inSpotlight ? (
           <div className="flex-1 flex flex-col overflow-hidden">

--- a/apps/web/types/database.ts
+++ b/apps/web/types/database.ts
@@ -407,6 +407,7 @@ export type Database = {
           slowmode_delay: number
           nsfw: boolean
           forum_guidelines: string | null
+          stream_url: string | null
           last_post_at: string | null
           expires_at: string | null
           created_at: string
@@ -422,6 +423,7 @@ export type Database = {
           slowmode_delay?: number
           nsfw?: boolean
           forum_guidelines?: string | null
+          stream_url?: string | null
           last_post_at?: string | null
           expires_at?: string | null
           created_at?: string
@@ -437,6 +439,7 @@ export type Database = {
           slowmode_delay?: number
           nsfw?: boolean
           forum_guidelines?: string | null
+          stream_url?: string | null
           last_post_at?: string | null
           expires_at?: string | null
           created_at?: string

--- a/supabase/migrations/00043_stage_stream_url.sql
+++ b/supabase/migrations/00043_stage_stream_url.sql
@@ -1,0 +1,8 @@
+-- Migration: stage channel stream URL
+-- Adds an optional YouTube stream URL for stage channels.
+
+ALTER TABLE public.channels
+  ADD COLUMN IF NOT EXISTS stream_url TEXT;
+
+COMMENT ON COLUMN public.channels.stream_url IS
+  'Optional external stream URL for stage channels (currently YouTube links).';


### PR DESCRIPTION
### Motivation

- Add an optional external stream URL to stage channels so servers can display embedded YouTube streams inside Stage views. 
- Surface this field in the channel edit UI so managers can configure a stream for stage channels. 
- Enforce server-side validation and permissions so only stage channels accept stream URLs and only YouTube links are supported.

### Description

- Adds a database migration `00043_stage_stream_url.sql` that creates an optional `stream_url` column on `public.channels` with a descriptive comment. 
- Extends the DB types in `types/database.ts` to include `stream_url` on `channels` for `Row`, `Insert`, and `Update`. 
- Updates server PATCH endpoints (`/api/channels/[channelId]` and `/api/servers/[serverId]/channels/[channelId]`) to accept, validate, and persist `stream_url`, with checks restricting the field to stage channels, limiting length to 2048, requiring a valid URL, and allowing only YouTube hosts; changes are included in audit logs. 
- Updates UI: `edit-channel-modal.tsx` adds a YouTube Stream URL input for stage channels and includes it in the PATCH payload; `page.tsx` passes `isStage` and `stageStreamUrl` into the `VoiceChannel` component; `voice-channel.tsx` adds a `toYoutubeEmbedUrl` helper and renders an embedded YouTube iframe when a valid URL is set.

### Testing

- Ran TypeScript type checking with `tsc --noEmit` and a Next.js build with `next build`, and both completed successfully. 
- Ran the existing automated unit/integration tests with `pnpm test` and they all passed. 
- No new automated tests were added for URL parsing or embedding in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7842ea03c8325b2a22778e2277539)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stage channels can now be configured with a YouTube stream URL
  * Added the ability to edit and set YouTube stream URLs for stage channels in the channel settings modal
  * Stage channels with a configured stream URL now display an embedded YouTube video player

* **Database**
  * Added stream_url field to channels table to store stage stream URLs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->