### PR TITLE
fix(middleware): skip Supabase session for webhook and cron routes

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -2,21 +2,30 @@ import { NextResponse, type NextRequest } from "next/server"
 import type { User } from "@supabase/supabase-js"
 import { updateSession } from "@/lib/supabase/middleware"
 
-const PUBLIC_ROUTES = [
-  "/login",
-  "/register",
-  "/api/auth",
-  "/auth/callback",
-  // Cron and webhook endpoints authenticate via their own bearer tokens,
-  // not Supabase sessions — they must not be blocked by the session middleware.
+// Routes that use their own auth (bearer tokens, URL tokens) — skip session
+// handling entirely so external callers are never redirected or delayed.
+const PASSTHROUGH_ROUTES = [
   "/api/cron",
   "/api/channels/cleanup",
   "/api/social-alerts/poll",
   "/api/webhooks",
 ]
 
+// Routes that are public but still benefit from session refresh (login page, etc.)
+const PUBLIC_ROUTES = [
+  "/login",
+  "/register",
+  "/api/auth",
+  "/auth/callback",
+]
+
 export async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname
+
+  // Machine-to-machine endpoints — pass through with zero Supabase overhead
+  if (PASSTHROUGH_ROUTES.some((route) => pathname.startsWith(route))) {
+    return NextResponse.next()
+  }
 
   // Allow public routes and marketing homepage
   if (pathname === "/" || PUBLIC_ROUTES.some((route) => pathname.startsWith(route))) {


### PR DESCRIPTION
Webhook and cron endpoints were being passed through updateSession() which added unnecessary latency and could fail for cookieless requests. Split into PASSTHROUGH_ROUTES (immediate NextResponse.next()) and PUBLIC_ROUTES (session refresh without auth gate).

Closes #205