### PR TITLE
Fix Supabase linter error on public.app_catalog_public by setting security_invoker

### DIFF
--- a/supabase/migrations/00044_app_catalog_public_security_invoker.sql
+++ b/supabase/migrations/00044_app_catalog_public_security_invoker.sql
@@ -1,0 +1,3 @@
+-- Ensure public catalog view uses querying user's permissions/RLS context.
+ALTER VIEW public.app_catalog_public
+SET (security_invoker = true);


### PR DESCRIPTION
### Motivation
- Supabase's database linter flagged the `public.app_catalog_public` view as a `security_definer_view`, so the view should run with the caller's privileges/RLS context instead of the view owner's.

### Description
- Add migration `supabase/migrations/00044_app_catalog_public_security_invoker.sql` that runs `ALTER VIEW public.app_catalog_public SET (security_invoker = true);` to switch the view to invoker security.

### Testing
- No automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a99bab96e883259dbd5978053ff33f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app catalog security to ensure proper user permission enforcement across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->