### PR TITLE
fix: synchronize membership screening toggles (#207)

### DIFF
--- a/apps/web/components/modals/server-settings-modal.tsx
+++ b/apps/web/components/modals/server-settings-modal.tsx
@@ -1022,25 +1022,26 @@ export function ScreeningTab({ serverId, open }: { serverId: string; open: boole
   const [title, setTitle] = useState("Server Rules")
   const [description, setDescription] = useState("")
   const [rulesText, setRulesText] = useState("")
-  const [requireAcceptance, setRequireAcceptance] = useState(true)
+  const [screeningEnabled, setScreeningEnabled] = useState(false)
 
   useEffect(() => {
     if (!open) return
     setLoading(true)
-    fetch(`/api/servers/${serverId}/screening`)
-      .then((r) => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`)
-        return r.json()
-      })
-      .then((d) => {
-        const cfg = d.config as ScreeningConfigRow | null
+    // Fetch both screening config and server moderation settings
+    Promise.all([
+      fetch(`/api/servers/${serverId}/screening`).then((r) => r.ok ? r.json() : null),
+      fetch(`/api/servers/${serverId}/moderation`).then((r) => r.ok ? r.json() : null),
+    ])
+      .then(([screeningData, moderationData]) => {
+        const cfg = screeningData?.config as ScreeningConfigRow | null
         setConfig(cfg)
         if (cfg) {
           setTitle(cfg.title)
           setDescription(cfg.description ?? "")
           setRulesText(cfg.rules_text)
-          setRequireAcceptance(cfg.require_acceptance)
         }
+        // Use the server's screening_enabled from moderation settings as the source of truth
+        setScreeningEnabled(moderationData?.screening_enabled ?? false)
         setLoading(false)
       })
       .catch(() => setLoading(false))
@@ -1051,7 +1052,7 @@ export function ScreeningTab({ serverId, open }: { serverId: string; open: boole
     const res = await fetch(`/api/servers/${serverId}/screening`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title, description: description || null, rules_text: rulesText, require_acceptance: requireAcceptance }),
+      body: JSON.stringify({ title, description: description || null, rules_text: rulesText, require_acceptance: true }),
     })
     if (res.ok) {
       const updated = await res.json()
@@ -1062,6 +1063,24 @@ export function ScreeningTab({ serverId, open }: { serverId: string; open: boole
       toast({ variant: "destructive", title: "Failed to save", description: d.error })
     }
     setSaving(false)
+  }
+
+  async function handleToggleScreening() {
+    const newValue = !screeningEnabled
+    setScreeningEnabled(newValue)
+    
+    // Update the server's screening_enabled setting
+    const res = await fetch(`/api/servers/${serverId}/moderation`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ screening_enabled: newValue }),
+    })
+    
+    if (!res.ok) {
+      // Revert on error
+      setScreeningEnabled(!newValue)
+      toast({ variant: "destructive", title: "Failed to update screening setting" })
+    }
   }
 
   async function handleDelete() {
@@ -1129,10 +1148,10 @@ export function ScreeningTab({ serverId, open }: { serverId: string; open: boole
 
       <div className="flex items-center gap-3">
         <button
-          onClick={() => setRequireAcceptance(!requireAcceptance)}
-          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${requireAcceptance ? 'bg-indigo-600' : 'bg-gray-600'}`}
+          onClick={handleToggleScreening}
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${screeningEnabled ? 'bg-indigo-600' : 'bg-gray-600'}`}
         >
-          <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${requireAcceptance ? 'translate-x-6' : 'translate-x-1'}`} />
+          <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${screeningEnabled ? 'translate-x-6' : 'translate-x-1'}`} />
         </button>
         <span className="text-sm text-white">Require acceptance to participate</span>
       </div>


### PR DESCRIPTION
This commit fixes issue #207 where two separate toggles for membership screening existed in conflicting states:

1. Moderation > Settings — 'Membership Screening' toggle
2. Moderation > Screening — 'Require acceptance to participate' toggle

Problem:
- The Moderation tab toggle was reading/writing to servers.screening_enabled
- The Screening tab toggle was reading/writing to screening_configs.require_acceptance
- These are two different database columns that didn't sync with each other

Solution:
- Changed the Screening tab toggle to read/write servers.screening_enabled
- Both toggles now use the same source of truth (servers.screening_enabled)
- The Screening tab now fetches both screening config and moderation settings
- Added handleToggleScreening() to update the server's screening_enabled setting
- Hardcoded screening_configs.require_acceptance to true when saving rules

This ensures both toggles stay in sync and eliminates the conflicting state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screening settings synchronization to source truth from server moderation settings, ensuring consistency between local and server state.
  * Enhanced screening toggle functionality with optimistic updates and error recovery—failed changes now revert with user notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->