### PR TITLE
Centralize block-policy and enforce across search, members, and friend suggestions

### DIFF
--- a/apps/web/app/api/friends/suggestions/route.ts
+++ b/apps/web/app/api/friends/suggestions/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { filterBlockedUserIds, getBlockedUserIdsForViewer } from "@/lib/social-block-policy"
+
+// GET /api/friends/suggestions?q=alice&limit=8
+export async function GET(req: NextRequest) {
+  const supabase = await createServerSupabaseClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const q = req.nextUrl.searchParams.get("q")?.trim() ?? ""
+  const limit = Math.min(Math.max(parseInt(req.nextUrl.searchParams.get("limit") ?? "8", 10) || 8, 1), 25)
+
+  const { data: relationshipRows, error: relationshipError } = await supabase
+    .from("friendships")
+    .select("requester_id, addressee_id")
+    .or(`requester_id.eq.${user.id},addressee_id.eq.${user.id}`)
+
+  if (relationshipError) {
+    return NextResponse.json({ error: relationshipError.message }, { status: 500 })
+  }
+
+  const blockedUserIds = await getBlockedUserIdsForViewer(supabase as any, user.id)
+
+  const excluded = new Set<string>([user.id, ...blockedUserIds])
+  for (const row of relationshipRows ?? []) {
+    if (row.requester_id === user.id) excluded.add(row.addressee_id)
+    if (row.addressee_id === user.id) excluded.add(row.requester_id)
+  }
+
+  let query = supabase
+    .from("users")
+    .select("id, username, display_name, avatar_url, status")
+    .order("created_at", { ascending: false })
+    .limit(100)
+
+  if (q) {
+    query = query.or(`username.ilike.%${q}%,display_name.ilike.%${q}%`)
+  }
+
+  const { data: users, error } = await query
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  const filtered = filterBlockedUserIds(users ?? [], (candidate) => candidate.id, blockedUserIds)
+    .filter((candidate) => !excluded.has(candidate.id))
+    .slice(0, limit)
+
+  return NextResponse.json(filtered)
+}

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createServerSupabaseClient } from "@/lib/supabase/server"
 import { getChannelPermissions, hasPermission } from "@/lib/permissions"
+import { filterBlockedUserIds, getBlockedUserIdsForViewer } from "@/lib/social-block-policy"
 
 interface SearchFilters {
   fromUserId?: string
@@ -184,8 +185,11 @@ export async function GET(req: NextRequest) {
       .limit(limit),
   ])
 
+  const blockedUserIds = await getBlockedUserIdsForViewer(supabase as any, user.id)
+  const visibleMessages = filterBlockedUserIds(messages ?? [], (message) => message.author_id, blockedUserIds)
+
   const results = [
-    ...(messages ?? []).map((m) => ({ type: "message", ...m })),
+    ...visibleMessages.map((m) => ({ type: "message", ...m })),
     ...(tasks ?? []).map((t) => ({ type: "task", ...t })),
     ...(docs ?? []).map((d) => ({ type: "doc", ...d })),
   ]

--- a/apps/web/app/api/servers/[serverId]/members/route.ts
+++ b/apps/web/app/api/servers/[serverId]/members/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { createServerSupabaseClient, createServiceRoleClient } from "@/lib/supabase/server"
 import { getMemberPermissions, hasPermission, PERMISSIONS } from "@/lib/permissions"
