### PR TITLE
Fix voice channel placeholder text capitalization

### DIFF
--- a/apps/web/components/modals/create-channel-modal.tsx
+++ b/apps/web/components/modals/create-channel-modal.tsx
@@ -211,7 +211,7 @@ export function CreateChannelModal({ open, onClose, serverId, categoryId }: Prop
                 onChange={(e) => setName(e.target.value)}
                 placeholder={
                   type === "category" ? "New Category" :
-                  type === "voice" ? "General" :
+                  type === "voice" ? "general" :
                   type === "stage" ? "town-hall" :
                   type === "forum" ? "help-forum" :
                   type === "announcement" ? "announcements" :


### PR DESCRIPTION
## Summary
Updated the placeholder text for voice channels in the create channel modal to use lowercase formatting, consistent with other channel type placeholders.

## Changes
- Changed voice channel placeholder from "General" to "general" to match the naming convention used for other channel types (stage, forum, announcement, etc.)

## Details
This ensures consistent placeholder text capitalization across all channel type options in the modal, improving visual consistency in the UI.

https://claude.ai/code/session_01JLtFj3Mr8oyejjxjM453b8