### PR TITLE
refactor: rename middleware.ts to proxy.ts for Next.js 16 convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+## VortexChat Hardening Sprint (Active)
+
+- We are closing Tier 1 and Tier 2 gaps from docs/mvp-core-features.md
+- That file is the SINGLE SOURCE OF TRUTH — update it when completing any feature
+- Stack: Next.js App Router, TypeScript, Supabase, Socket.IO, WebRTC, pnpm monorepo
+- Monorepo structure: apps/web (Next.js frontend + API routes), packages/shared (types, permissions, utilities), signal server (Socket.IO for voice/WebRTC)
+- Import permissions from @vortex/shared — never hardcode permission bits
+- Every new API endpoint needs permission checks using existing proxy/auth patterns
+- Every moderation action needs audit logging
+- Follow existing patterns — look before you build
+- `proxy.ts` is the correct file for request interception (Next.js 16 renamed `middleware.ts` → `proxy.ts`, exported function `middleware` → `proxy`). Do NOT create or reference `middleware.ts`.

--- a/apps/web/lib/supabase/server.ts
+++ b/apps/web/lib/supabase/server.ts
@@ -28,7 +28,7 @@ export async function createServerSupabaseClient() {
               cookieStore.set(name, value, options)
             )
           } catch {
-            // Called from a Server Component — middleware handles session refresh.
+            // Called from a Server Component — proxy handles session refresh.
           }
         },
       },

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -19,7 +19,7 @@ const PUBLIC_ROUTES = [
   "/auth/callback",
 ]
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname
 
   // Machine-to-machine endpoints — pass through with zero Supabase overhead


### PR DESCRIPTION
- Rename apps/web/middleware.ts → apps/web/proxy.ts
- Rename exported function middleware → proxy
- Update CLAUDE.md to document proxy.ts convention
- Update server.ts comment referencing middleware → proxy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive architectural documentation outlining patterns and best practices.

* **Chores**
  * Updated internal infrastructure comments and naming conventions for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->