### PR TITLE
fix(auth): establish session server-side for passkey and recovery login

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -137,9 +137,8 @@ export default function LoginPage() {
         return
       }
 
-      if (data.actionLink) {
-        window.location.href = data.actionLink
-      }
+      // Session cookies are now set by the redeem endpoint — navigate to the app
+      window.location.href = "/channels/me"
     } catch (error: any) {
       toast({ variant: "destructive", title: "Recovery failed", description: error.message })
     } finally {

--- a/apps/web/app/api/auth/passkeys/login/verify/route.ts
+++ b/apps/web/app/api/auth/passkeys/login/verify/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { createServiceRoleClient } from "@/lib/supabase/server"
+import { createServerSupabaseClient, createServiceRoleClient } from "@/lib/supabase/server"
 import { getOrigin, getRpId, verifyWithAdapter } from "@/lib/auth/passkeys"
 import { createAuthSession, issueTrustedDevice } from "@/lib/auth/security"
 import { rateLimiter } from "@/lib/rate-limit"
@@ -81,9 +81,22 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unable to resolve account email for passkey login" }, { status: 400 })
   }
 
+  // Generate a magic link token, then verify it server-side through the
+  // cookie-aware client so session cookies are set in this response —
+  // no implicit-grant redirect required.
   const link = await supabase.auth.admin.generateLink({ type: "magiclink", email })
-  if (!link.data.properties?.action_link) {
+  const tokenHash = link.data.properties?.hashed_token
+  if (!tokenHash) {
     return NextResponse.json({ error: "Unable to finalize session" }, { status: 500 })
+  }
+
+  const anonClient = await createServerSupabaseClient()
+  const { error: otpError } = await anonClient.auth.verifyOtp({
+    token_hash: tokenHash,
+    type: "magiclink",
+  })
+  if (otpError) {
+    return NextResponse.json({ error: "Session creation failed" }, { status: 500 })
   }
 
   const trustedDeviceId = body.trustedDeviceLabel
@@ -97,5 +110,5 @@ export async function POST(request: Request) {
     ipAddress: request.headers.get("x-forwarded-for"),
   })
 
-  return NextResponse.json({ ok: true, actionLink: link.data.properties.action_link })
+  return NextResponse.json({ ok: true })
 }

--- a/apps/web/app/api/auth/recovery-codes/redeem/route.ts
+++ b/apps/web/app/api/auth/recovery-codes/redeem/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { createServiceRoleClient } from "@/lib/supabase/server"
+import { createServerSupabaseClient, createServiceRoleClient } from "@/lib/supabase/server"
 import { verifyRecoveryCode } from "@/lib/auth/recovery-codes"
 import { rateLimiter } from "@/lib/rate-limit"
 
@@ -93,11 +93,22 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Recovery code already used" }, { status: 409 })
   }
 
-  // Generate a session link for the user (same pattern as passkey login verify)
+  // Generate a magic link token and verify it server-side so session cookies
+  // are set in this response — no implicit-grant redirect required.
   const link = await admin.auth.admin.generateLink({ type: "magiclink", email: body.email! })
-  if (!link.data.properties?.action_link) {
+  const tokenHash = link.data.properties?.hashed_token
+  if (!tokenHash) {
     return NextResponse.json({ error: "Unable to finalize session" }, { status: 500 })
   }
 
-  return NextResponse.json({ ok: true, actionLink: link.data.properties.action_link })
+  const anonClient = await createServerSupabaseClient()
+  const { error: otpError } = await anonClient.auth.verifyOtp({
+    token_hash: tokenHash,
+    type: "magiclink",
+  })
+  if (otpError) {
+    return NextResponse.json({ error: "Session creation failed" }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
 }

--- a/apps/web/lib/auth/passkeys-client.ts
+++ b/apps/web/lib/auth/passkeys-client.ts
@@ -102,9 +102,8 @@ export async function startPasskeyLogin(email?: string, trustedDeviceLabel?: str
   const verified = await verifyRes.json()
   if (!verifyRes.ok) throw new Error(verified.error || "Passkey login failed")
 
-  if (verified.actionLink) {
-    window.location.href = verified.actionLink
-  }
+  // Session cookies are now set by the verify endpoint — navigate to the app
+  window.location.href = "/channels/me"
 
   return options.policy as {
     passkey_first: boolean


### PR DESCRIPTION
Passkey and recovery-code login returned a Supabase action_link that redirected through the implicit grant flow, landing on the homepage with tokens in the hash fragment that no client code picked up.

Now verifyOtp is called server-side with the hashed_token so session cookies are set directly in the response. The client navigates to /channels/me after the verify call completes.

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved authentication navigation flow to consistently direct users to the channels section after successful recovery code redemption and passkey verification.
  * Improved session creation reliability by implementing server-side verification checks during the authentication process, ensuring session validity before finalizing login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->