### PR TITLE
Make migration 00041 idempotent when recovery-code delete policy already exists

### DIFF
--- a/supabase/migrations/00041_hardening_policy_fixes.sql
+++ b/supabase/migrations/00041_hardening_policy_fixes.sql
@@ -6,6 +6,7 @@
 -- ============================================================
 
 DROP POLICY IF EXISTS "Users can manage own recovery codes" ON public.recovery_codes;
+DROP POLICY IF EXISTS "Users can delete own recovery codes" ON public.recovery_codes;
 
 -- Separate SELECT already exists; add targeted DELETE (insert via service role)
 CREATE POLICY "Users can delete own recovery codes"


### PR DESCRIPTION
### Motivation
- Prevent the `ERROR: 42710: policy "Users can delete own recovery codes" ... already exists` failure when running migration 00041 by making the policy creation idempotent.

### Description
- Add `DROP POLICY IF EXISTS "Users can delete own recovery codes" ON public.recovery_codes;` immediately before the `CREATE POLICY` in `supabase/migrations/00041_hardening_policy_fixes.sql` so the migration can be applied safely even if the policy already exists.

### Testing
- Inspected the SQL diff for `supabase/migrations/00041_hardening_policy_fixes.sql` to confirm the `DROP` statement is present before the `CREATE` and that the migration ordering is correct (verified).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b50eeedc83258322355f04ec3c3b)