### PR TITLE
fix: atomic RPC for channel reorder, remove time-based sync hack

### DIFF
--- a/apps/web/components/layout/channel-sidebar.tsx
+++ b/apps/web/components/layout/channel-sidebar.tsx
@@ -249,11 +249,6 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
   const containerIndexRef = useRef<Record<string, string>>({})
   const isDraggingRef = useRef(false)
   isDraggingRef.current = activeId !== null
-  // After a drag-end reorder, suppress the sync effect briefly.
-  // handleDragEnd already set items to the correct order; realtime echoes
-  // trigger multiple sync firings that can overwrite items before all
-  // position updates propagate through the store.
-  const skipSyncUntilRef = useRef(0)
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
@@ -305,16 +300,24 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
   }, [server.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Sync items when channels change (store update, realtime event, etc.).
-  // After a drag-end reorder, skip syncing for a brief window — handleDragEnd
-  // already set items to the correct order, and realtime echoes from the
-  // individual Supabase updates can trigger multiple sync firings before all
-  // positions have propagated.
+  // Compare before overwriting to prevent no-op updates from realtime echoes
+  // that confirm the same order we already have locally.
   useEffect(() => {
-    if (Date.now() < skipSyncUntilRef.current) return
+    const next = buildItems(grouped)
     if (isDraggingRef.current) {
-      setItems((prev) => mergeItemsPreservingOrder(prev, buildItems(grouped)))
+      setItems((prev) => mergeItemsPreservingOrder(prev, next))
     } else {
-      setItems(buildItems(grouped))
+      setItems((prev) => {
+        const prevKeys = Object.keys(prev).sort()
+        const nextKeys = Object.keys(next).sort()
+        if (prevKeys.length !== nextKeys.length || prevKeys.some((k, i) => k !== nextKeys[i])) return next
+        for (const key of prevKeys) {
+          const a = prev[key]
+          const b = next[key]
+          if (!a || !b || a.length !== b.length || a.some((id, i) => id !== b[i])) return next
+        }
+        return prev
+      })
     }
   }, [grouped])
 
@@ -629,12 +632,10 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
         itemsRef.current = next
         containerIndexRef.current = buildContainerIndex(next)
         setItems(next)
-        skipSyncUntilRef.current = Date.now() + 2000
         persistChannelOrder()
       }
     } else {
       // Cross-container move was already applied in handleDragOver; persist
-      skipSyncUntilRef.current = Date.now() + 2000
       persistChannelOrder()
     }
   }
@@ -686,13 +687,11 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
 
     const supabase = createClientSupabaseClient()
     try {
-      const results = await Promise.all(
-        updates.map(({ id, position, parent_id }) =>
-          supabase.from("channels").update({ position, parent_id }).eq("id", id)
-        )
-      )
-      const failed = results.find(({ error }) => error)
-      if (failed?.error) throw failed.error
+      const { error } = await supabase.rpc("reorder_channels", {
+        p_server_id: server.id,
+        p_updates: updates.map(({ id, position, parent_id }) => ({ id, position, parent_id })),
+      })
+      if (error) throw error
     } catch (error: any) {
       // Rollback: restore previous positions in a single store update
       const rollbackMap = new Map(previous.map(({ id, position, parent_id }) => [id, { position, parent_id }]))

--- a/apps/web/types/database.ts
+++ b/apps/web/types/database.ts
@@ -2514,6 +2514,10 @@ export type Database = {
         Args: { p_rule_id: string }
         Returns: void
       }
+      reorder_channels: {
+        Args: { p_server_id: string; p_updates: Json }
+        Returns: undefined
+      }
     }
     Enums: {
       app_trust_badge: 'verified' | 'partner' | 'internal'

--- a/supabase/migrations/00053_reorder_channels_rpc.sql
+++ b/supabase/migrations/00053_reorder_channels_rpc.sql
@@ -1,0 +1,30 @@
+-- Atomic channel reorder: accepts a JSON array of {id, position, parent_id}
+-- and updates all rows in a single transaction. This avoids N individual
+-- updates that each trigger a realtime event, replacing them with one
+-- atomic operation.
+CREATE OR REPLACE FUNCTION public.reorder_channels(
+  p_server_id UUID,
+  p_updates JSONB
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  item JSONB;
+BEGIN
+  FOR item IN SELECT * FROM jsonb_array_elements(p_updates)
+  LOOP
+    UPDATE public.channels
+    SET
+      position = (item->>'position')::int,
+      parent_id = CASE
+        WHEN item->>'parent_id' IS NULL OR item->>'parent_id' = 'null' THEN NULL
+        ELSE (item->>'parent_id')::uuid
+      END
+    WHERE id = (item->>'id')::uuid
+      AND server_id = p_server_id;
+  END LOOP;
+END;
+$$;


### PR DESCRIPTION
## Summary
- Replace N individual Supabase `.update()` calls with a single `reorder_channels` RPC that updates all channel positions atomically in one transaction
- Remove the `skipSyncUntilRef` 2-second time-based hack that suppressed sync after drag-end
- Sync effect now compares previous vs next items and skips no-op overwrites from realtime echoes

## Problem
After a channel reorder, each channel's position was updated individually via `Promise.all`. Each update triggered a Postgres realtime event, which called `updateChannel()` one at a time. During this window, intermediate states (some channels updated, others not) could produce incorrect ordering that overwrote the correct local state.

The workaround was a 2-second `skipSyncUntilRef` window that suppressed the sync effect entirely — a brittle band-aid that could miss legitimate updates.

## Solution
**Option 3 from the issue** — single atomic RPC:

| Before | After |
|--------|-------|
| N individual `.update()` calls | 1 `.rpc("reorder_channels")` call |
| N realtime events with intermediate states | 1 atomic transaction |
| 2-second time-based sync suppression | Comparison-based no-op detection |

### Migration required
`supabase/migrations/00053_reorder_channels_rpc.sql` — creates the `reorder_channels(p_server_id, p_updates)` function.

## Test plan
- [ ] Drag a channel within the same category — persists after refresh
- [ ] Drag a channel between categories — persists after refresh
- [ ] Drag a category to reorder — all children move with it, persists
- [ ] Open two tabs — reorder in one, confirm other tab gets correct final order without flicker
- [ ] Rapid successive drags — no jumps or intermediate states

Closes #265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved channel ordering synchronization to prevent unnecessary state updates during concurrent changes.
  * Enhanced error recovery with automatic rollback for failed channel reordering operations.

* **Performance**
  * Optimized channel sync mechanism to more efficiently detect actual ordering changes and reduce redundant updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->