+import { filterBlockedUserIds, getBlockedUserIdsForViewer } from "@/lib/social-block-policy"
 
 export async function GET(
   request: Request,
@@ -77,7 +78,10 @@ export async function GET(
     return NextResponse.json({ error: error.message }, { status: 500 })
   }
 
-  return NextResponse.json(members, {
+  const blockedUserIds = await getBlockedUserIdsForViewer(supabase as any, user.id)
+  const visibleMembers = filterBlockedUserIds(members ?? [], (member) => member.user_id, blockedUserIds)
+
+  return NextResponse.json(visibleMembers, {
     headers: { "Cache-Control": "private, max-age=10, stale-while-revalidate=30" },
   })
 }

--- a/apps/web/lib/blocking.ts
+++ b/apps/web/lib/blocking.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js"
+import { getBlockedUserIdsForViewer } from "@/lib/social-block-policy"
 
 /** Returns true when either participant has blocked the other. */
 export async function isBlockedBetweenUsers(
@@ -7,24 +8,8 @@ export async function isBlockedBetweenUsers(
   rightUserId: string
 ): Promise<boolean> {
   if (!leftUserId || !rightUserId || leftUserId === rightUserId) return false
-
-  const participantIds = [leftUserId, rightUserId]
-  const { data, error } = await supabase
-    .from("friendships")
-    .select("requester_id, addressee_id")
-    .eq("status", "blocked")
-    .in("requester_id", participantIds)
-    .in("addressee_id", participantIds)
-
-  if (error) {
-    throw new Error(`Failed to evaluate block state: ${error.message}`)
-  }
-
-  return (data ?? []).some((row) => {
-    const isForward = row.requester_id === leftUserId && row.addressee_id === rightUserId
-    const isBackward = row.requester_id === rightUserId && row.addressee_id === leftUserId
-    return isForward || isBackward
-  })
+  const blockedIds = await getBlockedUserIdsForViewer(supabase, leftUserId, [rightUserId])
+  return blockedIds.has(rightUserId)
 }
 
 /** Filters mention ids down to users that are not blocked relative to sender. */
@@ -36,23 +21,7 @@ export async function filterMentionsByBlockState(
   const uniqueMentions = Array.from(new Set(mentions.filter(Boolean))).filter((id) => id !== senderUserId)
   if (uniqueMentions.length === 0) return { allowed: [], blocked: [] }
 
-  const participantIds = [senderUserId, ...uniqueMentions]
-  const { data, error } = await supabase
-    .from("friendships")
-    .select("requester_id, addressee_id")
-    .eq("status", "blocked")
-    .in("requester_id", participantIds)
-    .in("addressee_id", participantIds)
-
-  if (error) {
-    throw new Error(`Failed to evaluate mention block state: ${error.message}`)
-  }
-
-  const blockedSet = new Set<string>()
-  for (const row of data ?? []) {
-    if (row.requester_id === senderUserId && uniqueMentions.includes(row.addressee_id)) blockedSet.add(row.addressee_id)
-    if (row.addressee_id === senderUserId && uniqueMentions.includes(row.requester_id)) blockedSet.add(row.requester_id)
-  }
+  const blockedSet = await getBlockedUserIdsForViewer(supabase, senderUserId, uniqueMentions)
 
   return {
     allowed: uniqueMentions.filter((id) => !blockedSet.has(id)),

--- a/apps/web/lib/social-block-policy.test.ts
+++ b/apps/web/lib/social-block-policy.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import { deriveBlockedUserIds, filterBlockedUserIds, getBlockedUserIdsForViewer } from "@/lib/social-block-policy"
+
+function createSupabaseFriendshipMock(rows: Array<{ requester_id: string; addressee_id: string; status: "pending" | "accepted" | "blocked" }>) {
+  return {
+    from(table: string) {
+      if (table !== "friendships") throw new Error(`unexpected table ${table}`)
+      const state = { status: "blocked" as string | null, viewer: "" }
+      return {
+        select() {
+          return this
+        },
+        eq(column: string, value: string) {
+          if (column === "status") state.status = value
+          return this
+        },
+        or(expression: string) {
+          const viewerMatch = expression.match(/requester_id\.eq\.([^,]+)/) ?? expression.match(/addressee_id\.eq\.([^,\)]+)/)
+          if (viewerMatch?.[1]) state.viewer = viewerMatch[1]
+          const data = rows.filter((row) => {
+            if (state.status && row.status !== state.status) return false
+            if (!state.viewer) return true
+            return row.requester_id === state.viewer || row.addressee_id === state.viewer
+          })
+          return Promise.resolve({ data, error: null })
+        },
+      }
+    },
+  }
+}
+
+describe("social block policy transitions", () => {
+  it("filters blocked users across search/mentions/suggestions surfaces", async () => {
+    const supabase = createSupabaseFriendshipMock([
+      { requester_id: "viewer", addressee_id: "blocked-user", status: "blocked" },
+      { requester_id: "viewer", addressee_id: "friend", status: "accepted" },
+    ])
+
+    const blocked = await getBlockedUserIdsForViewer(supabase as any, "viewer", ["blocked-user", "friend"])
+    expect(blocked.has("blocked-user")).toBe(true)
+    expect(blocked.has("friend")).toBe(false)
+
+    const mentionCandidates = ["blocked-user", "friend"]
+    expect(mentionCandidates.filter((id) => !blocked.has(id))).toEqual(["friend"])
+
+    const previewCards = [{ author_id: "blocked-user" }, { author_id: "friend" }]
+    expect(filterBlockedUserIds(previewCards, (card) => card.author_id, blocked)).toEqual([{ author_id: "friend" }])
+  })
+
+  it("allows users again after blocked -> accepted transition", () => {
+    const before = deriveBlockedUserIds("viewer", [
+      { requester_id: "viewer", addressee_id: "target", status: "blocked" },
+    ])
+    const after = deriveBlockedUserIds("viewer", [
+      { requester_id: "viewer", addressee_id: "target", status: "accepted" },
+    ])
+
+    const candidates = [{ id: "target" }]
+    expect(filterBlockedUserIds(candidates, (user) => user.id, before)).toEqual([])
+    expect(filterBlockedUserIds(candidates, (user) => user.id, after)).toEqual(candidates)
+  })
+})

--- a/apps/web/lib/social-block-policy.ts
+++ b/apps/web/lib/social-block-policy.ts
@@ -1,0 +1,59 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+type FriendshipStatus = "pending" | "accepted" | "blocked"
+
+type FriendshipRow = {
+  requester_id: string
+  addressee_id: string
+  status: FriendshipStatus
+}
+
+/**
+ * Centralized policy helper for social surfaces that must suppress blocked users.
+ * Returns user ids that are blocked in either direction relative to `userId`.
+ */
+export async function getBlockedUserIdsForViewer(
+  supabase: SupabaseClient,
+  userId: string,
+  candidateUserIds?: string[]
+): Promise<Set<string>> {
+  if (!userId) return new Set<string>()
+
+  const uniqueCandidates = Array.from(new Set((candidateUserIds ?? []).filter(Boolean))).filter((id) => id !== userId)
+
+  let query = supabase
+    .from("friendships")
+    .select("requester_id, addressee_id, status")
+    .eq("status", "blocked")
+    .or(`requester_id.eq.${userId},addressee_id.eq.${userId}`)
+
+  const { data, error } = await query
+
+  if (error) {
+    throw new Error(`Failed to resolve block policy: ${error.message}`)
+  }
+
+  const blocked = deriveBlockedUserIds(userId, data ?? [])
+  if (uniqueCandidates.length === 0) return blocked
+  return new Set(uniqueCandidates.filter((id) => blocked.has(id)))
+}
+
+export function deriveBlockedUserIds(userId: string, rows: FriendshipRow[]): Set<string> {
+  const blocked = new Set<string>()
+
+  for (const row of rows) {
+    if (row.status !== "blocked") continue
+    if (row.requester_id === userId && row.addressee_id) blocked.add(row.addressee_id)
+    if (row.addressee_id === userId && row.requester_id) blocked.add(row.requester_id)
+  }
+
+  return blocked
+}
+
+export function filterBlockedUserIds<T>(items: T[], getUserId: (item: T) => string | null | undefined, blockedUserIds: Set<string>): T[] {
+  if (blockedUserIds.size === 0) return items
+  return items.filter((item) => {
+    const id = getUserId(item)
+    return !id || !blockedUserIds.has(id)
+  })
+}


### PR DESCRIPTION
### Motivation
- Prevent leakage of actionable previews for blocked users across search, mention/autocomplete sources, friend suggestions, and member lists by consolidating block logic.
- Reduce policy drift by providing a single reusable policy helper that other social surfaces can call.
- Ensure mention and DM-related helpers remain consistent with the centralized policy.

### Description
- Added a centralized policy module `apps/web/lib/social-block-policy.ts` exposing `getBlockedUserIdsForViewer`, `deriveBlockedUserIds`, and `filterBlockedUserIds` for resolving and applying block-state filtering.
- Refactored `apps/web/lib/blocking.ts` to delegate pairwise block checks and mention filtering to the centralized policy helper.
- Updated the unified search API `apps/web/app/api/search/route.ts` to remove message previews authored by blocked users before assembling results.
- Updated the server members API `apps/web/app/api/servers/[serverId]/members/route.ts` to suppress blocked users from the returned member list (which feeds mention-autocomplete and member surfaces).
- Added a new authenticated friend suggestions endpoint `apps/web/app/api/friends/suggestions/route.ts` that excludes self, existing relationships, and blocked users and supports optional query/limit parameters.
- Added integration-style tests in `apps/web/lib/social-block-policy.test.ts` validating blocked → filtered and blocked → accepted transitions and the `filterBlockedUserIds` behavior.

### Testing
- Ran the new unit/integration tests with `pnpm vitest lib/social-block-policy.test.ts`, which passed.
- Verified search contract test with `pnpm vitest __tests__/search-permissions-contract.test.ts`, which passed.
- All automated tests executed in this rollout completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e556c32c83258f8cdf25877089ba)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Friend suggestions now respect user blocks, excluding blocked users from recommendations.
  * Search results and server member lists now filter out blocked users for improved privacy.

* **Tests**
  * Added comprehensive test coverage for blocking utilities and filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->