### PR TITLE
Use server-scoped PATCH endpoint for channel edits to fix Stage URL 404

### DIFF
--- a/apps/web/components/modals/edit-channel-modal.tsx
+++ b/apps/web/components/modals/edit-channel-modal.tsx
@@ -62,7 +62,7 @@ export function EditChannelModal({ open, onClose, channel }: Props) {
         body.stream_url = streamUrl.trim() || null
       }
 
-      const res = await fetch(`/api/channels/${channel.id}`, {
+      const res = await fetch(`/api/servers/${channel.server_id}/channels/${channel.id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),


### PR DESCRIPTION
### Motivation
- Saving changes to Stage channels (stream URL) returned 404 because the client called the non-scoped endpoint `/api/channels/:channelId` while the server enforces server membership/permissions via the server-scoped route `/api/servers/:serverId/channels/:channelId`.

### Description
- Updated the edit channel modal to send the PATCH request to `/api/servers/${channel.server_id}/channels/${channel.id}` instead of `/api/channels/${channel.id}` in `apps/web/components/modals/edit-channel-modal.tsx`.

### Testing
- Ran `cd apps/web && npm run type-check` which completed successfully with no type errors.
- Ran ESLint against the modified file via `npx eslint components/modals/edit-channel-modal.tsx` which reported only a file-level configuration warning and no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8abb5d2fc8325af18061ba48e8f48)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the internal API endpoint structure for channel modifications to align with server-based organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->