### PR TITLE
fix(chat): remove optimistic message on automod block instead of show…

### DIFF
--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -1045,13 +1045,29 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
 
     if (!apiResponse.ok) {
       let errorMsg = "Your message could not be sent. Please try again."
+      let errorCode: string | undefined
       try {
         const body = await apiResponse.json()
         if (typeof body.error === "string") errorMsg = body.error
+        if (typeof body.code === "string") errorCode = body.code
       } catch {}
       if (attachments.length > 0) {
         await supabase.storage.from("attachments").remove(attachments.map((attachment) => attachment.storage_path))
       }
+
+      // AutoMod blocks/quarantines are not retriable — remove the optimistic
+      // message entirely instead of leaving a ghost "Failed" message in chat.
+      if (errorCode === "AUTOMOD_BLOCKED" || errorCode === "AUTOMOD_QUARANTINED") {
+        setAndPersistOutbox((current) => removeOutboxEntry(current, messageId))
+        setMessages((prev) => prev.filter((m) => m.id !== messageId))
+        toast({
+          variant: "destructive",
+          title: "Message blocked",
+          description: errorMsg,
+        })
+        throw new Error(errorMsg)
+      }
+
       setAndPersistOutbox((current) => updateOutboxStatus(current, messageId, {
         status: "failed",
         retryCount: 1,


### PR DESCRIPTION
…ing ghost

When AutoMod blocks a message, remove it from the message list and outbox entirely rather than marking it as "failed". Shows a single clear toast with the block reason. Prevents ghost messages with broken action buttons that error on edit/delete.

Closes #235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message handling for automatic content moderation blocks. Messages rejected by automatic content filters are now immediately removed from the chat interface instead of appearing as failed messages. Users receive a clear "Message blocked" notification explaining why the message was rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->