### PR TITLE
Add pinned-messages realtime parity, channel-scoped permission checks, and lifecycle tests

### DIFF
--- a/apps/web/__tests__/message-pin-route.test.ts
+++ b/apps/web/__tests__/message-pin-route.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, beforeEach, vi } from "vitest"
+import type { NextRequest } from "next/server"
+import { DELETE, PUT } from "@/app/api/messages/[messageId]/pin/route"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { getChannelPermissions, hasPermission } from "@/lib/permissions"
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}))
+
+vi.mock("@/lib/permissions", () => ({
+  getChannelPermissions: vi.fn(),
+  hasPermission: vi.fn(),
+}))
+
+type SupabaseMock = ReturnType<typeof createSupabaseMock>
+
+function createSupabaseMock() {
+  const updateMock = vi.fn(() => ({ eq: vi.fn(async () => ({ error: null })) }))
+  const insertMock = vi.fn(async () => ({ error: null }))
+
+  const messageSingleMock = vi.fn(async () => ({
+    data: { id: "m1", channel_id: "c1", channels: { server_id: "s1" } },
+  }))
+
+  const messagesSelectChain = {
+    eq: vi.fn(() => messagesSelectChain),
+    is: vi.fn(() => messagesSelectChain),
+    single: messageSingleMock,
+  }
+
+  const messagesTable = {
+    select: vi.fn(() => messagesSelectChain),
+    update: updateMock,
+  }
+
+  const auditTable = {
+    insert: insertMock,
+  }
+
+  return {
+    auth: {
+      getUser: vi.fn(async () => ({ data: { user: { id: "u1" } } })),
+    },
+    from: vi.fn((table: string) => {
+      if (table === "messages") return messagesTable
+      if (table === "audit_logs") return auditTable
+      throw new Error(`Unexpected table: ${table}`)
+    }),
+    __mocks: {
+      updateMock,
+      insertMock,
+      messageSingleMock,
+      messagesTable,
+      messagesSelectChain,
+    },
+  }
+}
+
+describe("message pin route lifecycle", () => {
+  let supabase: SupabaseMock
+
+  beforeEach(() => {
+    supabase = createSupabaseMock()
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(supabase as never)
+    vi.mocked(getChannelPermissions).mockResolvedValue({ isAdmin: false, permissions: 0 } as never)
+    vi.mocked(hasPermission).mockReturnValue(true)
+  })
+
+  it("pins a message and writes an audit log when permission checks pass", async () => {
+    const response = await PUT({} as NextRequest, { params: Promise.resolve({ messageId: "m1" }) })
+
+    expect(response.status).toBe(200)
+    expect(vi.mocked(getChannelPermissions)).toHaveBeenCalledWith(supabase, "s1", "c1", "u1")
+    expect(supabase.__mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({ pinned: true, pinned_by: "u1" }))
+    expect(supabase.__mocks.insertMock).toHaveBeenCalledWith(expect.objectContaining({ action: "message_pin", target_id: "m1" }))
+  })
+
+  it("rejects pin attempts without MANAGE_MESSAGES", async () => {
+    vi.mocked(hasPermission).mockReturnValue(false)
+
+    const response = await PUT({} as NextRequest, { params: Promise.resolve({ messageId: "m1" }) })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: "Missing MANAGE_MESSAGES permission" })
+    expect(supabase.__mocks.updateMock).not.toHaveBeenCalled()
+  })
+
+  it("unpins a message through the same channel-scoped permission path", async () => {
+    const response = await DELETE({} as NextRequest, { params: Promise.resolve({ messageId: "m1" }) })
+
+    expect(response.status).toBe(200)
+    expect(vi.mocked(getChannelPermissions)).toHaveBeenCalledWith(supabase, "s1", "c1", "u1")
+    expect(supabase.__mocks.updateMock).toHaveBeenCalledWith({ pinned: false, pinned_at: null, pinned_by: null })
+  })
+})

