### PR TITLE
Add identity security parity: step-up auth, suspicious-login telemetry, and OAuth linking

### DIFF
--- a/apps/web/__tests__/auth-security-parity.test.ts
+++ b/apps/web/__tests__/auth-security-parity.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const getUserMock = vi.fn()
+const updateUserByIdMock = vi.fn()
+const signInWithPasswordMock = vi.fn()
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerSupabaseClient: vi.fn(async () => ({
+    auth: {
+      getUser: getUserMock,
+      signOut: vi.fn(async () => ({ error: null })),
+    },
+  })),
+  createServiceRoleClient: vi.fn(async () => ({
+    auth: {
+      admin: {
+        updateUserById: updateUserByIdMock,
+      },
+    },
+  })),
+}))
+
+vi.mock("@/lib/auth/step-up", () => ({
+  hasValidStepUpToken: vi.fn(async () => false),
+}))
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      signInWithPassword: signInWithPasswordMock,
+      signOut: vi.fn(async () => ({ error: null })),
+    },
+  })),
+}))
+
+describe("security parity guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getUserMock.mockResolvedValue({ data: { user: { id: "user-1", email: "test@example.com" } } })
+    signInWithPasswordMock.mockResolvedValue({ error: null })
+    updateUserByIdMock.mockResolvedValue({ error: null })
+  })
+
+  it("enforces step-up before password change", async () => {
+    const { PATCH } = await import("@/app/api/auth/password/route")
+    const response = await PATCH(new Request("http://localhost/api/auth/password", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ currentPassword: "current-password", newPassword: "very-secure-password" }),
+    }))
+
+    expect(response.status).toBe(403)
+    const body = await response.json()
+    expect(body.error).toContain("Step-up")
+    expect(updateUserByIdMock).not.toHaveBeenCalled()
+  })
+
+  it("flags suspicious login when both subnet and device change", async () => {
+    const { computeLoginRisk } = await import("@/lib/auth/risk")
+    const risk = computeLoginRisk(
+      { userId: "user-1", ipAddress: "203.0.113.10", userAgent: "Chrome/123", locationHint: "US" },
+      { ipAddress: "198.51.100.22", userAgent: "Safari/17", locationHint: "DE" }
+    )
+
+    expect(risk.suspicious).toBe(true)
+    expect(risk.riskScore).toBeGreaterThanOrEqual(60)
+    expect(risk.reasons).toContain("new_ip_subnet")
+    expect(risk.reasons).toContain("new_device_signature")
+  })
+})

