### PR TITLE
fix: repair channel drag-and-drop so reorders and cross-category move…

### DIFF
--- a/apps/web/components/layout/channel-sidebar.tsx
+++ b/apps/web/components/layout/channel-sidebar.tsx
@@ -606,14 +606,23 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
     if (!sourceContainer || !targetContainer) return
 
     if (sourceContainer === targetContainer && draggedId !== resolvedOverId) {
-      // Compute the reordered array first, then update state and persist — no side
-      // effects inside the functional updater
       const containerItems = [...(latestItems[sourceContainer] ?? [])]
       const oldIndex = containerItems.indexOf(draggedId)
+      if (oldIndex === -1) return
       const newIndex = containerItems.indexOf(resolvedOverId)
-      if (oldIndex === -1 || newIndex === -1) return
-      const reordered = arrayMove(containerItems, oldIndex, newIndex)
-      setItems((prev) => ({ ...prev, [sourceContainer]: reordered }))
+      if (newIndex !== -1) {
+        // Reorder within the container; keep itemsRef in sync so persistChannelOrder
+        // reads the updated sequence — same pattern as handleDragOver
+        const reordered = arrayMove(containerItems, oldIndex, newIndex)
+        setItems((prev) => {
+          const next = { ...prev, [sourceContainer]: reordered }
+          itemsRef.current = next
+          return next
+        })
+      }
+      // Persist regardless: either we reordered within the container, or this was a
+      // cross-container move that landed on a category header (handleDragOver already
+      // placed the channel in the correct container / itemsRef position).
       persistChannelOrder()
     } else if (sourceContainer !== targetContainer) {
       // Cross-container move was already applied in handleDragOver; persist both


### PR DESCRIPTION
…s persist correctly

Two bugs prevented drag-and-drop from sticking:

1. Same-container reorder: setItems in handleDragEnd used a plain arrow-function updater that never wrote back to itemsRef.current, so persistChannelOrder read stale (pre-drag) order from the ref and saved no-op position updates to the DB. Fix: update itemsRef.current inside the functional updater, matching the pattern already used in handleDragOver.

2. Drop on category header: when a channel was dragged from one category and released over a category header (not a channel), resolvedOverId was the category id which isn't present in the channel list, giving newIndex === -1.  The early return discarded the cross-container move that handleDragOver had already applied to itemsRef, causing the channel to snap back.  Fix: only skip the arrayMove when newIndex is -1; always call persistChannelOrder so the correct itemsRef state (already written by handleDragOver) is persisted.

https://claude.ai/code/session_01QqabCL4q8VeYgNm7fSLuPc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel drag-and-drop reliability when dropping on category headers or in edge cases. Enhanced state synchronization to ensure channel order is properly persisted across different drag scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->