--- a/apps/web/app/api/messages/[messageId]/pin/route.ts
+++ b/apps/web/app/api/messages/[messageId]/pin/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createServerSupabaseClient } from "@/lib/supabase/server"
-import { getMemberPermissions, hasPermission } from "@/lib/permissions"
+import { getChannelPermissions, hasPermission } from "@/lib/permissions"
 
 // PUT /api/messages/[messageId]/pin — pin a message
 export async function PUT(
@@ -30,7 +30,14 @@ export async function PUT(
   }
 
   // Check permission: admin or MANAGE_MESSAGES
-  const { isAdmin, permissions } = await getMemberPermissions(supabase, serverId, user.id)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const channelId: string | undefined = (message as any).channel_id
+
+  if (!channelId) {
+    return NextResponse.json({ error: "Channel context not found" }, { status: 404 })
+  }
+
+  const { isAdmin, permissions } = await getChannelPermissions(supabase, serverId, channelId, user.id)
   if (!isAdmin && !hasPermission(permissions, "MANAGE_MESSAGES")) {
     return NextResponse.json({ error: "Missing MANAGE_MESSAGES permission" }, { status: 403 })
   }
@@ -66,7 +73,7 @@ export async function DELETE(
 
   const { data: message } = await supabase
     .from("messages")
-    .select("id, channels(server_id)")
+    .select("id, channel_id, channels(server_id)")
     .eq("id", messageId)
     .single()
 
@@ -79,7 +86,14 @@ export async function DELETE(
     return NextResponse.json({ error: "Cannot unpin messages outside of a server channel" }, { status: 400 })
   }
 
-  const { isAdmin, permissions } = await getMemberPermissions(supabase, serverId, user.id)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const channelId: string | undefined = (message as any).channel_id
+
+  if (!channelId) {
+    return NextResponse.json({ error: "Channel context not found" }, { status: 404 })
+  }
+
+  const { isAdmin, permissions } = await getChannelPermissions(supabase, serverId, channelId, user.id)
   if (!isAdmin && !hasPermission(permissions, "MANAGE_MESSAGES")) {
     return NextResponse.json({ error: "Missing MANAGE_MESSAGES permission" }, { status: 403 })
   }

--- a/apps/web/components/chat/pinned-messages-panel.tsx
+++ b/apps/web/components/chat/pinned-messages-panel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { Pin, PinOff, X, Loader2, ExternalLink } from "lucide-react"
 import { createClientSupabaseClient } from "@/lib/supabase/client"
 import { format } from "date-fns"
@@ -30,10 +30,27 @@ export function PinnedMessagesPanel({ channelId, channelName, canManageMessages 
   const [messages, setMessages] = useState<PinnedMessage[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [permissionDenied, setPermissionDenied] = useState(false)
+
+  const upsertPinnedMessage = useCallback((incoming: PinnedMessage) => {
+    setMessages((prev) => {
+      const existingIndex = prev.findIndex((message) => message.id === incoming.id)
+      const next = existingIndex === -1
+        ? [...prev, incoming]
+        : prev.map((message, index) => (index === existingIndex ? incoming : message))
+
+      return next.sort((a, b) => {
+        const aTs = a.pinned_at ? Date.parse(a.pinned_at) : 0
+        const bTs = b.pinned_at ? Date.parse(b.pinned_at) : 0
+        return bTs - aTs
+      })
+    })
+  }, [])
 
   const loadPinnedMessages = useCallback(async () => {
     setLoading(true)
     setError(null)
+    setPermissionDenied(false)
     try {
       const { data, error: dbError } = await supabase
         .from("messages")
@@ -50,7 +67,15 @@ export function PinnedMessagesPanel({ channelId, channelName, canManageMessages 
         .order("pinned_at", { ascending: false })
         .limit(50)
 
-      if (dbError) throw dbError
+      if (dbError) {
+        const denied = dbError.code === "42501" || /permission denied/i.test(dbError.message ?? "")
+        if (denied) {
+          setPermissionDenied(true)
+          setMessages([])
+          return
+        }
+        throw dbError
+      }
       setMessages((data ?? []) as PinnedMessage[])
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to load pinned messages")
@@ -62,6 +87,49 @@ export function PinnedMessagesPanel({ channelId, channelName, canManageMessages 
   useEffect(() => {
     loadPinnedMessages()
   }, [loadPinnedMessages])
+
+  useEffect(() => {
+    const realtimeChannel = supabase
+      .channel(`pinned-messages:${channelId}`)
+      .on("postgres_changes", {
+        event: "UPDATE",
+        schema: "public",
+        table: "messages",
+        filter: `channel_id=eq.${channelId}`,
+      }, async (payload) => {
+        const next = payload.new as { id: string; pinned?: boolean; pinned_at?: string | null }
+        if (!next.id) return
+        if (!next.pinned) {
+          setMessages((prev) => prev.filter((message) => message.id !== next.id))
+          return
+        }
+        const { data } = await supabase
+          .from("messages")
+          .select(`
+            id,
+            content,
+            created_at,
+            pinned_at,
+            author:users!messages_author_id_fkey(username, display_name, avatar_url)
+          `)
+          .eq("id", next.id)
+          .single()
+
+        if (data) {
+          upsertPinnedMessage(data as PinnedMessage)
+        }
+      })
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(realtimeChannel)
+    }
+  }, [channelId, supabase, upsertPinnedMessage])
+
+  const showEmptyState = useMemo(
+    () => !loading && !error && !permissionDenied && messages.length === 0,
+    [error, loading, messages.length, permissionDenied]
+  )
 
   function truncateContent(content: string, maxLen = 160): string {
     const clean = content.replace(/\*\*|__|~~|\|\||`{1,3}/g, "")
@@ -120,7 +188,16 @@ export function PinnedMessagesPanel({ channelId, channelName, canManageMessages 
           </div>
         )}
 
-        {!loading && !error && messages.length === 0 && (
+        {permissionDenied && (
+          <div className="flex flex-col items-center justify-center py-12 px-4 gap-3">
+            <PinOff className="w-8 h-8" style={{ color: "var(--theme-text-faint)" }} />
+            <p className="text-sm text-center" style={{ color: "var(--theme-text-muted)" }}>
+              You don&rsquo;t have permission to view pinned messages in #{channelName}.
+            </p>
+          </div>
+        )}
+
+        {showEmptyState && (
           <div className="flex flex-col items-center justify-center py-12 px-4 gap-3">
             <Pin className="w-8 h-8" style={{ color: "var(--theme-text-faint)" }} />
             <p className="text-sm text-center" style={{ color: "var(--theme-text-muted)" }}>
@@ -132,7 +209,7 @@ export function PinnedMessagesPanel({ channelId, channelName, canManageMessages 
           </div>
         )}
 
-        {!loading && messages.length > 0 && (
+        {!loading && !permissionDenied && messages.length > 0 && (
           <div className="divide-y" style={{ borderColor: "var(--theme-bg-tertiary)" }}>
             {messages.map((message) => {
               const author = Array.isArray(message.author) ? message.author[0] : message.author


### PR DESCRIPTION
### Motivation
- Ensure pinned-message UI stays in sync with server state and RLS by adding realtime updates for pin/unpin events. 
- Enforce correct permission semantics by checking channel-scoped permissions when pinning/unpinning messages. 
- Provide coverage for the pin lifecycle and permission failure modes with automated tests. 

### Description
- Updated the pin/unpin API to use `getChannelPermissions` and validate the message `channel_id` before performing permission checks for both `PUT` and `DELETE` flows (updated `apps/web/app/api/messages/[messageId]/pin/route.ts`).
- Enhanced `PinnedMessagesPanel` to add a permission-denied state, deterministic upsert + sort behavior for pinned items, and realtime syncing via Supabase `postgres_changes` so the panel reflects remote pin/unpin updates (`apps/web/components/chat/pinned-messages-panel.tsx`).
- Added `apps/web/__tests__/message-pin-route.test.ts` which exercises successful pin+audit logging, permission-denied pin attempts, and unpin flows using the new channel-scoped permission path. 

### Testing
- Ran the new route tests: `cd apps/web && npm test -- --run __tests__/message-pin-route.test.ts` and they passed. 
- Ran the full web test suite: `cd apps/web && npm test` and all tests passed (`19 files`, `129 tests` passed). 
- Attempted to run the dev server (`npm run dev`) to validate runtime UI but startup failed due to missing required environment variables (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`) in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9be22c81c83259073f26267a9754a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time updates for pinned messages with automatic list refresh
  * Permission-denied messaging displayed when users lack access to pinned messages

* **Bug Fixes**
  * Improved error handling for permission-restricted pinned message access
  * Enhanced empty state handling and display logic for pinned messages panel

* **Tests**
  * Added comprehensive test suite validating message pin/unpin route behavior and permission checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->