### PR TITLE
Add dedicated YouTube connection flow and show connected accounts in profile settings

### DIFF
--- a/apps/web/components/modals/profile-settings-modal.tsx
+++ b/apps/web/components/modals/profile-settings-modal.tsx
@@ -600,9 +600,8 @@ function ConnectionsSection() {
   const { toast } = useToast()
   const [connections, setConnections] = useState<ConnectionRow[]>([])
   const [loading, setLoading] = useState(false)
-  const [provider, setProvider] = useState("github")
-  const [username, setUsername] = useState("")
-  const [profileUrl, setProfileUrl] = useState("")
+  const [youtubeUsername, setYoutubeUsername] = useState("")
+  const [youtubeProfileUrl, setYoutubeProfileUrl] = useState("")
 
   const loadConnections = useCallback(async () => {
     const res = await fetch("/api/users/connections", { cache: "no-store" })
@@ -619,26 +618,23 @@ function ConnectionsSection() {
     window.location.href = `/api/users/connections/steam/start?next=${encodeURIComponent(next)}`
   }
 
-  async function addManualConnection(e: React.FormEvent) {
+  async function connectYouTube(e: React.FormEvent) {
     e.preventDefault()
     setLoading(true)
     const res = await fetch("/api/users/connections", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ provider, username, profile_url: profileUrl }),
+      body: JSON.stringify({ provider: "youtube", username: youtubeUsername, profile_url: youtubeProfileUrl }),
     })
     const payload = await res.json().catch(() => ({}))
     if (!res.ok) {
-      toast({ variant: "destructive", title: "Failed to add connection", description: payload.error || "Please try again" })
+      toast({ variant: "destructive", title: "Failed to connect YouTube", description: payload.error || "Please try again" })
       setLoading(false)
       return
     }
-    setUsername("")
-    setProfileUrl("")
-    setConnections((prev) => {
-      const others = prev.filter((item) => item.provider !== payload.connection.provider)
-      return [...others, payload.connection]
-    })
+    setYoutubeUsername("")
+    setYoutubeProfileUrl("")
+    setConnections((prev) => [...prev.filter((item) => item.provider !== "youtube"), payload.connection])
     setLoading(false)
   }
 
@@ -651,35 +647,36 @@ function ConnectionsSection() {
     setConnections((prev) => prev.filter((item) => item.id !== id))
   }
 
+  const steamConnection = connections.find((item) => item.provider === "steam")
+  const youtubeConnection = connections.find((item) => item.provider === "youtube")
+
   return (
     <div className="space-y-6">
       <div className="rounded-lg p-4 space-y-3" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
         <h3 className="text-base font-semibold text-white">Steam</h3>
         <p className="text-sm" style={{ color: "var(--theme-text-muted)" }}>Link your Steam account using official OpenID sign-in. We only store your Steam ID and profile URL.</p>
+        {steamConnection && (
+          <p className="text-xs" style={{ color: "var(--theme-text-secondary)" }}>
+            Connected as {steamConnection.display_name || steamConnection.username || steamConnection.provider_user_id}
+          </p>
+        )}
         <Button type="button" onClick={connectSteam} style={{ background: "var(--theme-accent)" }}>
-          <Link2 className="w-4 h-4 mr-2" /> Connect Steam
+          <Link2 className="w-4 h-4 mr-2" /> {steamConnection ? "Reconnect Steam" : "Connect Steam"}
         </Button>
       </div>
 
       <div className="rounded-lg p-4 space-y-3" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
-        <h3 className="text-base font-semibold text-white">Social Links</h3>
-        <form onSubmit={addManualConnection} className="grid grid-cols-1 md:grid-cols-[160px_1fr_1fr_auto] gap-2">
-          <select
-            value={provider}
-            onChange={(e) => setProvider(e.target.value)}
-            className="rounded px-2 py-2 text-sm"
-            style={{ background: "var(--theme-bg-tertiary)", border: "1px solid var(--theme-bg-tertiary)", color: "var(--theme-text-primary)" }}
-          >
-            <option value="github">GitHub</option>
-            <option value="x">X / Twitter</option>
-            <option value="twitch">Twitch</option>
-            <option value="youtube">YouTube</option>
-            <option value="reddit">Reddit</option>
-            <option value="website">Website</option>
-          </select>
-          <Input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="username" />
-          <Input value={profileUrl} onChange={(e) => setProfileUrl(e.target.value)} placeholder="https://..." required />
-          <Button type="submit" disabled={loading}>{loading ? "Adding..." : "Add"}</Button>
+        <h3 className="text-base font-semibold text-white">YouTube</h3>
+        <p className="text-sm" style={{ color: "var(--theme-text-muted)" }}>Connect your YouTube channel so your creator identity appears next to Steam.</p>
+        {youtubeConnection && (
+          <p className="text-xs" style={{ color: "var(--theme-text-secondary)" }}>
+            Connected as {youtubeConnection.display_name || youtubeConnection.username || youtubeConnection.provider_user_id}
+          </p>
+        )}
+        <form onSubmit={connectYouTube} className="grid grid-cols-1 md:grid-cols-[1fr_1fr_auto] gap-2">
+          <Input value={youtubeUsername} onChange={(e) => setYoutubeUsername(e.target.value)} placeholder="YouTube username (optional)" />
+          <Input value={youtubeProfileUrl} onChange={(e) => setYoutubeProfileUrl(e.target.value)} placeholder="https://youtube.com/@yourchannel" required />
+          <Button type="submit" disabled={loading}>{loading ? "Connecting..." : "Connect YouTube"}</Button>
         </form>
       </div>
 

--- a/apps/web/components/settings/profile-settings-page.tsx
+++ b/apps/web/components/settings/profile-settings-page.tsx
@@ -45,7 +45,6 @@ export function ProfileSettingsPage({ user }: Props) {
   const [saving, setSaving] = useState(false)
   const [connections, setConnections] = useState<Array<{ id: string; provider: string; provider_user_id: string; username: string | null; display_name: string | null; profile_url: string | null }>>([])
   const [connectionLoading, setConnectionLoading] = useState(false)
-  const [provider, setProvider] = useState("github")
   const [connectionUsername, setConnectionUsername] = useState("")
   const [connectionProfileUrl, setConnectionProfileUrl] = useState("")
 
@@ -136,26 +135,23 @@ export function ProfileSettingsPage({ user }: Props) {
     window.location.href = `/api/users/connections/steam/start?next=${encodeURIComponent(next)}`
   }
 
-  async function addManualConnection(e: React.FormEvent) {
+  async function connectYouTube(e: React.FormEvent) {
     e.preventDefault()
     setConnectionLoading(true)
     const res = await fetch("/api/users/connections", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ provider, username: connectionUsername, profile_url: connectionProfileUrl }),
+      body: JSON.stringify({ provider: "youtube", username: connectionUsername, profile_url: connectionProfileUrl }),
     })
     const payload = await res.json().catch(() => ({}))
     if (!res.ok) {
-      toast({ variant: "destructive", title: "Failed to add connection", description: payload.error || "Please try again" })
+      toast({ variant: "destructive", title: "Failed to connect YouTube", description: payload.error || "Please try again" })
       setConnectionLoading(false)
       return
     }
     setConnectionUsername("")
     setConnectionProfileUrl("")
-    setConnections((prev) => {
-      const others = prev.filter((item) => item.provider !== payload.connection.provider)
-      return [...others, payload.connection]
-    })
+    setConnections((prev) => [...prev.filter((item) => item.provider !== "youtube"), payload.connection])
     setConnectionLoading(false)
   }
 
@@ -168,6 +164,8 @@ export function ProfileSettingsPage({ user }: Props) {
     setConnections((prev) => prev.filter((item) => item.id !== id))
   }
 
+  const steamConnection = connections.find((item) => item.provider === "steam")
+  const youtubeConnection = connections.find((item) => item.provider === "youtube")
   const initials = (user.display_name || user.username || "?").slice(0, 2).toUpperCase()
 
   return (
@@ -391,25 +389,20 @@ export function ProfileSettingsPage({ user }: Props) {
         <div className="rounded-lg p-4 space-y-3" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
           <h3 className="text-sm font-semibold" style={{ color: "var(--theme-text-primary)" }}>Steam</h3>
           <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>Link your Steam account with OpenID sign-in.</p>
+          {steamConnection && <p className="text-xs" style={{ color: "var(--theme-text-secondary)" }}>Connected as {steamConnection.display_name || steamConnection.username || steamConnection.provider_user_id}</p>}
           <button type="button" onClick={connectSteam} className="inline-flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium" style={{ background: "var(--theme-accent)", color: "white" }}>
-            <Link2 className="w-4 h-4" /> Connect Steam
+            <Link2 className="w-4 h-4" /> {steamConnection ? "Reconnect Steam" : "Connect Steam"}
           </button>
         </div>
 
         <div className="rounded-lg p-4 space-y-3" style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}>
-          <h3 className="text-sm font-semibold" style={{ color: "var(--theme-text-primary)" }}>Social Links</h3>
-          <form onSubmit={addManualConnection} className="grid grid-cols-1 md:grid-cols-[140px_1fr_1fr_auto] gap-2">
-            <select value={provider} onChange={(e) => setProvider(e.target.value)} className="rounded-md px-3 py-2 text-sm" style={{ background: "var(--theme-surface-input)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-bg-tertiary)" }}>
-              <option value="github">GitHub</option>
-              <option value="x">X / Twitter</option>
-              <option value="twitch">Twitch</option>
-              <option value="youtube">YouTube</option>
-              <option value="reddit">Reddit</option>
-              <option value="website">Website</option>
-            </select>
-            <input value={connectionUsername} onChange={(e) => setConnectionUsername(e.target.value)} placeholder="username" className="rounded-md px-3 py-2 text-sm" style={{ background: "var(--theme-surface-input)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-bg-tertiary)" }} />
-            <input value={connectionProfileUrl} onChange={(e) => setConnectionProfileUrl(e.target.value)} placeholder="https://..." required className="rounded-md px-3 py-2 text-sm" style={{ background: "var(--theme-surface-input)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-bg-tertiary)" }} />
-            <button type="submit" disabled={connectionLoading} className="px-4 py-2 rounded-md text-sm font-medium disabled:opacity-60" style={{ background: "var(--theme-accent)", color: "white" }}>{connectionLoading ? "Adding..." : "Add"}</button>
+          <h3 className="text-sm font-semibold" style={{ color: "var(--theme-text-primary)" }}>YouTube</h3>
+          <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>Connect your YouTube channel so your creator identity appears next to Steam.</p>
+          {youtubeConnection && <p className="text-xs" style={{ color: "var(--theme-text-secondary)" }}>Connected as {youtubeConnection.display_name || youtubeConnection.username || youtubeConnection.provider_user_id}</p>}
+          <form onSubmit={connectYouTube} className="grid grid-cols-1 md:grid-cols-[1fr_1fr_auto] gap-2">
+            <input value={connectionUsername} onChange={(e) => setConnectionUsername(e.target.value)} placeholder="YouTube username (optional)" className="rounded-md px-3 py-2 text-sm" style={{ background: "var(--theme-surface-input)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-bg-tertiary)" }} />
+            <input value={connectionProfileUrl} onChange={(e) => setConnectionProfileUrl(e.target.value)} placeholder="https://youtube.com/@yourchannel" required className="rounded-md px-3 py-2 text-sm" style={{ background: "var(--theme-surface-input)", color: "var(--theme-text-primary)", border: "1px solid var(--theme-bg-tertiary)" }} />
+            <button type="submit" disabled={connectionLoading} className="px-4 py-2 rounded-md text-sm font-medium disabled:opacity-60" style={{ background: "var(--theme-accent)", color: "white" }}>{connectionLoading ? "Connecting..." : "Connect YouTube"}</button>
           </form>
         </div>
 


### PR DESCRIPTION
### Motivation
- Replace the generic social-provider dropdown with a first-class YouTube connection so creator identity can be shown alongside Steam.
- Surface connected account info and make CTAs clearer (`Connect` vs `Reconnect`) for Steam and YouTube.

### Description
- Introduced a dedicated YouTube connection card and form in the profile settings modal by adding `youtubeUsername` / `youtubeProfileUrl` state and `connectYouTube` handler in `apps/web/components/modals/profile-settings-modal.tsx`.
- Applied the same UX to the full page profile settings in `apps/web/components/settings/profile-settings-page.tsx`, replacing the generic provider dropdown with a YouTube card and form.
- Show connected account labels ("Connected as …") for Steam and YouTube and toggle CTA text between `Connect Steam` and `Reconnect Steam` when a Steam connection exists.
- Update connection list merging logic to replace only the `youtube` row when adding/updating YouTube.

### Testing
- Ran type checking with `npm --prefix apps/web run type-check`, which succeeded.
- Attempted to start the dev server with `npm --prefix apps/web run dev`, but startup was blocked by missing Supabase environment variables in this environment (dev server did not complete).
- Attempted a Playwright screenshot run against the local dev server, which failed because the app could not serve pages due to the missing environment configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98c5920f883259fda6e51d3693351)