### PR TITLE
Fix TabsList alignment in server settings modal

### DIFF
--- a/apps/web/components/modals/server-settings-modal.tsx
+++ b/apps/web/components/modals/server-settings-modal.tsx
@@ -169,7 +169,7 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, channels =
             <h3 className="text-xs font-semibold uppercase tracking-wider px-4 pt-4 pb-2 flex-shrink-0" style={{ color: 'var(--theme-text-muted)' }}>
               {liveServer.name}
             </h3>
-            <TabsList className="flex flex-col h-auto bg-transparent gap-0.5 w-full flex-1 overflow-y-auto px-4 pb-4">
+            <TabsList className="flex flex-col h-auto bg-transparent gap-0.5 w-full flex-1 overflow-y-auto px-4 pb-4 justify-start items-start">
               <TabsTrigger value="overview" className="w-full justify-start text-sm data-[state=active]:bg-white/10 data-[state=active]:text-white rounded" style={{ color: 'var(--theme-text-secondary)' }}>
                 Overview
               </TabsTrigger>


### PR DESCRIPTION
## Summary
Fixed the alignment of tab items in the server settings modal by adding flexbox alignment utilities to the TabsList component.

## Changes
- Added `justify-start items-start` classes to the TabsList component in the server settings modal
- This ensures tab items are properly aligned to the top-left of their container instead of being centered or stretched

## Details
The TabsList component was missing explicit alignment properties, which could cause inconsistent positioning of tab triggers. By adding `justify-start` and `items-start` utilities, we ensure the tabs are consistently aligned to the start of the flex container, providing a more predictable and visually correct layout.

https://claude.ai/code/session_015YbrSUN2PtDNxHbUMJQGoX