### PR TITLE
Add reply-reference navigation and return-to-context shortcut

### DIFF
--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -34,6 +34,7 @@ import {
   updateOutboxStatus,
   upsertOutboxEntry,
 } from "@/lib/chat-outbox"
+import { buildReplyJumpPath, shouldHandleReturnToContextShortcut } from "@/lib/reply-navigation"
 
 interface Props {
   channel: ChannelRow
@@ -130,10 +131,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
   })
 
   const jumpToMessage = useCallback((messageId: string) => {
-    const params = new URLSearchParams(searchParams.toString())
-    params.set("message", messageId)
-    params.delete("thread")
-    router.replace(`/channels/${serverId}/${channel.id}?${params.toString()}`)
+    router.replace(buildReplyJumpPath(`/channels/${serverId}/${channel.id}`, searchParams.toString(), messageId))
   }, [channel.id, router, searchParams, serverId])
 
   // Auto-open create thread modal when navigated from channel right-click
@@ -786,7 +784,16 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     void (async () => {
       const loadedFromContext = await loadMessageContextWindow(jumpToMessageId)
       const loaded = loadedFromContext || await ensureMessageLoaded(jumpToMessageId)
-      if (!loaded || cancelled) return
+      if (!loaded || cancelled) {
+        if (!cancelled) {
+          jumpedRef.current = true
+          toast({
+            title: "Original message unavailable",
+            description: "This reply target was deleted or can no longer be loaded.",
+          })
+        }
+        return
+      }
 
       rafId = window.requestAnimationFrame(() => {
         if (cancelled) return
@@ -815,7 +822,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
       if (rafId !== null) window.cancelAnimationFrame(rafId)
       if (timerId) window.clearTimeout(timerId)
     }
-  }, [ensureMessageLoaded, jumpToMessageId, loadMessageContextWindow, messageIndexMap, openThreadId, returnScrollStorageKey])
+  }, [ensureMessageLoaded, jumpToMessageId, loadMessageContextWindow, messageIndexMap, openThreadId, returnScrollStorageKey, toast, virtualizer])
 
   const jumpToLatest = useCallback(() => {
     scrollToLatest("smooth")
@@ -837,6 +844,19 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     router.replace(`/channels/${serverId}/${channel.id}`)
     setShowReturnToContext(false)
   }, [channel.id, returnScrollStorageKey, router, serverId])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!shouldHandleReturnToContextShortcut(showReturnToContext, event)) return
