### PR TITLE
feat: channel and server muting with notification settings

### DIFF
--- a/apps/web/components/layout/app-provider.tsx
+++ b/apps/web/components/layout/app-provider.tsx
@@ -17,8 +17,8 @@ interface AppProviderProps {
 
 /** Root client-side provider that seeds Zustand stores, syncs presence, applies appearance settings, and registers push notifications. */
 export function AppProvider({ user, servers, children }: AppProviderProps) {
-  const { setCurrentUser, setServers, setIsLoadingServers } = useAppStore(
-    useShallow((s) => ({ setCurrentUser: s.setCurrentUser, setServers: s.setServers, setIsLoadingServers: s.setIsLoadingServers }))
+  const { setCurrentUser, setServers, setIsLoadingServers, loadNotificationSettings } = useAppStore(
+    useShallow((s) => ({ setCurrentUser: s.setCurrentUser, setServers: s.setServers, setIsLoadingServers: s.setIsLoadingServers, loadNotificationSettings: s.loadNotificationSettings }))
   )
   const { messageDisplay, fontScale, saturation, themePreset, customCss, hydrateFromSettings } = useAppearanceStore(
     useShallow((s) => ({ messageDisplay: s.messageDisplay, fontScale: s.fontScale, saturation: s.saturation, themePreset: s.themePreset, customCss: s.customCss, hydrateFromSettings: s.hydrateFromSettings }))
@@ -29,7 +29,8 @@ export function AppProvider({ user, servers, children }: AppProviderProps) {
     setServers(servers)
     setIsLoadingServers(false)
     hydrateFromSettings(user?.appearance_settings as Parameters<typeof hydrateFromSettings>[0], user?.id ?? null)
-  }, [user, servers, setCurrentUser, setServers, setIsLoadingServers, hydrateFromSettings])
+    if (user) void loadNotificationSettings()
+  }, [user, servers, setCurrentUser, setServers, setIsLoadingServers, hydrateFromSettings, loadNotificationSettings])
 
   // Apply appearance data-attributes to <html> so CSS selectors can pick them up
   useEffect(() => {

--- a/apps/web/components/layout/channel-sidebar.tsx
+++ b/apps/web/components/layout/channel-sidebar.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation"
 import {
   Hash, Volume2, ChevronDown, ChevronRight,
   Plus, Clipboard, Pencil, Trash2, MessageSquare, Mic2, Megaphone, Image, Clock, GripVertical, CalendarDays, MessageCircle,
-  MicOff, Headphones
+  MicOff, Headphones, Bell, BellOff
 } from "lucide-react"
 import {
   DndContext,
@@ -43,6 +43,7 @@ const CreateChannelModal = dynamic(() => import("@/components/modals/create-chan
 const EditChannelModal = dynamic(() => import("@/components/modals/edit-channel-modal").then((m) => ({ default: m.EditChannelModal })))
 const ServerSettingsModal = dynamic(() => import("@/components/modals/server-settings-modal").then((m) => ({ default: m.ServerSettingsModal })))
 const QuickSwitcherModal = dynamic(() => import("@/components/modals/quickswitcher-modal").then((m) => ({ default: m.QuickSwitcherModal })))
+const NotificationSettingsModal = dynamic(() => import("@/components/modals/notification-settings-modal").then((m) => ({ default: m.NotificationSettingsModal })))
 const SearchModal = dynamic(() => import("@/components/modals/search-modal").then((m) => ({ default: m.SearchModal })))
 const KeyboardShortcutsModal = dynamic(() => import("@/components/modals/keyboard-shortcuts-modal").then((m) => ({ default: m.KeyboardShortcutsModal })))
 import { PERMISSIONS, hasPermission } from "@vortex/shared"
@@ -1188,7 +1189,10 @@ function SortableChannelItem({
 }) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: channel.id })
   const { toast } = useToast()
-  const showBadge = !isActive && (isUnread || (mentionCount ?? 0) > 0)
+  const notificationMode = useAppStore((s) => s.notificationModes[channel.id])
+  const isMuted = notificationMode === "muted"
+  const [showNotifSettings, setShowNotifSettings] = useState(false)
+  const showBadge = !isActive && !isMuted && (isUnread || (mentionCount ?? 0) > 0)
 
   // Live countdown for temporary channels
   const [timeRemaining, setTimeRemaining] = useState<string | null>(
@@ -1257,9 +1261,12 @@ function SortableChannelItem({
               </span>
             )}
             <ChannelIcon channel={channel} isVoiceActive={isVoiceActive} />
-            <span className={cn("truncate flex-1", isUnread && !isActive ? "font-semibold" : "")}>
+            <span className={cn("truncate flex-1", isMuted && "opacity-50", isUnread && !isActive && !isMuted ? "font-semibold" : "")}>
               {channel.name}
             </span>
+            {isMuted && (
+              <BellOff className="w-3 h-3 flex-shrink-0 opacity-40" />
+            )}
             <span className="ml-auto flex items-center gap-1 flex-shrink-0 tertiary-metadata">
               {timeRemaining && (
                 <Tooltip>
@@ -1308,6 +1315,9 @@ function SortableChannelItem({
               <ContextMenuSeparator />
             </>
           )}
+          <ContextMenuItem onClick={() => setShowNotifSettings(true)}>
+            <Bell className="w-4 h-4 mr-2" /> Notification Settings
+          </ContextMenuItem>
           <ContextMenuItem onClick={() => {
             navigator.clipboard.writeText(channel.id)
             toast({ title: "Channel ID copied!" })
@@ -1327,6 +1337,13 @@ function SortableChannelItem({
           )}
         </ContextMenuContent>
       </ContextMenu>
+
+      <NotificationSettingsModal
+        open={showNotifSettings}
+        onClose={() => setShowNotifSettings(false)}
+        channelId={channel.id}
+        label={`#${channel.name}`}
+      />
 
       {/* Voice participants listed under voice channels */}
       {voiceParticipants && voiceParticipants.length > 0 && (

--- a/apps/web/components/layout/server-sidebar.tsx
+++ b/apps/web/components/layout/server-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation"
 import Link from "next/link"
-import { Plus, Compass, Clipboard, LogOut, UserPlus } from "lucide-react"
+import { Plus, Compass, Clipboard, LogOut, UserPlus, Bell, BellOff } from "lucide-react"
 import { useAppStore } from "@/lib/stores/app-store"
 import { useShallow } from "zustand/react/shallow"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils/cn"
 import type { ServerRow } from "@/types/database"
 import { VortexLogo } from "@/components/ui/vortex-logo"
 import { Skeleton } from "@/components/ui/skeleton"
+import { NotificationSettingsModal } from "@/components/modals/notification-settings-modal"
 import Image from "next/image"
 
 /** Vertical icon strip listing joined servers, DM shortcut, and create/discover actions. */
@@ -190,6 +191,9 @@ function ServerIcon({
   onLeave: () => void
 }) {
   const { toast } = useToast()
+  const notificationMode = useAppStore((s) => s.notificationModes[server.id])
+  const isMuted = notificationMode === "muted"
+  const [showNotifSettings, setShowNotifSettings] = useState(false)
   const initials = server.name
     .split(" ")
     .map((w) => w[0])
@@ -206,6 +210,7 @@ function ServerIcon({
   }, [])
 
   return (
+    <>
     <ContextMenu>
       <Tooltip>
         <TooltipTrigger asChild>
@@ -248,8 +253,15 @@ function ServerIcon({
                 )}
               </div>
 
-              {/* Unread pip — shown when the server has unread channels and is not active */}
-              {hasUnread && !isActive && (
+              {/* Muted indicator */}
+              {isMuted && (
+                <div className="absolute -bottom-0.5 -right-0.5 w-[16px] h-[16px] rounded-full flex items-center justify-center pointer-events-none" style={{ background: "var(--theme-bg-tertiary)" }}>
+                  <BellOff className="w-2.5 h-2.5" style={{ color: "var(--theme-text-muted)" }} />
+                </div>
+              )}
+
+              {/* Unread pip — shown when the server has unread channels and is not active/muted */}
+              {hasUnread && !isActive && !isMuted && (
                 <div
                   className="absolute -bottom-0.5 -right-0.5 min-w-[14px] h-[14px] rounded-full border-2 pointer-events-none server-sidebar-unread-pip"
                 />
@@ -261,6 +273,10 @@ function ServerIcon({
       </Tooltip>
 
       <ContextMenuContent className="w-48">
+        <ContextMenuItem onClick={() => setShowNotifSettings(true)}>
+          <Bell className="w-4 h-4 mr-2" /> Notification Settings
+        </ContextMenuItem>
+        <ContextMenuSeparator />
         <ContextMenuItem onClick={() => {
           navigator.clipboard.writeText(server.invite_code)
           toast({ title: "Invite code copied!" })
@@ -286,5 +302,13 @@ function ServerIcon({
         )}
       </ContextMenuContent>
     </ContextMenu>
+
+    <NotificationSettingsModal
+      open={showNotifSettings}
+      onClose={() => setShowNotifSettings(false)}
+      serverId={server.id}
+      label={server.name}
+    />
+    </>
   )
 }

--- a/apps/web/components/modals/notification-settings-modal.tsx
+++ b/apps/web/components/modals/notification-settings-modal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react"
 import { Bell, BellOff, AtSign, Loader2 } from "lucide-react"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { useAppStore } from "@/lib/stores/app-store"
 
 type Mode = "all" | "mentions" | "muted"
 
@@ -24,9 +25,12 @@ export function NotificationSettingsModal({ open, onClose, serverId, channelId, 
   const [mode, setMode] = useState<Mode>("all")
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
+  const setNotificationMode = useAppStore((s) => s.setNotificationMode)
+  const removeNotificationMode = useAppStore((s) => s.removeNotificationMode)
 
   useEffect(() => {
     if (!open) return
+    setLoading(true)
     const param = serverId ? `serverId=${serverId}` : `channelId=${channelId}`
     fetch(`/api/notification-settings?${param}`)
       .then((r) => r.json())
@@ -41,6 +45,11 @@ export function NotificationSettingsModal({ open, onClose, serverId, channelId, 
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ serverId, channelId, mode: newMode }),
     })
+    const entityId = serverId || channelId
+    if (entityId) {
+      if (newMode === "all") removeNotificationMode(entityId)
+      else setNotificationMode(entityId, newMode)
+    }
     setSaving(false)
     onClose()
   }

--- a/apps/web/lib/stores/app-store.ts
+++ b/apps/web/lib/stores/app-store.ts
@@ -102,6 +102,13 @@ interface AppState {
   dmUnreadCount: number
   setDmUnreadCount: (count: number) => void
 
+  // Notification mute state (synced from notification_settings table)
+  // Maps entity ID -> mode for quick lookup
+  notificationModes: Record<string, "all" | "mentions" | "muted">
+  setNotificationMode: (entityId: string, mode: "all" | "mentions" | "muted") => void
+  removeNotificationMode: (entityId: string) => void
+  loadNotificationSettings: () => Promise<void>
+
   // Voice state
   voiceChannelId: string | null
   voiceServerId: string | null
@@ -204,6 +211,34 @@ export const useAppStore = create<AppState>((set) => ({
   setNotificationUnreadCount: (count) => set({ notificationUnreadCount: count }),
   dmUnreadCount: 0,
   setDmUnreadCount: (count) => set({ dmUnreadCount: count }),
+
+  notificationModes: {},
+  setNotificationMode: (entityId, mode) =>
+    set((state) => ({
+      notificationModes: { ...state.notificationModes, [entityId]: mode },
+    })),
+  removeNotificationMode: (entityId) =>
+    set((state) => {
+      const next = { ...state.notificationModes }
+      delete next[entityId]
+      return { notificationModes: next }
+    }),
+  loadNotificationSettings: async () => {
+    try {
+      const res = await fetch("/api/notification-settings")
+      if (!res.ok) return
+      const rows = await res.json()
+      if (!Array.isArray(rows)) return
+      const modes: Record<string, "all" | "mentions" | "muted"> = {}
+      for (const row of rows) {
+        const id = row.server_id || row.channel_id || row.thread_id
+        if (id && row.mode) modes[id] = row.mode
+      }
+      set({ notificationModes: modes })
+    } catch {
+      // Non-critical — mute indicators just won't show
+    }
+  },
 
   voiceChannelId: null,
   voiceServerId: null,


### PR DESCRIPTION
## Summary
- Wire up the existing `NotificationSettingsModal` into channel and server right-click context menus
- Add `notificationModes` map to Zustand store, fetched on login from `/api/notification-settings`
- Show visual mute indicators: dimmed channel name + BellOff icon, server icon BellOff badge
- Suppress unread badges/pips for muted channels and servers
- Store updates instantly on modal save for immediate UI feedback

## How it works
Right-click any channel or server to access **Notification Settings**, which offers three modes:

| Mode | Behavior |
|------|----------|
| **All Messages** | Default — notifications for every message |
| **Mentions Only** | Only notified when @mentioned |
| **Muted** | No notifications, visual indicators dimmed |

Settings are stored in the `notification_settings` table with precedence: thread > channel > server > global default. Push notifications already respect these settings via `resolveNotification()` in `lib/push.ts`.

## Test plan
- [ ] Right-click a channel — "Notification Settings" appears in context menu
- [ ] Right-click a server icon — "Notification Settings" appears in context menu
- [ ] Set a channel to "Muted" — channel name dims and BellOff icon appears
- [ ] Set a server to "Muted" — small BellOff badge appears on server icon
- [ ] Muted channels suppress unread dots and mention badges
- [ ] Muted servers suppress the unread pip
- [ ] Change back to "All Messages" — indicators disappear immediately
- [ ] Refresh the page — mute state persists (loaded from API)

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-channel notification settings: users can now mute or customize notifications for individual channels.
  * Added per-server notification settings: users can now manage notification modes for specific servers.
  * Visual mute indicators: muted channels and servers display a bell-off icon for easy identification.
  * New "Notification Settings" option in context menus for channels and servers to configure notification preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->