--- a/apps/web/app/api/auth/account/route.ts
+++ b/apps/web/app/api/auth/account/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server"
+import { createServerSupabaseClient, createServiceRoleClient } from "@/lib/supabase/server"
+import { hasValidStepUpToken } from "@/lib/auth/step-up"
+
+export async function DELETE() {
+  const supabase = await createServerSupabaseClient()
+  const admin = await createServiceRoleClient()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  if (!(await hasValidStepUpToken(auth.user.id))) {
+    return NextResponse.json({ error: "Step-up authentication required" }, { status: 403 })
+  }
+
+  const { error } = await admin.auth.admin.deleteUser(auth.user.id)
+  if (error) return NextResponse.json({ error: error.message || "Failed to delete account" }, { status: 500 })
+
+  await supabase.auth.signOut({ scope: "global" })
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import { createServiceRoleClient } from "@/lib/supabase/server"
 import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
+import { computeLoginRisk } from "@/lib/auth/risk"
 
 /**
  * POST /api/auth/login
@@ -86,6 +87,51 @@ export async function POST(request: Request) {
     await adminDb.rpc("clear_login_attempts", { target_email: email })
   } catch {
     // Swallow — failing to clear shouldn't block a successful login
+  }
+
+  // Risk telemetry + suspicious login alerts (best effort)
+  try {
+    const db = admin as any
+    const currentIp = ipAddress
+    const currentUa = request.headers.get("user-agent") || null
+    const currentLocation = request.headers.get("x-vercel-ip-country") || request.headers.get("cf-ipcountry") || null
+
+    const { data: prev } = await db
+      .from("login_risk_events")
+      .select("ip_address,user_agent,location_hint")
+      .eq("user_id", data.user.id)
+      .eq("succeeded", true)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    const risk = computeLoginRisk(
+      { userId: data.user.id, ipAddress: currentIp, userAgent: currentUa, locationHint: currentLocation },
+      prev ? { ipAddress: prev.ip_address, userAgent: prev.user_agent, locationHint: prev.location_hint } : null
+    )
+
+    await db.from("login_risk_events").insert({
+      user_id: data.user.id,
+      email,
+      ip_address: currentIp,
+      user_agent: currentUa,
+      location_hint: currentLocation,
+      risk_score: risk.riskScore,
+      reasons: risk.reasons,
+      suspicious: risk.suspicious,
+      succeeded: true,
+    })
+
+    if (risk.suspicious) {
+      await db.from("notifications").insert({
+        user_id: data.user.id,
+        type: "system",
+        title: "Suspicious login detected",
+        body: `We noticed a login from a new device or location (${currentIp || "unknown IP"}). If this wasn't you, reset your password immediately.`,
+      })
+    }
+  } catch {
+    // Do not block successful login on telemetry or alert failures
   }
 
   // Check if user has TOTP enrolled (for MFA challenge redirect)

--- a/apps/web/app/api/auth/mfa/disable/route.ts
+++ b/apps/web/app/api/auth/mfa/disable/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server"
+import { createServerSupabaseClient, createServiceRoleClient } from "@/lib/supabase/server"
+import { hasValidStepUpToken } from "@/lib/auth/step-up"
+
+export async function POST(request: Request) {
+  const supabase = await createServerSupabaseClient()
+  const admin = await createServiceRoleClient()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  if (!(await hasValidStepUpToken(auth.user.id))) {
+    return NextResponse.json({ error: "Step-up authentication required" }, { status: 403 })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as { factorId?: string }
+  if (!body.factorId) return NextResponse.json({ error: "factorId is required" }, { status: 400 })
+
+  const result = await (admin.auth.admin as any).mfa.deleteFactor({
+    userId: auth.user.id,
+    id: body.factorId,
+  })
+
+  if (result?.error) {
+    return NextResponse.json({ error: result.error.message || "Failed to disable MFA" }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/app/api/auth/password/route.ts
+++ b/apps/web/app/api/auth/password/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createServerSupabaseClient, createServiceRoleClient } from "@/lib/supabase/server"
+import { hasValidStepUpToken } from "@/lib/auth/step-up"
 
 const MIN_PASSWORD_LENGTH = 12
 
@@ -12,6 +13,10 @@ export async function PATCH(request: Request) {
   const supabase = await createServerSupabaseClient()
   const { data: auth } = await supabase.auth.getUser()
   if (!auth.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  if (!(await hasValidStepUpToken(auth.user.id))) {
+    return NextResponse.json({ error: "Step-up authentication required" }, { status: 403 })
+  }
 
   const body = (await request.json().catch(() => ({}))) as {
     currentPassword?: string

--- a/apps/web/app/api/auth/step-up/route.ts
+++ b/apps/web/app/api/auth/step-up/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { issueStepUpToken } from "@/lib/auth/step-up"
+
+export async function POST(request: Request) {
+  const supabase = await createServerSupabaseClient()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const body = (await request.json().catch(() => ({}))) as { currentPassword?: string }
+  if (!body.currentPassword) {
+    return NextResponse.json({ error: "currentPassword is required" }, { status: 400 })
+  }
+
+  const email = auth.user.email
+  if (!email) return NextResponse.json({ error: "Email not found" }, { status: 400 })
+
+  const { createClient } = await import("@supabase/supabase-js")
+  const verifier = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!)
+
+  const { error } = await verifier.auth.signInWithPassword({ email, password: body.currentPassword })
+  await verifier.auth.signOut().catch(() => undefined)
+
+  if (error) return NextResponse.json({ error: "Step-up verification failed" }, { status: 401 })
+
+  await issueStepUpToken(auth.user.id)
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/app/api/users/connections/oauth/callback/route.ts
+++ b/apps/web/app/api/users/connections/oauth/callback/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+
+const OAUTH_PROVIDERS = new Set(["github", "reddit", "twitch"] as const)
+
+
+export async function GET(request: Request) {
+  const supabase = await createServerSupabaseClient()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) return NextResponse.redirect(new URL("/settings/profile?linked=0", request.url))
+
+  const { searchParams } = new URL(request.url)
+  const provider = ((searchParams.get("provider") || "").toLowerCase()) as "github" | "reddit" | "twitch"
+  const state = searchParams.get("state") || ""
+  if (!OAUTH_PROVIDERS.has(provider)) {
+    return NextResponse.redirect(new URL("/settings/profile?linked=0&error=provider", request.url))
+  }
+
+  const cookieStore = await cookies()
+  const stateCookie = cookieStore.get("vtx_oauth_link_state")?.value
+  cookieStore.delete("vtx_oauth_link_state")
+
+  if (!stateCookie || stateCookie !== `${provider}:${state}`) {
+    return NextResponse.redirect(new URL("/settings/profile?linked=0&error=state", request.url))
+  }
+
+  const { data: identities } = await (supabase.auth as any).getUserIdentities?.() ?? { data: [] }
+  const matched = (identities?.identities || []).find((entry: any) => entry.provider === provider)
+  if (!matched?.id) {
+    return NextResponse.redirect(new URL("/settings/profile?linked=0&error=identity", request.url))
+  }
+
+  await supabase.from("user_connections").upsert({
+    user_id: auth.user.id,
+    provider,
+    provider_user_id: matched.id,
+    username: matched.identity_data?.user_name || matched.identity_data?.email || matched.id,
+    display_name: matched.identity_data?.full_name || null,
+    profile_url: matched.identity_data?.profile_url || null,
+    metadata: { linked_via: "oauth", identity_id: matched.id },
+  }, { onConflict: "user_id,provider" })
+
+  return NextResponse.redirect(new URL("/settings/profile?linked=1", request.url))
+}

--- a/apps/web/app/api/users/connections/oauth/start/route.ts
+++ b/apps/web/app/api/users/connections/oauth/start/route.ts
@@ -1,0 +1,38 @@
+import crypto from "node:crypto"
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { hasValidStepUpToken } from "@/lib/auth/step-up"
+
+const OAUTH_PROVIDERS = new Set(["github", "reddit", "twitch"])
+
+export async function GET(request: Request) {
+  const supabase = await createServerSupabaseClient()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  if (!(await hasValidStepUpToken(auth.user.id))) {
+    return NextResponse.json({ error: "Step-up authentication required" }, { status: 403 })
+  }
+
+  const { searchParams, origin } = new URL(request.url)
+  const provider = (searchParams.get("provider") || "").toLowerCase()
+  if (!OAUTH_PROVIDERS.has(provider)) return NextResponse.json({ error: "Unsupported provider" }, { status: 422 })
+
+  const state = crypto.randomUUID()
+  const cookieStore = await cookies()
+  cookieStore.set("vtx_oauth_link_state", `${provider}:${state}`, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: 60 * 10,
+    path: "/",
+  })
+
+  const redirectTo = `${origin}/api/users/connections/oauth/callback?provider=${provider}&state=${state}`
+  const { data, error } = await (supabase.auth as any).linkIdentity({ provider, options: { redirectTo } })
+  if (error || !data?.url) {
+    return NextResponse.json({ error: error?.message || "Unable to start link flow" }, { status: 500 })
+  }
+
+  return NextResponse.redirect(data.url)
+}

--- a/apps/web/components/modals/profile-settings-modal.tsx
+++ b/apps/web/components/modals/profile-settings-modal.tsx
@@ -1501,13 +1501,33 @@ function TwoFactorSection({ supabase, toast }: { supabase: ReturnType<typeof imp
   }
 
   async function handleUnenroll(id: string) {
-    const { error } = await supabase.auth.mfa.unenroll({ factorId: id })
-    if (error) {
-      toast({ variant: "destructive", title: "Failed to disable 2FA", description: error.message })
-    } else {
-      toast({ title: "2FA disabled" })
-      loadFactors()
+    const currentPassword = window.prompt("Confirm your password to disable 2FA")
+    if (!currentPassword) return
+
+    const stepRes = await fetch("/api/auth/step-up", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ currentPassword }),
+    })
+    if (!stepRes.ok) {
+      const data = await stepRes.json().catch(() => ({}))
+      toast({ variant: "destructive", title: "Step-up failed", description: data.error ?? "Could not verify identity" })
+      return
     }
+
+    const res = await fetch("/api/auth/mfa/disable", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ factorId: id }),
+    })
+    const payload = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      toast({ variant: "destructive", title: "Failed to disable 2FA", description: payload.error ?? "Unknown error" })
+      return
+    }
+
+    toast({ title: "2FA disabled" })
+    loadFactors()
   }
 
   function copySecret() {

--- a/apps/web/components/settings/security-settings-page.tsx
+++ b/apps/web/components/settings/security-settings-page.tsx
@@ -42,8 +42,18 @@ export function SecuritySettingsPage({ userId: _userId, hasTOTP, userEmail }: Pr
 
     setChangingPassword(true)
     try {
-      const res = await fetch("/api/auth/change-password", {
+      const stepUp = await fetch("/api/auth/step-up", {
         method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ currentPassword: oldPassword }),
+      })
+      if (!stepUp.ok) {
+        const step = await stepUp.json().catch(() => ({}))
+        throw new Error(step.error ?? "Step-up verification failed")
+      }
+
+      const res = await fetch("/api/auth/password", {
+        method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ currentPassword: oldPassword, newPassword }),
       })

--- a/apps/web/lib/auth/risk.ts
+++ b/apps/web/lib/auth/risk.ts
@@ -1,0 +1,46 @@
+export interface LoginFingerprint {
+  userId: string
+  ipAddress: string | null
+  userAgent: string | null
+  locationHint: string | null
+}
+
+export interface PreviousLoginFingerprint {
+  ipAddress: string | null
+  userAgent: string | null
+  locationHint: string | null
+}
+
+function subnet(ip: string | null) {
+  if (!ip) return null
+  if (ip.includes(":")) return ip.split(":").slice(0, 4).join(":")
+  const p = ip.split(".")
+  if (p.length !== 4) return ip
+  return `${p[0]}.${p[1]}.${p[2]}`
+}
+
+export function computeLoginRisk(current: LoginFingerprint, previous: PreviousLoginFingerprint | null) {
+  if (!previous) {
+    return { riskScore: 25, suspicious: false, reasons: ["first_seen_login"] }
+  }
+
+  const reasons: string[] = []
+  let score = 0
+
+  if (subnet(current.ipAddress) && subnet(current.ipAddress) !== subnet(previous.ipAddress)) {
+    score += 45
+    reasons.push("new_ip_subnet")
+  }
+
+  if (current.locationHint && previous.locationHint && current.locationHint !== previous.locationHint) {
+    score += 25
+    reasons.push("new_location")
+  }
+
+  if (current.userAgent && previous.userAgent && current.userAgent !== previous.userAgent) {
+    score += 30
+    reasons.push("new_device_signature")
+  }
+
+  return { riskScore: Math.min(score, 100), suspicious: score >= 60, reasons }
+}

--- a/apps/web/lib/auth/step-up.ts
+++ b/apps/web/lib/auth/step-up.ts
@@ -1,0 +1,52 @@
+import crypto from "node:crypto"
+import { cookies } from "next/headers"
+
+const STEP_UP_COOKIE = "vtx_step_up"
+const STEP_UP_TTL_MS = 10 * 60 * 1000
+
+function stepUpSecret() {
+  return process.env.STEP_UP_SECRET || process.env.NEXTAUTH_SECRET || process.env.SUPABASE_SERVICE_ROLE_KEY || "local-step-up-secret"
+}
+
+function sign(payload: string) {
+  return crypto.createHmac("sha256", stepUpSecret()).update(payload).digest("hex")
+}
+
+export async function issueStepUpToken(userId: string) {
+  const issuedAt = Date.now()
+  const payload = `${userId}:${issuedAt}`
+  const signature = sign(payload)
+  const cookieStore = await cookies()
+  cookieStore.set(STEP_UP_COOKIE, `${payload}:${signature}`, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    expires: new Date(issuedAt + STEP_UP_TTL_MS),
+    path: "/",
+  })
+}
+
+export async function clearStepUpToken() {
+  const cookieStore = await cookies()
+  cookieStore.delete(STEP_UP_COOKIE)
+}
+
+export async function hasValidStepUpToken(userId: string) {
+  const cookieStore = await cookies()
+  const raw = cookieStore.get(STEP_UP_COOKIE)?.value
+  if (!raw) return false
+
+  const [cookieUserId, issuedAtRaw, signature] = raw.split(":")
+  if (!cookieUserId || !issuedAtRaw || !signature) return false
+  if (cookieUserId !== userId) return false
+
+  const payload = `${cookieUserId}:${issuedAtRaw}`
+  const expected = sign(payload)
+  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) return false
+
+  const issuedAt = Number(issuedAtRaw)
+  if (!Number.isFinite(issuedAt)) return false
+  return Date.now() - issuedAt <= STEP_UP_TTL_MS
+}
+
+export const STEP_UP_WINDOW_SECONDS = STEP_UP_TTL_MS / 1000

--- a/supabase/migrations/00046_login_risk_events.sql
+++ b/supabase/migrations/00046_login_risk_events.sql
@@ -1,0 +1,22 @@
+-- Identity security parity: risk telemetry for successful logins + suspicious login alerts.
+
+CREATE TABLE IF NOT EXISTS public.login_risk_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  email TEXT NOT NULL,
+  ip_address TEXT,
+  user_agent TEXT,
+  location_hint TEXT,
+  risk_score INT NOT NULL DEFAULT 0,
+  reasons JSONB NOT NULL DEFAULT '[]'::jsonb,
+  suspicious BOOLEAN NOT NULL DEFAULT FALSE,
+  succeeded BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_login_risk_events_user_created ON public.login_risk_events(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_login_risk_events_suspicious ON public.login_risk_events(suspicious, created_at DESC);
+
+ALTER TABLE public.login_risk_events ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies intentionally omitted: service role writes/reads telemetry.


### PR DESCRIPTION
### Motivation
- Raise account security parity by gating sensitive actions with a short-lived step-up verification and by detecting/surfacing suspicious logins. 
- Provide secure OAuth/social linking with CSRF-style state validation and account linking telemetry for audit/risk workflows. 

### Description
- Implemented a step-up primitive with signed, short-lived cookie helpers in `apps/web/lib/auth/step-up.ts` and `/api/auth/step-up` to verify current password and mint the step-up token. 
- Enforced step-up checks on sensitive server endpoints: password change (`PATCH /api/auth/password`), MFA disable (`POST /api/auth/mfa/disable`), and account deletion (`DELETE /api/auth/account`). 
- Updated client flows to perform step-up prior to sensitive actions in `apps/web/components/settings/security-settings-page.tsx` and `apps/web/components/modals/profile-settings-modal.tsx`. 
- Added risk telemetry and suspicious-login heuristics (`apps/web/lib/auth/risk.ts`) and persisted telemetry in `login_risk_events` from the login path, with user-facing `system` notifications on suspicious events. 
- Added OAuth account-linking start/callback routes with state cookies and step-up enforcement in `apps/web/app/api/users/connections/oauth/*`, and upsert into `user_connections` on success. 
- Added DB migration `supabase/migrations/00046_login_risk_events.sql` to store login risk events. 
- Added unit tests in `apps/web/__tests__/auth-security-parity.test.ts` covering step-up gate enforcement and the suspicious-login heuristic. 

### Testing
- Ran the new unit tests: `npm --prefix apps/web run test -- auth-security-parity.test.ts`, which passed (1 test file, 2 tests). 
- Ran static type checks: `npm --prefix apps/web run type-check`, which completed successfully (no `tsc` errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9c58054508325bdd4f9a45efd9950)