### PR TITLE
fix: message deletion blocked by RLS, service role client not bypassi…

### DIFF
--- a/apps/web/app/api/servers/[serverId]/channels/[channelId]/messages/[messageId]/route.ts
+++ b/apps/web/app/api/servers/[serverId]/channels/[channelId]/messages/[messageId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { createServerSupabaseClient, createServiceRoleClient } from "@/lib/supabase/server"
 import { getChannelPermissions, hasPermission } from "@/lib/permissions"
 
 // PATCH /api/servers/[serverId]/channels/[channelId]/messages/[messageId] — edit a server channel message
@@ -97,4 +97,61 @@ export async function PATCH(
     )
 
   return NextResponse.json(data)
+}
+
+// DELETE /api/servers/[serverId]/channels/[channelId]/messages/[messageId] — soft-delete a message
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ serverId: string; channelId: string; messageId: string }> }
+) {
+  const { serverId, channelId, messageId } = await params
+  const supabase = await createServerSupabaseClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  // Verify channel belongs to this server
+  const { data: channelRow } = await supabase
+    .from("channels")
+    .select("id")
+    .eq("id", channelId)
+    .eq("server_id", serverId)
+    .single()
+
+  if (!channelRow)
+    return NextResponse.json({ error: "Channel not found" }, { status: 404 })
+
+  // Verify message exists in this channel
+  const { data: message } = await supabase
+    .from("messages")
+    .select("id, author_id")
+    .eq("id", messageId)
+    .eq("channel_id", channelId)
+    .is("deleted_at", null)
+    .single()
+
+  if (!message)
+    return NextResponse.json({ error: "Message not found" }, { status: 404 })
+
+  // Permission: author can delete own, or user needs MANAGE_MESSAGES
+  const isAuthor = message.author_id === user.id
+  if (!isAuthor) {
+    const { isAdmin, permissions } = await getChannelPermissions(supabase, serverId, channelId, user.id)
+    if (!isAdmin && !hasPermission(permissions, "MANAGE_MESSAGES")) {
+      return NextResponse.json({ error: "You can only delete your own messages" }, { status: 403 })
+    }
+  }
+
+  // Use service role to bypass RLS for the soft-delete update
+  const admin = await createServiceRoleClient()
+  const { error } = await admin
+    .from("messages")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("id", messageId)
+
+  if (error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+
+  return NextResponse.json({ ok: true })
 }

--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -1060,11 +1060,6 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
       if (errorCode === "AUTOMOD_BLOCKED" || errorCode === "AUTOMOD_QUARANTINED") {
         setAndPersistOutbox((current) => removeOutboxEntry(current, messageId))
         setMessages((prev) => prev.filter((m) => m.id !== messageId))
-        toast({
-          variant: "destructive",
-          title: "Message blocked",
-          description: errorMsg,
-        })
         throw new Error(errorMsg)
       }
 
@@ -1534,15 +1529,12 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
                         )
                       }}
                       onDelete={async () => {
-                        const { data, error } = await supabase
-                          .from("messages")
-                          .update({ deleted_at: new Date().toISOString() })
-                          .eq("id", message.id)
-                          .eq("author_id", currentUserId)
-                          .select("id")
-                        if (error) throw error
-                        if (!data || data.length === 0) {
-                          throw new Error("Message could not be deleted. It may have already been removed.")
+                        const res = await fetch(`/api/servers/${serverId}/channels/${channel.id}/messages/${message.id}`, {
+                          method: "DELETE",
+                        })
+                        if (!res.ok) {
+                          const data = await res.json().catch(() => ({ error: "Failed to delete message" }))
+                          throw new Error(data.error || "Failed to delete message")
                         }
                         setMessages((prev) => prev.filter((m) => m.id !== message.id))
                         setAndPersistOutbox((current) => removeOutboxEntry(current, message.id))

--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -435,7 +435,6 @@ export const MessageItem = memo(function MessageItem({
     try {
       await onDelete()
       setShowDeleteDialog(false)
-      toast({ title: "Message deleted" })
     } catch (error: any) {
       toast({ variant: "destructive", title: "Failed to delete message", description: error?.message ?? "Please try again." })
     }
@@ -993,7 +992,7 @@ export const MessageItem = memo(function MessageItem({
                 </button>
               )}
 
-              {isOwn && (
+              {(isOwn || canManageMessages) && (
                 <button
                   onClick={() => setShowDeleteDialog(true)}
                   className="motion-interactive motion-press w-8 h-8 flex items-center justify-center hover:bg-red-500/20 focus-ring"
@@ -1084,7 +1083,7 @@ export const MessageItem = memo(function MessageItem({
             </ContextMenuItem>
           </>
         )}
-        {isOwn && (
+        {(isOwn || canManageMessages) && (
           <>
             <ContextMenuSeparator />
             <ContextMenuItem variant="destructive" onClick={() => setShowDeleteDialog(true)}>

--- a/apps/web/lib/supabase/server.ts
+++ b/apps/web/lib/supabase/server.ts
@@ -1,5 +1,6 @@
 import { cache } from "react"
 import { createServerClient } from "@supabase/ssr"
+import { createClient } from "@supabase/supabase-js"
 import { cookies } from "next/headers"
 import type { Database } from "@/types/database"
 
@@ -37,24 +38,9 @@ export async function createServerSupabaseClient() {
 
 /** Creates a Supabase client with the service-role key, bypassing RLS. Use only for admin operations. */
 export async function createServiceRoleClient() {
-  const cookieStore = await cookies()
-
-  return createServerClient<Database>(
+  return createClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return cookieStore.getAll()
-        },
-        setAll(cookiesToSet) {
-          try {
-            cookiesToSet.forEach(({ name, value, options }) =>
-              cookieStore.set(name, value, options)
-            )
-          } catch {}
-        },
-      },
-    }
+    { auth: { persistSession: false } }
   )
 }

--- a/supabase/migrations/00002_rls_policies.sql
+++ b/supabase/migrations/00002_rls_policies.sql
@@ -234,8 +234,26 @@ CREATE POLICY "Authors can edit own messages"
   WITH CHECK (author_id = auth.uid());
 
 -- Soft delete: authors and moderators can set deleted_at
-CREATE POLICY "Authors and moderators can delete messages"
+CREATE POLICY "Authors and moderators can soft delete messages"
   ON public.messages FOR UPDATE
+  USING (
+    author_id = auth.uid() OR
+    EXISTS (
+      SELECT 1 FROM public.channels c
+      WHERE c.id = channel_id AND public.has_permission(c.server_id, 4) -- MANAGE_MESSAGES
+    )
+  )
+  WITH CHECK (
+    author_id = auth.uid() OR
+    EXISTS (
+      SELECT 1 FROM public.channels c
+      WHERE c.id = channel_id AND public.has_permission(c.server_id, 4) -- MANAGE_MESSAGES
+    )
+  );
+
+-- Hard delete: authors can remove own messages, moderators can remove any
+CREATE POLICY "Authors and moderators can hard delete messages"
+  ON public.messages FOR DELETE
   USING (
     author_id = auth.uid() OR
     EXISTS (

--- a/supabase/migrations/00052_messages_delete_policy.sql
+++ b/supabase/migrations/00052_messages_delete_policy.sql
@@ -1,0 +1,48 @@
+-- Fix: Add missing DELETE policy on messages table
+-- Without this, hard deletes (used in forum/announcement/media channels and threads)
+-- are blocked by RLS for all users.
+
+-- Also add a WITH CHECK to the soft-delete UPDATE policy to ensure moderators
+-- can set deleted_at on other users' messages without being blocked.
+
+-- Hard delete: authors can remove own messages, moderators/owners can remove any
+DROP POLICY IF EXISTS "Authors and moderators can hard delete messages" ON public.messages;
+CREATE POLICY "Authors and moderators can hard delete messages"
+  ON public.messages FOR DELETE
+  USING (
+    author_id = auth.uid() OR
+    EXISTS (
+      SELECT 1 FROM public.channels c
+      WHERE c.id = channel_id AND public.has_permission(c.server_id, 4) -- MANAGE_MESSAGES
+    )
+  );
+
+-- The existing "Authors and moderators can delete messages" UPDATE policy lacks
+-- a WITH CHECK, and the "Authors can edit own messages" policy's WITH CHECK
+-- (author_id = auth.uid()) can block moderator soft-deletes in some Postgres
+-- versions. Replace both UPDATE policies with a single unified one.
+
+DROP POLICY IF EXISTS "Authors can edit own messages" ON public.messages;
+DROP POLICY IF EXISTS "Authors and moderators can delete messages" ON public.messages;
+
+CREATE POLICY "Authors can edit own messages"
+  ON public.messages FOR UPDATE
+  USING (author_id = auth.uid())
+  WITH CHECK (author_id = auth.uid());
+
+CREATE POLICY "Authors and moderators can soft delete messages"
+  ON public.messages FOR UPDATE
+  USING (
+    author_id = auth.uid() OR
+    EXISTS (
+      SELECT 1 FROM public.channels c
+      WHERE c.id = channel_id AND public.has_permission(c.server_id, 4) -- MANAGE_MESSAGES
+    )
+  )
+  WITH CHECK (
+    author_id = auth.uid() OR
+    EXISTS (
+      SELECT 1 FROM public.channels c
+      WHERE c.id = channel_id AND public.has_permission(c.server_id, 4) -- MANAGE_MESSAGES
+    )
+  );


### PR DESCRIPTION
…ng RLS

- Add DELETE API route for server channel messages with server-side permission checks (author or MANAGE_MESSAGES)
- Fix createServiceRoleClient to use createClient instead of createServerClient — the SSR variant was injecting user cookies, preventing actual RLS bypass
- Add FOR DELETE RLS policy on messages table and explicit WITH CHECK on soft-delete UPDATE policy
- Update message-item UI to show delete for moderators (isOwn || canManageMessages)
- Remove unnecessary success toast on delete and automod block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Moderators and channel managers can now delete messages in addition to message authors.

* **Improvements**
  * Message deletion now enforces proper permission validation via API.
  * Removed "Message deleted" success notification after deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->