+      event.preventDefault()
+      returnToContext()
+    }
+
+    window.addEventListener("keydown", onKeyDown)
+    return () => {
+      window.removeEventListener("keydown", onKeyDown)
+    }
+  }, [returnToContext, showReturnToContext])
 
   useRealtimeMessages(
     channel.id,

--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -610,19 +610,19 @@ export const MessageItem = memo(function MessageItem({
           }}
         >
           {/* Reply reference */}
-          {message.reply_to_id && message.reply_to && (
+          {message.reply_to_id && (
             onReplyJump ? (
               <button
                 type="button"
                 onClick={() => onReplyJump(message.reply_to_id!)}
                 className="w-full text-left flex items-center gap-2 mb-1 ml-10 text-xs tertiary-metadata rounded px-1 py-0.5 surface-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--theme-accent)]"
-                aria-label="Jump to replied message"
+                aria-label={message.reply_to ? "Jump to replied message" : "Jump to original message"}
               >
                 <Reply className="w-3 h-3 -scale-x-100" />
                 <span className="font-medium" style={{ color: 'var(--theme-text-secondary)' }}>
-                  {message.reply_to.author?.display_name || message.reply_to.author?.username}
+                  {message.reply_to?.author?.display_name || message.reply_to?.author?.username || "Original message"}
                 </span>
-                <span className="truncate">{message.reply_to.content}</span>
+                <span className="truncate">{message.reply_to?.content || "Message unavailable"}</span>
               </button>
             ) : (
               <div
@@ -630,9 +630,9 @@ export const MessageItem = memo(function MessageItem({
               >
                 <Reply className="w-3 h-3 -scale-x-100" />
                 <span className="font-medium" style={{ color: 'var(--theme-text-secondary)' }}>
-                  {message.reply_to.author?.display_name || message.reply_to.author?.username}
+                  {message.reply_to?.author?.display_name || message.reply_to?.author?.username || "Original message"}
                 </span>
-                <span className="truncate">{message.reply_to.content}</span>
+                <span className="truncate">{message.reply_to?.content || "Message unavailable"}</span>
               </div>
             )
           )}

--- a/apps/web/lib/reply-navigation.test.ts
+++ b/apps/web/lib/reply-navigation.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { buildReplyJumpPath, shouldHandleReturnToContextShortcut } from "@/lib/reply-navigation"
+
+describe("reply navigation", () => {
+  it("builds a jump path while preserving unrelated params", () => {
+    const path = buildReplyJumpPath("/channels/s1/c1", "thread=t1&foo=bar", "m-42")
+    expect(path).toBe("/channels/s1/c1?foo=bar&message=m-42")
+  })
+
+  it("adds the message query when no existing params are present", () => {
+    const path = buildReplyJumpPath("/channels/s1/c1", "", "m-42")
+    expect(path).toBe("/channels/s1/c1?message=m-42")
+  })
+
+  it("only handles bare escape for return-to-context", () => {
+    expect(shouldHandleReturnToContextShortcut(true, { key: "Escape" })).toBe(true)
+    expect(shouldHandleReturnToContextShortcut(false, { key: "Escape" })).toBe(false)
+    expect(shouldHandleReturnToContextShortcut(true, { key: "Escape", metaKey: true })).toBe(false)
+    expect(shouldHandleReturnToContextShortcut(true, { key: "Enter" })).toBe(false)
+  })
+})

--- a/apps/web/lib/reply-navigation.ts
+++ b/apps/web/lib/reply-navigation.ts
@@ -1,0 +1,21 @@
+export function buildReplyJumpPath(pathname: string, search: string, messageId: string): string {
+  const params = new URLSearchParams(search)
+  params.set("message", messageId)
+  params.delete("thread")
+  const query = params.toString()
+  return query ? `${pathname}?${query}` : pathname
+}
+
+type ReturnShortcutEvent = {
+  key: string
+  altKey?: boolean
+  ctrlKey?: boolean
+  metaKey?: boolean
+  shiftKey?: boolean
+}
+
+export function shouldHandleReturnToContextShortcut(enabled: boolean, event: ReturnShortcutEvent): boolean {
+  if (!enabled) return false
+  if (event.key !== "Escape") return false
+  return !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey
+}


### PR DESCRIPTION
### Motivation
- Enable clicking a reply preview to jump to and highlight the original message even when using a virtualized/paginated message list.
- Provide a “return to recent position” affordance so users can go back after a jump.
- Handle missing or deleted original messages gracefully and keep reply previews keyboard-accessible.
- Centralize URL building and keyboard gating logic for predictable behavior across navigation.

### Description
- Added `apps/web/lib/reply-navigation.ts` with `buildReplyJumpPath` to construct reply jump URLs while preserving unrelated query params and removing `thread`, and `shouldHandleReturnToContextShortcut` to gate the return shortcut.
- Updated `ChatArea` to use `buildReplyJumpPath` for reply jumps, show a toast when a jumped-to message cannot be loaded, persist the previous scroll position for a return action, and register an `Escape` key handler to trigger `returnToContext` when shown.
- Updated `MessageItem` reply previews to render even when `reply_to` payload is missing, showing fallback text and keeping the preview interactive with an accessible `aria-label`.
- Added unit tests `apps/web/lib/reply-navigation.test.ts` covering URL construction and return-shortcut rules.

### Testing
- Ran unit tests: `npm run test -- reply-navigation.test.ts`, all tests passed (`3 tests, 3 passed`).
- Performed static type checks: `npm run type-check` (`tsc --noEmit`) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9bfca714c8325aa3885e8c0784526)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcut (Escape) to navigate back to context during chat conversations
  * Enhanced reply navigation with toast notification feedback when target message isn't loaded

* **Bug Fixes**
  * Improved resilience of reply reference display with fallback text for unavailable messages and authors

* **Tests**
  * Added unit tests for reply navigation utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->