### PR TITLE
Handle missing user_connections table errors in connections APIs

### DIFF
--- a/apps/web/app/api/users/connections/route.ts
+++ b/apps/web/app/api/users/connections/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { isUserConnectionsTableMissing, USER_CONNECTIONS_SETUP_HINT } from "@/lib/supabase/user-connections-errors"
 
 const MANUAL_PROVIDERS = ["github", "x", "twitch", "youtube", "reddit", "website"] as const
 type ManualProvider = (typeof MANUAL_PROVIDERS)[number]
@@ -20,7 +21,12 @@ export async function GET() {
     .eq("user_id", user.id)
     .order("created_at", { ascending: true })
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  if (error) {
+    if (isUserConnectionsTableMissing(error)) {
+      return NextResponse.json({ error: USER_CONNECTIONS_SETUP_HINT }, { status: 503 })
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
   return NextResponse.json({ connections: data ?? [] })
 }
 
@@ -63,7 +69,12 @@ export async function POST(request: Request) {
     .select("id, provider, provider_user_id, username, display_name, profile_url, metadata, created_at")
     .single()
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  if (error) {
+    if (isUserConnectionsTableMissing(error)) {
+      return NextResponse.json({ error: USER_CONNECTIONS_SETUP_HINT }, { status: 503 })
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
   return NextResponse.json({ connection: data })
 }
 
@@ -82,6 +93,11 @@ export async function DELETE(request: Request) {
     .eq("id", id)
     .eq("user_id", user.id)
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  if (error) {
+    if (isUserConnectionsTableMissing(error)) {
+      return NextResponse.json({ error: USER_CONNECTIONS_SETUP_HINT }, { status: 503 })
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/app/api/users/connections/steam/callback/route.ts
+++ b/apps/web/app/api/users/connections/steam/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { cookies } from "next/headers"
 import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { isUserConnectionsTableMissing } from "@/lib/supabase/user-connections-errors"
 
 async function verifySteamAssertion(searchParams: URLSearchParams) {
   const verificationParams = new URLSearchParams(searchParams)
@@ -71,7 +72,8 @@ export async function GET(request: Request) {
       metadata: { linked_via: "openid" },
     }, { onConflict: "user_id,provider" })
 
-  const response = NextResponse.redirect(buildRedirect(url, nextPath, error ? "steam_save_failed" : "steam_linked"))
+  const status = !error ? "steam_linked" : isUserConnectionsTableMissing(error) ? "connections_storage_unavailable" : "steam_save_failed"
+  const response = NextResponse.redirect(buildRedirect(url, nextPath, status))
   response.cookies.delete("steam_oauth_state")
   return response
 }

--- a/apps/web/lib/supabase/user-connections-errors.ts
+++ b/apps/web/lib/supabase/user-connections-errors.ts
@@ -1,0 +1,21 @@
+const USER_CONNECTIONS_MISSING_MESSAGES = [
+  "Could not find the table 'public.user_connections' in the schema cache",
+  'relation "public.user_connections" does not exist',
+  'relation "user_connections" does not exist',
+] as const
+
+type SupabaseErrorLike = {
+  code?: string
+  message?: string
+}
+
+export function isUserConnectionsTableMissing(error: SupabaseErrorLike | null | undefined) {
+  if (!error) return false
+  if (error.code === "PGRST205" || error.code === "42P01") return true
+  const message = error.message ?? ""
+  return USER_CONNECTIONS_MISSING_MESSAGES.some((snippet) => message.includes(snippet))
+}
+
+export const USER_CONNECTIONS_SETUP_HINT =
+  "Connections are not configured on this environment yet. Run Supabase migrations (`npx supabase db push`) and reload the Supabase API schema cache."
+


### PR DESCRIPTION
### Motivation
- Make failures transparent and actionable when the `public.user_connections` table is missing from the Supabase schema cache instead of surfacing opaque DB errors. 

### Description
- Add a shared Supabase error helper at `apps/web/lib/supabase/user-connections-errors.ts` with `isUserConnectionsTableMissing()` and a user-facing `USER_CONNECTIONS_SETUP_HINT`. 
- Update `/api/users/connections` handlers (`GET`, `POST`, `DELETE` in `apps/web/app/api/users/connections/route.ts`) to detect the missing-table condition and return a `503` with the setup hint instead of a generic `500`. 
- Update the Steam OAuth callback (`apps/web/app/api/users/connections/steam/callback/route.ts`) to map the same storage error to a dedicated redirect status `connections_storage_unavailable` so the UI can surface the condition explicitly. 

### Testing
- Ran TypeScript check with `npm run -w @vortex/web type-check`, which succeeded. 
- Ran lint with `npm run -w @vortex/web lint`, which failed due to existing style-guardrail violations in `apps/web/components/settings/profile-settings-page.tsx` unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b1c4e224832583b7a32374ba3892)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error messaging for connection management. When database configuration issues occur, users now receive helpful setup instructions instead of generic error messages. This applies to all connection endpoints and authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->