### PR TITLE
perf: optimize server switching and rendering pipeline

### DIFF
--- a/apps/web/app/api/appeals/route.ts
+++ b/apps/web/app/api/appeals/route.ts
@@ -54,40 +54,43 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Too many submissions, please try later" }, { status: 429 })
   }
 
-  const { data: ban, error: banError } = await serviceSupabase
-    .from("server_bans")
-    .select("server_id, user_id")
-    .eq("server_id", serverId)
-    .eq("user_id", user.id)
-    .maybeSingle()
+  const thirtyDaysAgoIso = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
 
-  if (banError) return NextResponse.json({ error: banError.message }, { status: 500 })
-  if (!ban) {
+  // Run ban check, duplicate check, and 30-day count in parallel (all independent)
+  const [banResult, duplicateResult, countResult] = await Promise.all([
+    serviceSupabase
+      .from("server_bans")
+      .select("server_id, user_id")
+      .eq("server_id", serverId)
+      .eq("user_id", user.id)
+      .maybeSingle(),
+    (serviceSupabase as any)
+      .from("moderation_appeals")
+      .select("id")
+      .eq("server_id", serverId)
+      .eq("user_id", user.id)
+      .in("status", ["submitted", "reviewing"])
+      .maybeSingle(),
+    (serviceSupabase as any)
+      .from("moderation_appeals")
+      .select("id", { count: "exact", head: true })
+      .eq("server_id", serverId)
+      .eq("user_id", user.id)
+      .gte("submitted_at", thirtyDaysAgoIso),
+  ])
+
+  if (banResult.error) return NextResponse.json({ error: banResult.error.message }, { status: 500 })
+  if (!banResult.data) {
     return NextResponse.json({ error: "Appeal cannot be created" }, { status: 403 })
   }
 
-  const { data: duplicate, error: duplicateError } = await (serviceSupabase as any)
-    .from("moderation_appeals")
-    .select("id")
-    .eq("server_id", serverId)
-    .eq("user_id", user.id)
-    .in("status", ["submitted", "reviewing"])
-    .maybeSingle()
-
-  if (duplicateError) return NextResponse.json({ error: duplicateError.message }, { status: 500 })
-  if (duplicate) {
+  if (duplicateResult.error) return NextResponse.json({ error: duplicateResult.error.message }, { status: 500 })
+  if (duplicateResult.data) {
     return NextResponse.json({ error: "An active appeal already exists" }, { status: 409 })
   }
 
-  const thirtyDaysAgoIso = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
-  const { count, error: countError } = await (serviceSupabase as any)
-    .from("moderation_appeals")
-    .select("id", { count: "exact", head: true })
-    .eq("server_id", serverId)
-    .eq("user_id", user.id)
-    .gte("submitted_at", thirtyDaysAgoIso)
-
-  if (countError) return NextResponse.json({ error: countError.message }, { status: 500 })
+  if (countResult.error) return NextResponse.json({ error: countResult.error.message }, { status: 500 })
+  const count = countResult.count
 
   const antiAbuseScore = computeAntiAbuseScore({
     statement,

--- a/apps/web/app/api/dm/channels/[channelId]/members/route.ts
+++ b/apps/web/app/api/dm/channels/[channelId]/members/route.ts
@@ -11,22 +11,22 @@ export async function POST(
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
-  // Verify caller is a member
-  const { data: membership } = await supabase
-    .from("dm_channel_members")
-    .select("user_id")
-    .eq("dm_channel_id", channelId)
-    .eq("user_id", user.id)
-    .single()
+  // Verify caller membership and channel type in parallel
+  const [{ data: membership }, { data: channel }] = await Promise.all([
+    supabase
+      .from("dm_channel_members")
+      .select("user_id")
+      .eq("dm_channel_id", channelId)
+      .eq("user_id", user.id)
+      .single(),
+    supabase
+      .from("dm_channels")
+      .select("is_group")
+      .eq("id", channelId)
+      .single(),
+  ])
 
   if (!membership) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
-
-  // Only group DMs can have members added
-  const { data: channel } = await supabase
-    .from("dm_channels")
-    .select("is_group")
-    .eq("id", channelId)
-    .single()
 
   if (!channel?.is_group) {
     return NextResponse.json({ error: "Cannot add members to a 1:1 DM" }, { status: 400 })

--- a/apps/web/app/api/dm/channels/[channelId]/messages/route.ts
+++ b/apps/web/app/api/dm/channels/[channelId]/messages/route.ts
@@ -29,18 +29,7 @@ export async function POST(
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
-  // Verify membership
-  const { data: membership, error: membershipError } = await supabase
-    .from("dm_channel_members")
-    .select("user_id")
-    .eq("dm_channel_id", channelId)
-    .eq("user_id", user.id)
-    .maybeSingle()
-
-  if (membershipError) return NextResponse.json({ error: membershipError.message }, { status: 500 })
-
-  if (!membership) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
-
+  // Fetch all channel members (verifies membership and gets other member IDs in one query)
   const { data: channelMembers, error: channelMembersError } = await supabase
     .from("dm_channel_members")
     .select("user_id")
@@ -50,34 +39,48 @@ export async function POST(
     return NextResponse.json({ error: channelMembersError?.message ?? "Failed to load DM members" }, { status: 500 })
   }
 
-  for (const member of channelMembers) {
-    if (member.user_id === user.id) continue
-    try {
-      if (await isBlockedBetweenUsers(supabase as any, user.id, member.user_id)) {
-        return NextResponse.json({ error: "Cannot send messages while blocked" }, { status: 403 })
-      }
-    } catch (error) {
-      return NextResponse.json(
-        {
-          error: "Error checking block status",
-          details: error instanceof Error ? error.message : "Unknown error",
-        },
-        { status: 500 }
-      )
-    }
+  if (!channelMembers.some((member) => member.user_id === user.id)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
   }
 
-  let body: { content?: string; reply_to_id?: string }
-  try {
-    body = await req.json()
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  const otherMemberIds = channelMembers
+    .filter((member) => member.user_id !== user.id)
+    .map((member) => member.user_id)
+
+  // Run blocking checks, body parsing, and channel encryption fetch in parallel
+  const [blockCheckResult, bodyResult, channelResult] = await Promise.all([
+    Promise.all(
+      otherMemberIds.map((memberId) => isBlockedBetweenUsers(supabase as any, user.id, memberId))
+    ).then((results) => ({ blocked: results.some(Boolean), error: null as Error | null }))
+     .catch((error: Error) => ({ blocked: false, error })),
+    req.json().then((b: any) => ({ body: b as { content?: string; reply_to_id?: string }, error: null as string | null }))
+      .catch(() => ({ body: null as any, error: "Invalid JSON body" })),
+    (supabase as any)
+      .from("dm_channels")
+      .select("is_encrypted, encryption_key_version")
+      .eq("id", channelId)
+      .maybeSingle(),
+  ])
+
+  if (blockCheckResult.error) {
+    return NextResponse.json(
+      {
+        error: "Error checking block status",
+        details: blockCheckResult.error.message,
+      },
+      { status: 500 }
+    )
   }
-  const { data: channel, error: channelError } = await (supabase as any)
-    .from("dm_channels")
-    .select("is_encrypted, encryption_key_version")
-    .eq("id", channelId)
-    .maybeSingle()
+  if (blockCheckResult.blocked) {
+    return NextResponse.json({ error: "Cannot send messages while blocked" }, { status: 403 })
+  }
+
+  if (bodyResult.error) {
+    return NextResponse.json({ error: bodyResult.error }, { status: 400 })
+  }
+  const body = bodyResult.body
+
+  const { data: channel, error: channelError } = channelResult
   if (channelError || !channel) {
     return NextResponse.json({ error: "Unable to verify channel encryption" }, { status: 500 })
   }
@@ -100,12 +103,13 @@ export async function POST(
     }
   }
 
-  // Validate reply_to_id if provided
+  // Validate reply_to_id and fetch full reply data in one query (avoids redundant re-fetch after insert)
   const replyToId = body.reply_to_id ?? null
+  let replyToMessage: any = null
   if (replyToId) {
     const { data: replyTarget, error: replyError } = await supabase
       .from("direct_messages")
-      .select("id, dm_channel_id")
+      .select("id, dm_channel_id, content, sender_id, sender:users!direct_messages_sender_id_fkey(id, username, display_name, avatar_url, status)")
       .eq("id", replyToId)
       .is("deleted_at", null)
       .single()
@@ -116,6 +120,7 @@ export async function POST(
     if (replyTarget.dm_channel_id !== channelId) {
       return NextResponse.json({ error: "Replied-to message must be in the same channel" }, { status: 400 })
     }
+    replyToMessage = replyTarget
   }
 
   const { data: message, error } = await supabase
@@ -130,19 +135,6 @@ export async function POST(
     .single()
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
-
-  // Fetch reply_to message info if this is a reply (use replyToId since reply_to_id is not in generated types yet)
-  let replyToMessage = null
-  if (replyToId) {
-    const { data: replyMsg } = await supabase
-      .from("direct_messages")
-      .select("id, content, sender_id, sender:users!direct_messages_sender_id_fkey(id, username, display_name, avatar_url, status)")
-      .eq("id", replyToId)
-      .eq("dm_channel_id", channelId)
-      .is("deleted_at", null)
-      .single()
-    replyToMessage = replyMsg ?? null
-  }
 
   // Send push notifications (fire-and-forget)
   const senderName = (message as any)?.sender?.display_name || (message as any)?.sender?.username || "Someone"

--- a/apps/web/app/api/dm/channels/route.ts
+++ b/apps/web/app/api/dm/channels/route.ts
@@ -136,17 +136,21 @@ export async function POST(req: NextRequest) {
   if (!isGroup) {
     const partnerId = userIds[0] as string
 
-    // Find existing 1:1 channel between current user and partner
-    const { data: userMems, error: userMemsError } = await supabase
-      .from("dm_channel_members")
-      .select("dm_channel_id")
-      .eq("user_id", user.id)
+    // Find existing 1:1 channel between current user and partner — fetch in parallel
+    const [
+      { data: userMems, error: userMemsError },
+      { data: partnerMems, error: partnerMemsError },
+    ] = await Promise.all([
+      supabase
+        .from("dm_channel_members")
+        .select("dm_channel_id")
+        .eq("user_id", user.id),
+      supabase
+        .from("dm_channel_members")
+        .select("dm_channel_id")
+        .eq("user_id", partnerId),
+    ])
     if (userMemsError) return NextResponse.json({ error: userMemsError.message }, { status: 500 })
-
-    const { data: partnerMems, error: partnerMemsError } = await supabase
-      .from("dm_channel_members")
-      .select("dm_channel_id")
-      .eq("user_id", partnerId)
     if (partnerMemsError) return NextResponse.json({ error: partnerMemsError.message }, { status: 500 })
 
     const userChannelIds = new Set((userMems ?? []).map((m) => m.dm_channel_id))

--- a/apps/web/app/api/dm/route.ts
+++ b/apps/web/app/api/dm/route.ts
@@ -10,18 +10,19 @@ export async function GET(request: Request) {
   const partnerId = searchParams.get("partnerId")
 
   if (!partnerId) {
-    // Return all DM conversations (latest message per partner)
-    const { data: sent } = await supabase
-      .from("direct_messages")
-      .select("receiver_id, created_at")
-      .eq("sender_id", user.id)
-      .order("created_at", { ascending: false })
-
-    const { data: received } = await supabase
-      .from("direct_messages")
-      .select("sender_id, created_at")
-      .eq("receiver_id", user.id)
-      .order("created_at", { ascending: false })
+    // Return all DM conversations (latest message per partner) — fetch in parallel
+    const [{ data: sent }, { data: received }] = await Promise.all([
+      supabase
+        .from("direct_messages")
+        .select("receiver_id, created_at")
+        .eq("sender_id", user.id)
+        .order("created_at", { ascending: false }),
+      supabase
+        .from("direct_messages")
+        .select("sender_id, created_at")
+        .eq("receiver_id", user.id)
+        .order("created_at", { ascending: false }),
+    ])
 
     const partnerIds = new Set<string>([
       ...(sent?.map((m) => m.receiver_id).filter((id): id is string => id !== null) ?? []),

--- a/apps/web/app/api/messages/route.ts
+++ b/apps/web/app/api/messages/route.ts
@@ -353,8 +353,8 @@ async function runServerAutomodChecks({
   if (alertChannels.length > 0 && !dryRun) {
     createServiceRoleClient()
       .then((serviceSupabase) => {
-        for (const alertChannelId of alertChannels) {
-          Promise.resolve(
+        Promise.all(
+          alertChannels.map((alertChannelId) =>
             serviceSupabase
               .from("messages")
               .insert({
@@ -374,8 +374,8 @@ async function runServerAutomodChecks({
                   changes: { channel_id: alertChannelId, reason: violations[0].reason },
                 })
               )
-          ).catch(() => {})
-        }
+          )
+        ).catch(() => {})
       })
       .catch(() => {})
   }

--- a/apps/web/app/channels/[serverId]/[channelId]/page.tsx
+++ b/apps/web/app/channels/[serverId]/[channelId]/page.tsx
@@ -6,9 +6,9 @@ import { AnnouncementChannel } from "@/components/channels/announcement-channel"
 import { ForumChannel } from "@/components/channels/forum-channel"
 import { MediaChannel } from "@/components/channels/media-channel"
 import { hydrateReplyTo, MESSAGE_PROJECTION } from "@/lib/messages/hydration"
-import { computePermissions, hasPermission } from "@vortex/shared"
-import { getChannelPermissions } from "@/lib/permissions"
+import { PERMISSIONS, computePermissions, hasPermission } from "@vortex/shared"
 import type { RoleRow } from "@/types/database"
+import { perfTimer } from "@/lib/perf"
 
 interface Props {
   params: Promise<{ serverId: string; channelId: string }>
@@ -23,6 +23,7 @@ const VOICE_CHANNEL_TYPES = ["voice", "stage"] as const
 /** Server-rendered channel page that fetches channel data, messages, and read-state, then delegates to the appropriate channel-type component. */
 export default async function ChannelPage({ params: paramsPromise }: Props) {
   const params = await paramsPromise
+  const pageTimer = perfTimer(`channel-page total [${params.channelId.slice(0, 8)}]`)
 
   const [supabase, { data: { user }, error }] = await Promise.all([
     createServerSupabaseClient(),
@@ -31,8 +32,20 @@ export default async function ChannelPage({ params: paramsPromise }: Props) {
 
   if (error || !user) redirect("/login")
 
-  // Fetch channel, messages, read-state, server ownership, and member roles in parallel
-  const [{ data: channel }, { data: messagesData }, { data: readState }, { data: server }, { data: memberRoles }] = await Promise.all([
+  // Fetch channel, messages, read-state, server ownership, member roles, default role,
+  // and channel permission overrides — ALL in one parallel block.
+  // Previously getChannelPermissions() ran sequentially after this block and re-queried
+  // server ownership + member_roles (5 redundant queries eliminated).
+  const queryTimer = perfTimer("channel-page queries")
+  const [
+    { data: channel },
+    { data: messagesData },
+    { data: readState },
+    { data: server },
+    { data: memberRoles },
+    { data: defaultRole },
+    { data: channelOverwrites },
+  ] = await Promise.all([
     supabase
       .from("channels")
       .select("*")
@@ -62,30 +75,60 @@ export default async function ChannelPage({ params: paramsPromise }: Props) {
       .select("role_id, roles(*)")
       .eq("server_id", params.serverId)
       .eq("user_id", user.id),
+    supabase
+      .from("roles")
+      .select("id")
+      .eq("server_id", params.serverId)
+      .eq("is_default", true)
+      .maybeSingle(),
+    supabase
+      .from("channel_permissions")
+      .select("role_id, allow_permissions, deny_permissions")
+      .eq("channel_id", params.channelId),
   ])
+
+  queryTimer.end()
 
   if (!channel) notFound()
 
-  // Compute canManageMessages server-side (avoids 2 client-side Supabase queries)
+  // Compute permissions synchronously from the already-fetched data
   const isOwner = server?.owner_id === user.id
   type MemberRoleWithRole = { role_id: string; roles: RoleRow | null }
-  const roleBitmasks = ((memberRoles ?? []) as unknown as MemberRoleWithRole[])
-    .map((mr) => mr.roles?.permissions ?? 0)
+  const typedMemberRoles = (memberRoles ?? []) as unknown as MemberRoleWithRole[]
+  const roleBitmasks = typedMemberRoles.map((mr) => mr.roles?.permissions ?? 0)
   const effectivePerms = computePermissions(roleBitmasks)
+  const isAdmin = isOwner || !!(effectivePerms & PERMISSIONS.ADMINISTRATOR)
   const canManageMessages = isOwner || hasPermission(effectivePerms, "MANAGE_MESSAGES")
-  const channelPerms = await getChannelPermissions(supabase, params.serverId, params.channelId, user.id)
-  const canSendMessages = channelPerms.isAdmin || hasPermission(channelPerms.permissions, "SEND_MESSAGES")
+
+  // Apply channel-level permission overwrites (deny first, then allow)
+  let channelPerms = effectivePerms
+  if (!isAdmin) {
+    const roleIds = new Set(typedMemberRoles.map((mr) => mr.role_id))
+    if (defaultRole?.id) roleIds.add(defaultRole.id)
+    if (roleIds.size > 0) {
+      const relevant = (channelOverwrites ?? []).filter((row) => roleIds.has(row.role_id))
+      const denyMask = relevant.reduce((acc, row) => acc | (row.deny_permissions ?? 0), 0)
+      const allowMask = relevant.reduce((acc, row) => acc | (row.allow_permissions ?? 0), 0)
+      channelPerms = (effectivePerms & ~denyMask) | allowMask
+    }
+  }
+
+  const canSendMessages = isAdmin || hasPermission(channelPerms, "SEND_MESSAGES")
   const canAttachMedia = canSendMessages
-  const canConnectVoice = channelPerms.isAdmin || hasPermission(channelPerms.permissions, "CONNECT_VOICE")
-  const canSpeakOnStage = channelPerms.isAdmin || hasPermission(channelPerms.permissions, "SPEAK")
-  const canModerateStage = channelPerms.isAdmin || hasPermission(channelPerms.permissions, "MUTE_MEMBERS")
+  const canConnectVoice = isAdmin || hasPermission(channelPerms, "CONNECT_VOICE")
+  const canSpeakOnStage = isAdmin || hasPermission(channelPerms, "SPEAK")
+  const canModerateStage = isAdmin || hasPermission(channelPerms, "MUTE_MEMBERS")
 
   // Filter messages to only text-based channel types
   let messages: any[] = []
   if ((MESSAGE_CHANNEL_TYPES as readonly string[]).includes(channel.type)) {
+    const hydrateTimer = perfTimer("channel-page reply hydration")
     const raw = (messagesData ?? []).reverse()
     messages = await hydrateReplyTo(supabase, raw)
+    hydrateTimer.end()
   }
+
+  pageTimer.end()
 
   // Voice and Stage channels use the WebRTC voice infrastructure
   if ((VOICE_CHANNEL_TYPES as readonly string[]).includes(channel.type)) {

--- a/apps/web/app/channels/[serverId]/layout.tsx
+++ b/apps/web/app/channels/[serverId]/layout.tsx
@@ -6,6 +6,7 @@ import { MemberList } from "@/components/layout/member-list"
 import { ServerEmojiProvider } from "@/components/chat/server-emoji-context"
 import type { RoleRow } from "@/types/database"
 import type { MemberData } from "@/components/layout/member-list"
+import { perfTimer } from "@/lib/perf"
 
 interface Props {
   children: React.ReactNode
@@ -14,22 +15,28 @@ interface Props {
 
 /** Server-rendered layout that verifies membership and renders the channel sidebar alongside the active channel. */
 export default async function ServerLayout({ children, params: paramsPromise }: Props) {
+  const layoutTimer = perfTimer(`server-layout total [${(await paramsPromise).serverId.slice(0, 8)}]`)
   const params = await paramsPromise
 
+  const authTimer = perfTimer("server-layout auth")
   const [supabase, { data: { user }, error }] = await Promise.all([
     createServerSupabaseClient(),
     getAuthUser(),
   ])
+  authTimer.end()
 
   if (error || !user) redirect("/login")
 
   // Fetch membership, server, channels, and roles in parallel
+  const round1Timer = perfTimer("server-layout round-1 (member/server/channels/roles)")
   const [{ data: member }, { data: server }, { data: channels }, { data: memberRoles }] = await Promise.all([
     supabase.from("server_members").select("server_id").eq("server_id", params.serverId).eq("user_id", user.id).single(),
     supabase.from("servers").select("*").eq("id", params.serverId).single(),
     supabase.from("channels").select("*").eq("server_id", params.serverId).order("position", { ascending: true }),
     supabase.from("member_roles").select("role_id, roles(*)").eq("server_id", params.serverId).eq("user_id", user.id),
   ])
+
+  round1Timer.end()
 
   if (!server) notFound()
   if (!member) notFound()
@@ -46,6 +53,7 @@ export default async function ServerLayout({ children, params: paramsPromise }: 
     .map((c) => c.id)
 
   // Fetch 5 additional data sources in parallel for SSR hydration
+  const round2Timer = perfTimer("server-layout round-2 (members/emojis/threads/voice/reads/messages)")
   const adminSupabase = await createServiceRoleClient()
 
   const [
@@ -123,6 +131,8 @@ export default async function ServerLayout({ children, params: paramsPromise }: 
       : Promise.resolve({ data: [] as { channel_id: string; created_at: string }[] }),
   ])
 
+  round2Timer.end()
+
   // Normalize members: flatten nested roles
   type ApiRoleEntry = { role_id: string; roles: RoleRow | null }
   type ApiMember = Omit<MemberData, "roles"> & { roles?: ApiRoleEntry[] }
@@ -172,6 +182,8 @@ export default async function ServerLayout({ children, params: paramsPromise }: 
       }
     }
   }
+
+  layoutTimer.end()
 
   return (
     <ServerEmojiProvider serverId={params.serverId} initialEmojis={emojis ?? []}>

--- a/apps/web/app/channels/layout.tsx
+++ b/apps/web/app/channels/layout.tsx
@@ -4,6 +4,7 @@ import { ServerSidebar } from "@/components/layout/server-sidebar"
 import { AppProvider } from "@/components/layout/app-provider"
 import { MobileBottomTabBar } from "@/components/layout/mobile-bottom-tab-bar"
 import type { ServerRow } from "@/types/database"
+import { perfTimer } from "@/lib/perf"
 
 /** Root layout for all /channels routes — authenticates the user, loads profile and server list, wraps children in AppProvider. */
 export default async function ChannelsLayout({
@@ -11,20 +12,25 @@ export default async function ChannelsLayout({
 }: {
   children: React.ReactNode
 }) {
+  const rootTimer = perfTimer("channels-layout total")
+  const authTimer = perfTimer("channels-layout auth")
   const [supabase, { data: { user }, error }] = await Promise.all([
     createServerSupabaseClient(),
     getAuthUser(),
   ])
+  authTimer.end()
 
   if (error || !user) {
     redirect("/login")
   }
 
   // Fetch user profile and server memberships in parallel
+  const profileTimer = perfTimer("channels-layout profile+memberships")
   const [{ data: profile, error: profileError }, { data: serverMembers, error: serverMembersError }] = await Promise.all([
     supabase.from("users").select("*").eq("id", user.id).single(),
     supabase.from("server_members").select("server_id, joined_at").eq("user_id", user.id).order("joined_at", { ascending: true }),
   ])
+  profileTimer.end()
 
   if (profileError || !profile) redirect("/login")
 
@@ -33,9 +39,11 @@ export default async function ChannelsLayout({
   }
 
   const membershipIds = (serverMembers ?? []).map((membership) => membership.server_id)
+  const serverListTimer = perfTimer("channels-layout server-list")
   const { data: serverRows, error: serversError } = membershipIds.length
     ? await supabase.from("servers").select("*").in("id", membershipIds)
     : { data: [], error: null }
+  serverListTimer.end()
 
   if (serversError) {
     throw new Error(`Failed to load servers for membershipIds (${membershipIds.join(", ")}): ${serversError.message}`)
@@ -45,6 +53,8 @@ export default async function ChannelsLayout({
   const servers = membershipIds
     .map((serverId) => serversById.get(serverId))
     .filter((server): server is ServerRow => Boolean(server))
+
+  rootTimer.end()
 
   return (
     <AppProvider user={profile} servers={servers}>

--- a/apps/web/components/channels/forum-channel.tsx
+++ b/apps/web/components/channels/forum-channel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useMemo, useRef } from "react"
+import { useState, useEffect, useMemo, useRef, useCallback } from "react"
 import { MessageSquare, Plus, ArrowLeft, Users } from "lucide-react"
 import { createClientSupabaseClient } from "@/lib/supabase/client"
 import { sendReactionMutation } from "@/lib/reactions-client"
@@ -182,23 +182,72 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
     await supabase.from("channels").update({ last_post_at: new Date().toISOString() }).eq("id", channel.id)
   }
 
-  // Top-level posts: messages not replying to another message
-  const topLevelPosts = messages.filter((m) => !m.reply_to_id)
-  const sortedPosts = [...topLevelPosts].sort((a, b) => {
-    const repliesFor = (id: string) => messages.filter((m) => m.reply_to_id === id).length
-    if (sortMode === "popular") return repliesFor(b.id) - repliesFor(a.id)
-    if (sortMode === "unanswered") {
-      const aReplies = repliesFor(a.id)
-      const bReplies = repliesFor(b.id)
-      if ((aReplies === 0) !== (bReplies === 0)) return aReplies === 0 ? -1 : 1
+  // Pre-compute reply counts once (avoids O(n²) in sort comparator)
+  const replyCountMap = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const m of messages) {
+      if (m.reply_to_id) {
+        map.set(m.reply_to_id, (map.get(m.reply_to_id) ?? 0) + 1)
+      }
     }
-    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-  })
+    return map
+  }, [messages])
+
+  // Top-level posts: messages not replying to another message
+  const sortedPosts = useMemo(() => {
+    const topLevelPosts = messages.filter((m) => !m.reply_to_id)
+    return [...topLevelPosts].sort((a, b) => {
+      if (sortMode === "popular") return (replyCountMap.get(b.id) ?? 0) - (replyCountMap.get(a.id) ?? 0)
+      if (sortMode === "unanswered") {
+        const aReplies = replyCountMap.get(a.id) ?? 0
+        const bReplies = replyCountMap.get(b.id) ?? 0
+        if ((aReplies === 0) !== (bReplies === 0)) return aReplies === 0 ? -1 : 1
+      }
+      return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    })
+  }, [messages, sortMode, replyCountMap])
 
   // Replies to the active thread post
-  const threadReplies = activeThread
-    ? messages.filter((m) => m.reply_to_id === activeThread.id)
-    : []
+  const threadReplies = useMemo(
+    () => activeThread ? messages.filter((m) => m.reply_to_id === activeThread.id) : [],
+    [messages, activeThread]
+  )
+
+  // Stable handlers for MessageItem callbacks (avoids recreating logic per render)
+  const handleMessageEdit = useCallback(async (messageId: string, content: string) => {
+    const { error } = await supabase.from("messages").update({ content, edited_at: new Date().toISOString() }).eq("id", messageId)
+    if (!error) setMessages((prev) => prev.map((m) => m.id === messageId ? { ...m, content, edited_at: new Date().toISOString() } : m))
+  }, [supabase])
+
+  const handleMessageDelete = useCallback(async (messageId: string) => {
+    const { error } = await supabase.from("messages").delete().eq("id", messageId)
+    if (!error) setMessages((prev) => prev.filter((m) => m.id !== messageId))
+  }, [supabase])
+
+  const handleMessageReaction = useCallback(async (messageId: string, emoji: string) => {
+    let previousReactions: MessageWithAuthor["reactions"] = []
+    let remove = false
+
+    setMessages((prev) => prev.map((m) => {
+      if (m.id !== messageId) return m
+      previousReactions = m.reactions
+      const hasOwn = m.reactions.some((r) => r.user_id === currentUserId && r.emoji === emoji)
+      remove = hasOwn
+      return {
+        ...m,
+        reactions: hasOwn
+          ? m.reactions.filter((r) => !(r.user_id === currentUserId && r.emoji === emoji))
+          : [...m.reactions, { message_id: messageId, user_id: currentUserId, emoji, created_at: new Date().toISOString() }],
+      }
+    }))
+
+    try {
+      await sendReactionMutation({ messageId, emoji, remove, nonce: crypto.randomUUID() })
+    } catch (error) {
+      console.error("Failed to update reaction", error)
+      setMessages((prev) => prev.map((m) => m.id === messageId ? { ...m, reactions: previousReactions } : m))
+    }
+  }, [currentUserId])
 
   if (view === "thread" && activeThread) {
     return (
@@ -233,40 +282,13 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
               isGrouped={false}
               currentUserId={currentUserId}
               onReply={() => {}}
-              onEdit={async (content) => {
-                const { error } = await supabase.from("messages").update({ content, edited_at: new Date().toISOString() }).eq("id", activeThread.id)
-                if (!error) setMessages((prev) => prev.map((m) => m.id === activeThread.id ? { ...m, content, edited_at: new Date().toISOString() } : m))
-              }}
+              onEdit={(content) => handleMessageEdit(activeThread.id, content)}
               onDelete={async () => {
-                const { error } = await supabase.from("messages").delete().eq("id", activeThread.id)
-                if (!error) { setMessages((prev) => prev.filter((m) => m.id !== activeThread.id)); setView("list"); setActiveThread(null) }
+                await handleMessageDelete(activeThread.id)
+                setView("list")
+                setActiveThread(null)
               }}
-              onReaction={async (emoji) => {
-                const currentThread = messages.find((m) => m.id === activeThread.id)
-                const previousReactions = currentThread?.reactions ?? activeThread.reactions
-                const existing = previousReactions.find((r) => r.emoji === emoji && r.user_id === currentUserId)
-                const remove = Boolean(existing)
-                setMessages((prev) => prev.map((m) => {
-                  if (m.id !== activeThread.id) return m
-                  const hasOwnReaction = m.reactions.some((r) => r.user_id === currentUserId && r.emoji === emoji)
-                  return {
-                    ...m,
-                    reactions: remove
-                      ? m.reactions.filter((r) => !(r.user_id === currentUserId && r.emoji === emoji))
-                      : hasOwnReaction
-                        ? m.reactions
-                        : [...m.reactions, { message_id: activeThread.id, user_id: currentUserId, emoji, created_at: new Date().toISOString() }],
-                  }
-                }))
-                try {
-                  await sendReactionMutation({ messageId: activeThread.id, emoji, remove, nonce: crypto.randomUUID() })
-                } catch (error) {
-                  console.error("Failed to update thread reaction", error)
-                  setMessages((prev) =>
-                    prev.map((m) => (m.id === activeThread.id ? { ...m, reactions: previousReactions } : m))
-                  )
-                }
-              }}
+              onReaction={(emoji) => handleMessageReaction(activeThread.id, emoji)}
             />
           </div>
 
@@ -286,39 +308,9 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
                   isGrouped={!!isGrouped}
                   currentUserId={currentUserId}
                   onReply={() => setReplyTo(reply)}
-                  onEdit={async (content) => {
-                    const { error } = await supabase.from("messages").update({ content, edited_at: new Date().toISOString() }).eq("id", reply.id)
-                    if (!error) setMessages((prev) => prev.map((m) => m.id === reply.id ? { ...m, content, edited_at: new Date().toISOString() } : m))
-                  }}
-                  onDelete={async () => {
-                    const { error } = await supabase.from("messages").delete().eq("id", reply.id)
-                    if (!error) setMessages((prev) => prev.filter((m) => m.id !== reply.id))
-                  }}
-                  onReaction={async (emoji) => {
-                    const previousReactions = reply.reactions
-                    const existing = reply.reactions.find((r) => r.emoji === emoji && r.user_id === currentUserId)
-                    const remove = Boolean(existing)
-                    setMessages((prev) => prev.map((m) => {
-                      if (m.id !== reply.id) return m
-                      const hasOwnReaction = m.reactions.some((r) => r.user_id === currentUserId && r.emoji === emoji)
-                      return {
-                        ...m,
-                        reactions: remove
-                          ? m.reactions.filter((r) => !(r.user_id === currentUserId && r.emoji === emoji))
-                          : hasOwnReaction
-                            ? m.reactions
-                            : [...m.reactions, { message_id: reply.id, user_id: currentUserId, emoji, created_at: new Date().toISOString() }],
-                      }
-                    }))
-                    try {
-                      await sendReactionMutation({ messageId: reply.id, emoji, remove, nonce: crypto.randomUUID() })
-                    } catch (error) {
-                      console.error("Failed to update thread reply reaction", error)
-                      setMessages((prev) =>
-                        prev.map((m) => (m.id === reply.id ? { ...m, reactions: previousReactions } : m))
-                      )
-                    }
-                  }}
+                  onEdit={(content) => handleMessageEdit(reply.id, content)}
+                  onDelete={() => handleMessageDelete(reply.id)}
+                  onReaction={(emoji) => handleMessageReaction(reply.id, emoji)}
                 />
               )
             })}
@@ -438,7 +430,7 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
 
       {/* Post list */}
       <div className="flex-1 overflow-y-auto py-4 px-4 space-y-2">
-        {topLevelPosts.length === 0 && !showNewPost && (
+        {sortedPosts.length === 0 && !showNewPost && (
           <div className="text-center py-12">
             <div
               className="w-16 h-16 rounded-full flex items-center justify-center mb-4 mx-auto"
@@ -463,7 +455,7 @@ export function ForumChannel({ channel, initialMessages, currentUserId, serverId
         )}
 
         {sortedPosts.map((post) => {
-          const replyCount = messages.filter((m) => m.reply_to_id === post.id).length
+          const replyCount = replyCountMap.get(post.id) ?? 0
           const firstLine = post.content?.split("\n")[0] ?? ""
           const isTitle = firstLine.startsWith("**") && firstLine.endsWith("**")
           const title = isTitle ? firstLine.replace(/\*\*/g, "") : null

--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState, lazy, Suspense, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react"
+import { perfLogSinceNav, perfClearNav } from "@/lib/perf"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { useRouter, useSearchParams } from "next/navigation"
 import { CircleHelp, Hash, MessageSquareText, Pin, Search, Users, Briefcase, Sparkles, MoreHorizontal } from "lucide-react"
@@ -14,10 +15,10 @@ import { MessageInput } from "@/components/chat/message-input"
 import { useRealtimeMessages } from "@/hooks/use-realtime-messages"
 import { useTyping } from "@/hooks/use-typing"
 import { useToast } from "@/components/ui/use-toast"
-import { ThreadPanel } from "@/components/chat/thread-panel"
-import { SearchModal } from "@/components/modals/search-modal"
-import { CreateThreadModal } from "@/components/modals/create-thread-modal"
-import { KeyboardShortcutsModal } from "@/components/modals/keyboard-shortcuts-modal"
+const ThreadPanel = lazy(() => import("@/components/chat/thread-panel").then((m) => ({ default: m.ThreadPanel })))
+const SearchModal = lazy(() => import("@/components/modals/search-modal").then((m) => ({ default: m.SearchModal })))
+const CreateThreadModal = lazy(() => import("@/components/modals/create-thread-modal").then((m) => ({ default: m.CreateThreadModal })))
+const KeyboardShortcutsModal = lazy(() => import("@/components/modals/keyboard-shortcuts-modal").then((m) => ({ default: m.KeyboardShortcutsModal })))
 import { WorkspacePanel } from "@/components/chat/workspace-panel"
 import { TypingIndicator } from "@/components/chat/typing-indicator"
 import { NotificationBell } from "@/components/notifications/notification-bell"
@@ -378,6 +379,8 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
   }, [channel.id, sendOutboxEntry])
 
   useEffect(() => {
+    perfLogSinceNav("ChatArea mounted")
+    perfClearNav()
     setActiveServer(serverId)
     setActiveChannel(channel.id)
     return () => {
@@ -1267,8 +1270,14 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     }
   }, [layout.overflowActionIds.length, trackCommandEvent, viewportWidth])
 
-  const visibleActions = commandActions.filter((action) => layout.visibleActionIds.includes(action.id))
-  const overflowActions = commandActions.filter((action) => layout.overflowActionIds.includes(action.id))
+  const visibleActions = useMemo(
+    () => commandActions.filter((action) => layout.visibleActionIds.includes(action.id)),
+    [commandActions, layout.visibleActionIds]
+  )
+  const overflowActions = useMemo(
+    () => commandActions.filter((action) => layout.overflowActionIds.includes(action.id)),
+    [commandActions, layout.overflowActionIds]
+  )
 
   const handleCommandBarKeydown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (!visibleActions.length) return
@@ -1409,25 +1418,31 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
         </div>
 
         {showSearchModal && (
-          <SearchModal
-            serverId={serverId}
-            onClose={() => setShowSearchModal(false)}
-            onJumpToMessage={(channelId, messageId) => router.push(`/channels/${serverId}/${channelId}?message=${messageId}`)}
-          />
+          <Suspense fallback={null}>
+            <SearchModal
+              serverId={serverId}
+              onClose={() => setShowSearchModal(false)}
+              onJumpToMessage={(channelId, messageId) => router.push(`/channels/${serverId}/${channelId}?message=${messageId}`)}
+            />
+          </Suspense>
         )}
 
-        <KeyboardShortcutsModal
-          open={showKeyboardShortcuts}
-          onOpenChange={setShowKeyboardShortcuts}
-          handlers={{
-            onSearch: () => setShowSearchModal(true),
-            onSearchInChannel: () => setShowSearchModal(true),
-            onToggleMemberList: toggleMemberList,
-            onToggleThreadPanel: toggleThreadPanel,
-            onToggleWorkspacePanel: toggleWorkspacePanel,
-            onOpenShortcutHelp: () => setShowKeyboardShortcuts(true),
-          }}
-        />
+        {showKeyboardShortcuts && (
+          <Suspense fallback={null}>
+            <KeyboardShortcutsModal
+              open={showKeyboardShortcuts}
+              onOpenChange={setShowKeyboardShortcuts}
+              handlers={{
+                onSearch: () => setShowSearchModal(true),
+                onSearchInChannel: () => setShowSearchModal(true),
+                onToggleMemberList: toggleMemberList,
+                onToggleThreadPanel: toggleThreadPanel,
+                onToggleWorkspacePanel: toggleWorkspacePanel,
+                onOpenShortcutHelp: () => setShowKeyboardShortcuts(true),
+              }}
+            />
+          </Suspense>
+        )}
 
         <div className="sr-only" aria-live="polite" aria-atomic="true">{liveAnnouncement}</div>
         <div className="sr-only" aria-live="polite" aria-atomic="true">{typingAnnouncement}</div>
@@ -1669,13 +1684,15 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
 
       {activeThread && threadPanelOpen && (
         <div data-state="open" className="panel-surface-motion" style={{ ["--panel-transform-origin" as string]: "center right" }}>
-          <ThreadPanel
-            thread={activeThread}
-            currentUserId={currentUserId}
-            onClose={() => setThreadPanelOpen(false)}
-            onThreadUpdate={(updated) => setActiveThread(updated)}
-            focusMessageId={openThreadId ? jumpToMessageId : null}
-          />
+          <Suspense fallback={null}>
+            <ThreadPanel
+              thread={activeThread}
+              currentUserId={currentUserId}
+              onClose={() => setThreadPanelOpen(false)}
+              onThreadUpdate={(updated) => setActiveThread(updated)}
+              focusMessageId={openThreadId ? jumpToMessageId : null}
+            />
+          </Suspense>
         </div>
       )}
 
@@ -1696,16 +1713,20 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
 
       <WorkspacePanel channelId={channel.id} open={workspaceOpen} onClose={toggleWorkspacePanel} />
 
-      <CreateThreadModal
-        open={showCreateChannelThread}
-        onClose={() => setShowCreateChannelThread(false)}
-        channelId={channel.id}
-        onCreated={(thread) => {
-          setActiveThread(thread)
-          setThreadPanelOpen(true)
-          setShowCreateChannelThread(false)
-        }}
-      />
+      {showCreateChannelThread && (
+        <Suspense fallback={null}>
+          <CreateThreadModal
+            open={showCreateChannelThread}
+            onClose={() => setShowCreateChannelThread(false)}
+            channelId={channel.id}
+            onCreated={(thread) => {
+              setActiveThread(thread)
+              setThreadPanelOpen(true)
+              setShowCreateChannelThread(false)
+            }}
+          />
+        </Suspense>
+      )}
     </div>
   )
 }

--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -1,10 +1,9 @@
 "use client"
 
-import { memo, useCallback, useEffect, useId, useRef, useState } from "react"
+import { memo, useCallback, useEffect, useId, useRef, useState, lazy, Suspense } from "react"
 import { createPortal } from "react-dom"
 import { format } from "date-fns"
 import { Reply, Edit2, Trash2, Smile, Clipboard, Hash, MessageSquare, RefreshCcw, CheckSquare, Flag, Copy, Check, Pin, PinOff } from "lucide-react"
-import { Highlight, themes } from "prism-react-renderer"
 import { EmojiPicker } from "frimousse"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { UserProfilePopover } from "@/components/user-profile-popover"
@@ -19,8 +18,8 @@ import { useShallow } from "zustand/react/shallow"
 import { LinkEmbed, extractFirstUrl, extractGiphyUrl, getEmbeddableGiphyUrl, stripUrlFromContent } from "@/components/chat/link-embed"
 import { WorkspaceReferenceEmbed, extractWorkspaceReference } from "@/components/chat/workspace-reference-embed"
 import { ServerEmojiImage } from "@/components/chat/server-emoji-context"
-import { CreateThreadModal } from "@/components/modals/create-thread-modal"
-import { ReportModal } from "@/components/modals/report-modal"
+const CreateThreadModal = lazy(() => import("@/components/modals/create-thread-modal").then((m) => ({ default: m.CreateThreadModal })))
+const ReportModal = lazy(() => import("@/components/modals/report-modal").then((m) => ({ default: m.ReportModal })))
 import Image from "next/image"
 import { useParams } from "next/navigation"
 import { isAttachmentDownloadAllowed } from "@/lib/attachment-access"
@@ -80,6 +79,31 @@ const SUPPORTED_PRISM_LANGUAGES = new Set([
   "nginx", "regex", "wasm", "text",
 ])
 
+const HighlightedCode = lazy(() =>
+  import("prism-react-renderer").then((m) => ({
+    default: function HighlightedCodeInner({ code, language }: { code: string; language: string }) {
+      return (
+        <m.Highlight code={code} language={language} theme={m.themes.nightOwl}>
+          {({ style, tokens, getLineProps, getTokenProps }) => (
+            <pre
+              className="overflow-x-auto text-sm p-3 font-mono"
+              style={{ ...style, margin: 0 }}
+            >
+              {tokens.map((line, i) => (
+                <div key={i} {...getLineProps({ line })}>
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({ token })} />
+                  ))}
+                </div>
+              ))}
+            </pre>
+          )}
+        </m.Highlight>
+      )
+    },
+  }))
+)
+
 function CodeBlock({ lang, code }: { lang: string; code: string }) {
   const [copied, setCopied] = useState(false)
 
@@ -118,22 +142,15 @@ function CodeBlock({ lang, code }: { lang: string; code: string }) {
           {copied ? "Copied!" : "Copy"}
         </button>
       </div>
-      <Highlight code={code} language={language} theme={themes.nightOwl}>
-        {({ style, tokens, getLineProps, getTokenProps }) => (
-          <pre
-            className="overflow-x-auto text-sm p-3 font-mono"
-            style={{ ...style, margin: 0 }}
-          >
-            {tokens.map((line, i) => (
-              <div key={i} {...getLineProps({ line })}>
-                {line.map((token, key) => (
-                  <span key={key} {...getTokenProps({ token })} />
-                ))}
-              </div>
-            ))}
+      <Suspense
+        fallback={
+          <pre className="overflow-x-auto text-sm p-3 font-mono" style={{ background: "#011627", color: "#d6deeb", margin: 0 }}>
+            {code}
           </pre>
-        )}
-      </Highlight>
+        }
+      >
+        <HighlightedCode code={code} language={language} />
+      </Suspense>
     </div>
   )
 }
@@ -1104,27 +1121,31 @@ export const MessageItem = memo(function MessageItem({
       </ContextMenuContent>
     </ContextMenu>
 
-    {!isOwn && (
-      <ReportModal
-        open={showReportModal}
-        onClose={() => setShowReportModal(false)}
-        reportedUserId={message.author_id}
-        reportedUsername={displayName}
-        reportedMessageId={message.id}
-        serverId={activeServerId ?? undefined}
-      />
+    {!isOwn && showReportModal && (
+      <Suspense fallback={null}>
+        <ReportModal
+          open={showReportModal}
+          onClose={() => setShowReportModal(false)}
+          reportedUserId={message.author_id}
+          reportedUsername={displayName}
+          reportedMessageId={message.id}
+          serverId={activeServerId ?? undefined}
+        />
+      </Suspense>
     )}
 
-    {onThreadCreated && (
-      <CreateThreadModal
-        open={showCreateThread}
-        onClose={() => setShowCreateThread(false)}
-        messageId={message.id}
-        onCreated={(thread) => {
-          setShowCreateThread(false)
-          onThreadCreated(thread)
-        }}
-      />
+    {onThreadCreated && showCreateThread && (
+      <Suspense fallback={null}>
+        <CreateThreadModal
+          open={showCreateThread}
+          onClose={() => setShowCreateThread(false)}
+          messageId={message.id}
+          onCreated={(thread) => {
+            setShowCreateThread(false)
+            onThreadCreated(thread)
+          }}
+        />
+      </Suspense>
     )}
 
     <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
@@ -1330,6 +1351,7 @@ function AttachmentDisplay({ attachment, onOpenImage, canManageMessages, serverI
           alt={attachment.filename}
           width={384}
           height={320}
+          loading="lazy"
           className="rounded object-contain"
           style={{ width: "auto", maxWidth: "100%", height: "auto", maxHeight: "20rem", background: "var(--theme-bg-tertiary)" }}
         />

--- a/apps/web/components/dm/dm-channel-area.tsx
+++ b/apps/web/components/dm/dm-channel-area.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState, useCallback } from "react"
+import { useEffect, useMemo, useRef, useState, useCallback, lazy, Suspense } from "react"
 import { createClientSupabaseClient } from "@/lib/supabase/client"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { Send, Phone, Video, Users, Paperclip, Pencil, Trash2, PhoneOff, Mic, MicOff, VideoOff, Search, Pin, SmilePlus, Reply, X } from "lucide-react"
@@ -16,7 +16,7 @@ import { useShallow } from "zustand/react/shallow"
 import { decryptDmContent, encryptDmContent, exportPublicKey, fingerprintFromPublicKey, generateConversationKey, generateDeviceKeyPair, importPublicKey, parseEncryptedEnvelope, unwrapConversationKey, wrapConversationKey } from "@/lib/dm-encryption"
 import { useNotificationSound } from "@/hooks/use-notification-sound"
 import { useLocalSearch } from "@/hooks/use-local-search"
-import { DmLocalSearchModal } from "@/components/modals/dm-local-search-modal"
+const DmLocalSearchModal = lazy(() => import("@/components/modals/dm-local-search-modal").then((m) => ({ default: m.DmLocalSearchModal })))
 import type { IndexedDocument } from "@/lib/local-search-index"
 import { ChannelRowSkeleton, MessageListSkeleton } from "@/components/ui/skeleton"
 
@@ -1008,6 +1008,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
 
       {/* Local search modal for encrypted DM channels */}
       {showLocalSearch && channel?.is_encrypted && (
+        <Suspense fallback={null}>
         <DmLocalSearchModal
           channelId={channel.id}
           channelLabel={displayName}
@@ -1044,6 +1045,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
           searchFn={searchLocal}
           indexedCount={Object.values(decryptedContent).filter((d) => !d.failed).length}
         />
+        </Suspense>
       )}
     </div>
   )

--- a/apps/web/components/events/events-calendar.tsx
+++ b/apps/web/components/events/events-calendar.tsx
@@ -111,12 +111,33 @@ export function EventsCalendar({ serverId, channels, canManageEvents = false }: 
   }
 
   async function rsvp(eventId: string, status: "going" | "maybe" | "not_going") {
-    await fetch(`/api/servers/${serverId}/events/${eventId}/rsvp`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ status }),
-    })
-    await load()
+    // Snapshot for rollback
+    const prevEvents = events
+
+    // Optimistic update: immediately reflect the new RSVP in local state
+    setEvents((prev) => prev.map((e) => {
+      if (e.id !== eventId) return e
+      const prevStatus: string | null = e.myRsvp?.status ?? null
+      const newStats = { ...(e.stats ?? {}) }
+      if (prevStatus && prevStatus !== status) {
+        newStats[prevStatus] = Math.max(0, (newStats[prevStatus] ?? 0) - 1)
+      }
+      if (prevStatus !== status) {
+        newStats[status] = (newStats[status] ?? 0) + 1
+      }
+      return { ...e, myRsvp: { ...(e.myRsvp ?? {}), status }, stats: newStats }
+    }))
+
+    try {
+      const res = await fetch(`/api/servers/${serverId}/events/${eventId}/rsvp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      })
+      if (!res.ok) setEvents(prevEvents)
+    } catch {
+      setEvents(prevEvents)
+    }
   }
 
   return (

--- a/apps/web/components/layout/channel-sidebar.tsx
+++ b/apps/web/components/layout/channel-sidebar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect, useRef, useCallback, useMemo } from "react"
+import { perfLogSinceNav } from "@/lib/perf"
 import { useRouter } from "next/navigation"
 import {
   Hash, Volume2, ChevronDown, ChevronRight,
@@ -254,6 +255,11 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
   )
 
+  // Perf: log mount time relative to navigation start
+  useEffect(() => {
+    perfLogSinceNav("ChannelSidebar mounted")
+  }, [server.id])
+
   // Seed store with server-fetched channels once per server
   const seededServerRef = useRef<string | null>(null)
   useEffect(() => {
@@ -404,7 +410,7 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
   }, [voiceParticipants])
 
   // Compute effective permissions
-  const userPermissions = userRoles.reduce((acc, role) => acc | role.permissions, 0)
+  const userPermissions = useMemo(() => userRoles.reduce((acc, role) => acc | role.permissions, 0), [userRoles])
   const canManageChannels = isOwner || hasPermission(userPermissions, "MANAGE_CHANNELS")
   const canManageEvents = isOwner || hasPermission(userPermissions, "MANAGE_EVENTS")
 
@@ -725,19 +731,25 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
   const activeCategory = activeCategoryId ? channels.find((c) => c.id === activeCategoryId) : null
 
   // Rebuild grouped view from live items map to reflect drag state
-  const liveGrouped = grouped.map(({ category }) => {
-    const key = category?.id ?? NO_CATEGORY
-    const channelIds = items[key] ?? []
-    const categoryChannels = channelIds
-      .map((id) => channelById.get(id))
-      .filter((c): c is ChannelRow => !!c)
-    return { category, channels: categoryChannels }
-  })
+  const liveGrouped = useMemo(
+    () => grouped.map(({ category }) => {
+      const key = category?.id ?? NO_CATEGORY
+      const channelIds = items[key] ?? []
+      const categoryChannels = channelIds
+        .map((id) => channelById.get(id))
+        .filter((c): c is ChannelRow => !!c)
+      return { category, channels: categoryChannels }
+    }),
+    [grouped, items, channelById]
+  )
 
   // Channels eligible for webhooks are all message-based channel types
-  const webhookEligibleChannels = channels
-    .filter((c) => (MESSAGE_CHANNEL_TYPES as readonly string[]).includes(c.type))
-    .map((c) => ({ id: c.id, name: c.name }))
+  const webhookEligibleChannels = useMemo(
+    () => channels
+      .filter((c) => (MESSAGE_CHANNEL_TYPES as readonly string[]).includes(c.type))
+      .map((c) => ({ id: c.id, name: c.name })),
+    [channels]
+  )
 
   return (
     <TooltipProvider delayDuration={200}>

--- a/apps/web/components/layout/member-list.tsx
+++ b/apps/web/components/layout/member-list.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState } from "react"
+import { memo, useEffect, useMemo, useRef, useState, lazy, Suspense } from "react"
+import { perfLogSinceNav } from "@/lib/perf"
 import { useRouter } from "next/navigation"
 import { Clipboard, AtSign, MessageSquare, UserPlus, UserCircle, Flag } from "lucide-react"
 import { createClientSupabaseClient } from "@/lib/supabase/client"
@@ -16,7 +17,7 @@ import type { RoleRow } from "@/types/database"
 import type { RealtimeChannel } from "@supabase/supabase-js"
 import { Skeleton } from "@/components/ui/skeleton"
 import { openDmChannel, sendFriendRequest } from "@/lib/social-actions"
-import { ReportModal } from "@/components/modals/report-modal"
+const ReportModal = lazy(() => import("@/components/modals/report-modal").then((m) => ({ default: m.ReportModal })))
 import { getStatusColor } from "@/lib/presence-status"
 import { cn } from "@/lib/utils/cn"
 
@@ -63,6 +64,11 @@ export function MemberList({ serverId, initialMembers }: Props) {
   const channelRef = useRef<RealtimeChannel | null>(null)
   const memberFetchControllerRef = useRef<AbortController | null>(null)
   const supabase = useMemo(() => createClientSupabaseClient(), [])
+
+  // Perf: log mount time relative to navigation start
+  useEffect(() => {
+    perfLogSinceNav("MemberList mounted")
+  }, [serverId])
 
   // Sync SSR-provided members to the app store for mention autocomplete
   useEffect(() => {
@@ -233,16 +239,22 @@ export function MemberList({ serverId, initialMembers }: Props) {
     }
   }, [currentUser?.status, currentUser?.id])
 
-  if (!memberListOpen) return null
+  const onlineMembers = useMemo(
+    () => members.filter((m) => {
+      const p = presence[m.user_id]
+      return p && p.status !== "offline" && p.status !== "invisible"
+    }),
+    [members, presence]
+  )
+  const offlineMembers = useMemo(
+    () => members.filter((m) => {
+      const p = presence[m.user_id]
+      return !p || p.status === "offline" || p.status === "invisible"
+    }),
+    [members, presence]
+  )
 
-  const onlineMembers = members.filter((m) => {
-    const p = presence[m.user_id]
-    return p && p.status !== "offline" && p.status !== "invisible"
-  })
-  const offlineMembers = members.filter((m) => {
-    const p = presence[m.user_id]
-    return !p || p.status === "offline" || p.status === "invisible"
-  })
+  if (!memberListOpen) return null
 
   const selectedMember = selectedMemberId
     ? members.find((member) => member.user_id === selectedMemberId) ?? null
@@ -329,7 +341,7 @@ export function MemberList({ serverId, initialMembers }: Props) {
   )
 }
 
-function MemberItem({
+const MemberItem = memo(function MemberItem({
   member,
   presence,
   currentUserId,
@@ -520,15 +532,17 @@ function MemberItem({
       </ContextMenuContent>
     </ContextMenu>
 
-    {isOtherUser && (
-      <ReportModal
-        open={showReportModal}
-        onClose={() => setShowReportModal(false)}
-        reportedUserId={member.user_id}
-        reportedUsername={displayName}
-        serverId={serverId}
-      />
+    {isOtherUser && showReportModal && (
+      <Suspense fallback={null}>
+        <ReportModal
+          open={showReportModal}
+          onClose={() => setShowReportModal(false)}
+          reportedUserId={member.user_id}
+          reportedUsername={displayName}
+          serverId={serverId}
+        />
+      </Suspense>
     )}
     </>
   )
-}
+})

--- a/apps/web/components/layout/server-sidebar.tsx
+++ b/apps/web/components/layout/server-sidebar.tsx
@@ -13,6 +13,7 @@ import { useToast } from "@/components/ui/use-toast"
 import { CreateServerModal } from "@/components/modals/create-server-modal"
 import { createClientSupabaseClient } from "@/lib/supabase/client"
 import { useState, useMemo, useCallback, useEffect } from "react"
+import { perfMarkNavStart } from "@/lib/perf"
 import { cn } from "@/lib/utils/cn"
 import type { ServerRow } from "@/types/database"
 import { VortexLogo } from "@/components/ui/vortex-logo"
@@ -31,6 +32,7 @@ export function ServerSidebar() {
   const supabase = useMemo(() => createClientSupabaseClient(), [])
 
   const navigateToServer = useCallback((serverId: string) => {
+    perfMarkNavStart(`server:${serverId.slice(0, 8)}`)
     setActiveServer(serverId)
 
     // Check Zustand store for cached channels (populated after any visit this session)

--- a/apps/web/components/layout/user-panel.tsx
+++ b/apps/web/components/layout/user-panel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useMemo, useEffect } from "react"
+import { useState, useMemo, useEffect, lazy, Suspense } from "react"
 import { useRouter } from "next/navigation"
 import { Mic, MicOff, Headphones, PhoneOff, Settings, Clipboard, Circle, LogOut, UserRound } from "lucide-react"
 import { useAppStore } from "@/lib/stores/app-store"
@@ -9,7 +9,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuSub, ContextMenuSubTrigger, ContextMenuSubContent } from "@/components/ui/context-menu"
 import { useToast } from "@/components/ui/use-toast"
-import { ProfileSettingsModal } from "@/components/modals/profile-settings-modal"
+const ProfileSettingsModal = lazy(() => import("@/components/modals/profile-settings-modal").then((m) => ({ default: m.ProfileSettingsModal })))
 import { createClientSupabaseClient } from "@/lib/supabase/client"
 import type { UserRow } from "@/types/database"
 
@@ -273,11 +273,15 @@ export function UserPanel() {
         </Tooltip>
       </div>
 
-      <ProfileSettingsModal
-        open={showProfileSettings}
-        onClose={() => setShowProfileSettings(false)}
-        user={currentUser}
-      />
+      {showProfileSettings && (
+        <Suspense fallback={null}>
+          <ProfileSettingsModal
+            open={showProfileSettings}
+            onClose={() => setShowProfileSettings(false)}
+            user={currentUser}
+          />
+        </Suspense>
+      )}
     </div>
   )
 }

--- a/apps/web/hooks/use-presence-sync.ts
+++ b/apps/web/hooks/use-presence-sync.ts
@@ -33,9 +33,12 @@ export function usePresenceSync(userId: string | null, status?: PresenceStatus) 
     if (!userId) return
     userIdRef.current = userId
 
+    let isInitialCall = true
     const persistStatus = (nextStatus: PresenceStatus, options?: { persistUserRecord?: boolean; rememberExplicit?: boolean }) => {
       const persistUserRecord = options?.persistUserRecord ?? true
       const rememberExplicit = options?.rememberExplicit ?? (nextStatus === "idle" || nextStatus === "dnd" || nextStatus === "invisible")
+
+      const statusChanged = currentStatusRef.current !== nextStatus
 
       currentStatusRef.current = nextStatus
       if (rememberExplicit) {
@@ -49,6 +52,10 @@ export function usePresenceSync(userId: string | null, status?: PresenceStatus) 
       } else if (rememberExplicit) {
         isIdleExplicitRef.current = false
       }
+
+      // Skip redundant track/persist calls when status hasn't actually changed
+      if (!statusChanged && !isInitialCall) return
+      isInitialCall = false
 
       if (persistUserRecord) {
         supabase

--- a/apps/web/hooks/use-realtime-messages.ts
+++ b/apps/web/hooks/use-realtime-messages.ts
@@ -28,21 +28,24 @@ export function useRealtimeMessages(
         async (payload) => {
           // Fetch full message with relations (reply_to hydrated separately to
           // avoid depending on the self-referential FK being in PostgREST cache)
-          const { data } = await supabase
-            .from("messages")
-            .select(`*, author:users!messages_author_id_fkey(*), attachments(*), reactions(*)`)
-            .eq("id", payload.new.id)
-            .single()
-          if (!data) return
-          let replyTo = null
-          if (data.reply_to_id) {
-            const { data: parent } = await supabase
+          const replyToId = (payload.new as any).reply_to_id
+          const [messageResult, replyResult] = await Promise.all([
+            supabase
               .from("messages")
-              .select(`*, author:users!messages_author_id_fkey(*)`)
-              .eq("id", data.reply_to_id)
-              .single()
-            replyTo = parent ?? null
-          }
+              .select(`*, author:users!messages_author_id_fkey(*), attachments(*), reactions(*)`)
+              .eq("id", payload.new.id)
+              .single(),
+            replyToId
+              ? supabase
+                  .from("messages")
+                  .select(`*, author:users!messages_author_id_fkey(*)`)
+                  .eq("id", replyToId)
+                  .single()
+              : Promise.resolve({ data: null }),
+          ])
+          const data = messageResult.data
+          if (!data) return
+          const replyTo = replyResult.data ?? null
           onInsert({ ...data, reply_to: replyTo } as unknown as MessageWithAuthor)
         }
       )

--- a/apps/web/lib/perf.ts
+++ b/apps/web/lib/perf.ts
@@ -1,0 +1,54 @@
+/**
+ * Lightweight performance timing for diagnosing server-switch latency.
+ * All logging is dev-only and prefixed with [perf] for easy filtering.
+ *
+ * Server-side: use `perfTimer()` to time async blocks.
+ * Client-side: use `perfMarkNavStart()` at navigation trigger,
+ *              then `perfLogSinceNav()` in component mount effects.
+ */
+
+const ENABLED = process.env.NODE_ENV !== "production"
+
+// ── Server-side timing ──────────────────────────────────────────────────────
+
+/** Start a timer; call `.end()` to log the elapsed time. */
+export function perfTimer(label: string): { end: () => void } {
+  if (!ENABLED) return { end() {} }
+  const start = performance.now()
+  return {
+    end() {
+      const ms = (performance.now() - start).toFixed(1)
+      console.log(`[perf] ${label} — ${ms}ms`)
+    },
+  }
+}
+
+// ── Client-side navigation timing ───────────────────────────────────────────
+
+/** Mark the start of a server/channel switch navigation. */
+export function perfMarkNavStart(context?: string) {
+  if (!ENABLED || typeof window === "undefined") return
+  const w = window as any
+  w.__vortexNavStart = performance.now()
+  w.__vortexNavContext = context ?? "unknown"
+  console.log(`[perf] ▶ navigation start${context ? ` (${context})` : ""}`)
+}
+
+/** Log elapsed time since the last `perfMarkNavStart()` call. */
+export function perfLogSinceNav(label: string) {
+  if (!ENABLED || typeof window === "undefined") return
+  const w = window as any
+  const start = w.__vortexNavStart as number | undefined
+  if (start == null) return
+  const elapsed = (performance.now() - start).toFixed(1)
+  const ctx = w.__vortexNavContext ?? ""
+  console.log(`[perf]   ${label} — ${elapsed}ms${ctx ? ` [${ctx}]` : ""}`)
+}
+
+/** Clear the navigation mark (call when the final component mounts). */
+export function perfClearNav() {
+  if (!ENABLED || typeof window === "undefined") return
+  const w = window as any
+  delete w.__vortexNavStart
+  delete w.__vortexNavContext
+}

--- a/apps/web/lib/supabase/server.ts
+++ b/apps/web/lib/supabase/server.ts
@@ -10,8 +10,8 @@ export const getAuthUser = cache(async () => {
   return supabase.auth.getUser()
 })
 
-/** Creates a Supabase client authenticated via the request's cookies (anon key). Safe for Server Components, Route Handlers, and Server Actions. */
-export async function createServerSupabaseClient() {
+/** Per-request cached Supabase client. Deduplicates client creation across nested layouts and pages within a single render. */
+export const createServerSupabaseClient = cache(async () => {
   const cookieStore = await cookies()
 
   return createServerClient<Database>(
@@ -34,13 +34,13 @@ export async function createServerSupabaseClient() {
       },
     }
   )
-}
+})
 
-/** Creates a Supabase client with the service-role key, bypassing RLS. Use only for admin operations. */
-export async function createServiceRoleClient() {
+/** Per-request cached service-role client. Bypasses RLS — use only for admin operations. */
+export const createServiceRoleClient = cache(async () => {
   return createClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     { auth: { persistSession: false } }
   )
-}
+})

--- a/apps/web/lib/voice/use-voice-intelligence.ts
+++ b/apps/web/lib/voice/use-voice-intelligence.ts
@@ -4,7 +4,7 @@
 // and live transcription. Designed to be used alongside the existing use-voice
 // and use-livekit-voice hooks without modifying them.
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { createClientSupabaseClient } from "@/lib/supabase/client"
 import { createSTTProvider, type STTProvider, type STTSegment } from "@/lib/voice/stt-provider"
 import {
@@ -65,7 +65,7 @@ export interface UseVoiceIntelligenceReturn extends VoiceIntelligenceState {
 }
 
 export function useVoiceIntelligence(userId: string | null): UseVoiceIntelligenceReturn {
-  const supabase = createClientSupabaseClient()
+  const supabase = useMemo(() => createClientSupabaseClient(), [])
 
   const [session, setSession] = useState<VoiceCallSessionRow | null>(null)
   const [policy, setPolicy] = useState<EffectiveVoicePolicy | null>(null)


### PR DESCRIPTION
## Summary

- **Server switch HTTP time: 667-755ms → 385-461ms (42% faster)**
- **Channel page total: 551-630ms → 207-246ms (60% faster)**
- 23 files changed across API routes, server components, and client components

## Changes

### Request-level deduplication
- Cache `createServerSupabaseClient` and `createServiceRoleClient` with React `cache()` — eliminates duplicate client creation across layout/page boundaries
- Inline channel permission computation into the main parallel query block, removing the sequential `getChannelPermissions()` call and its 5 redundant DB queries

### API route parallelization (Promise.all)
- `appeals/route.ts` — 3 sequential queries (ban, duplicate, 30-day count) → parallel
- `dm/route.ts` — sent + received message queries → parallel
- `dm/channels/route.ts` — user + partner membership queries → parallel
- `dm/channels/[channelId]/members/route.ts` — membership + channel type check → parallel
- `dm/channels/[channelId]/messages/route.ts` — blocking + body parsing + encryption check → parallel
- `messages/route.ts` — automod alert channel inserts → parallel
- `use-realtime-messages.ts` — message + reply-to fetch → parallel

### React rendering optimizations
- Lazy-load heavy components (prism-react-renderer, modals, ThreadPanel) with `React.lazy` + `Suspense`
- Memoize computed values with `useMemo` (sortedPosts, replyCountMap, online/offline members, grouped channels, permissions)
- Wrap `MemberItem` in `React.memo` for large member lists
- Extract forum channel message handlers into `useCallback`
- Memoize Supabase client in `use-voice-intelligence` hook

### Other improvements
- Optimistic RSVP updates in events calendar (instant UI feedback, rollback on failure)
- Skip redundant presence track/DB writes when status unchanged
- Pre-compute reply count map to avoid O(n²) in forum sort comparator
- Fix `topLevelPosts` scoping bug after `useMemo` refactor

### Dev tooling
- Add `lib/perf.ts` — lightweight dev-only timing instrumentation for server switch diagnostics
- Instrument server layout, channel page, and client component mounts with `[perf]` console logging

## Test plan

- [ ] Switch between servers rapidly — verify no visual regressions
- [ ] Send messages, reactions, replies in text/forum channels — verify real-time updates work
- [ ] RSVP to events — verify optimistic update and rollback on network error
- [ ] Open/close modals (search, thread, report, keyboard shortcuts) — verify lazy loading works
- [ ] Check member list renders correctly with presence indicators
- [ ] Verify DM channels load correctly (send messages, add members to group DMs)
- [ ] Check dev console for `[perf]` timing output during server switches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized data fetching across API endpoints for faster response times
  * Lazy-loaded modals and components to improve initial page load performance
  * Added performance instrumentation for monitoring

* **Bug Fixes**
  * Enhanced error handling for concurrent operations
  * Improved permission calculations on channel pages

* **Features**
  * RSVP actions now display instant feedback before network confirmation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->