### PR TITLE
Make member_roles composite FK migration idempotent

### DIFF
--- a/supabase/migrations/00039_member_roles_composite_fk.sql
+++ b/supabase/migrations/00039_member_roles_composite_fk.sql
@@ -3,11 +3,21 @@
 --   server_members → member_roles → roles
 -- Previously relied on implicit column-name matching which broke on schema cache reload.
 
-ALTER TABLE public.member_roles
-  ADD CONSTRAINT fk_member_roles_server_member
-  FOREIGN KEY (server_id, user_id)
-  REFERENCES public.server_members(server_id, user_id)
-  ON DELETE CASCADE;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'fk_member_roles_server_member'
+      AND conrelid = 'public.member_roles'::regclass
+  ) THEN
+    ALTER TABLE public.member_roles
+      ADD CONSTRAINT fk_member_roles_server_member
+      FOREIGN KEY (server_id, user_id)
+      REFERENCES public.server_members(server_id, user_id)
+      ON DELETE CASCADE;
+  END IF;
+END $$;
 
 -- Rollback:
 -- ALTER TABLE public.member_roles DROP CONSTRAINT IF EXISTS fk_member_roles_server_member;


### PR DESCRIPTION
### Motivation
- Prevent Supabase/Postgres from failing with `ERROR: 42710` when the composite foreign key `fk_member_roles_server_member` already exists by making the migration safe to re-run.

### Description
- Guarded the `ALTER TABLE public.member_roles ADD CONSTRAINT fk_member_roles_server_member ...` with a `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_member_roles_server_member' AND conrelid = 'public.member_roles'::regclass) THEN ... END IF; END $$;` block in `supabase/migrations/00039_member_roles_composite_fk.sql` so the constraint is only added when missing.
- Left the rollback note intact (`ALTER TABLE public.member_roles DROP CONSTRAINT IF EXISTS fk_member_roles_server_member;`) so behavior is unchanged aside from idempotency.

### Testing
- Inspected repository migration list with `rg` to locate `00039_member_roles_composite_fk.sql` and confirm the target migration was edited, and these checks succeeded.
- Verified the updated SQL via `sed -n` and `nl -ba` to confirm the `DO $$ ... IF NOT EXISTS ... END $$;` guard and the `FOREIGN KEY (server_id, user_id) REFERENCES public.server_members(server_id, user_id) ON DELETE CASCADE` clause are present, and these inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b3c100d883259ea45fa13c574308)