### PR TITLE
Fix iOS auth page viewport/scroll behavior

### DIFF
--- a/apps/web/app/(auth)/layout.tsx
+++ b/apps/web/app/(auth)/layout.tsx
@@ -7,7 +7,7 @@ export default function AuthLayout({
 }) {
   return (
     <div
-      className="relative flex min-h-screen items-center justify-center overflow-hidden px-6"
+      className="relative flex min-h-[100dvh] items-center justify-center overflow-x-hidden overflow-y-auto px-6 py-8"
       style={{
         background:
           "radial-gradient(ellipse 80% 60% at 50% -10%, color-mix(in srgb, var(--theme-accent) 10%, transparent), transparent 70%), var(--theme-bg-tertiary)",


### PR DESCRIPTION
### Motivation
- iOS Safari/other mobile browsers can change visible viewport height when browser chrome or the keyboard appears, which can trap or hide the login/MFA form when the auth shell uses `100vh` and disables scrolling, so the auth layout needs to adapt to dynamic viewport height and allow vertical scrolling.

### Description
- Replaced `min-h-screen` with dynamic viewport height `min-h-[100dvh]` in the auth shell to follow the device viewport changes and added vertical padding to avoid content being clipped; file modified: `apps/web/app/(auth)/layout.tsx`.
- Switched from fully hidden overflow to `overflow-x-hidden overflow-y-auto` so the auth surface can scroll vertically when necessary.

### Testing
- Ran `npm -C apps/web run lint`, which failed due to pre-existing `style-guardrails` regressions unrelated to this change (lint error reported but not caused by this patch). 
- Attempted to run the dev server with `npm -C apps/web run dev`, which could not fully boot because required Supabase env vars were not present, so manual/visual validation was limited. 
- A Playwright-based screenshot attempt against `http://127.0.0.1:3000/login` failed with `ERR_EMPTY_RESPONSE` because the dev server was not available due to missing environment configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae1c866eb48325a1575e8fa74d14bb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated authentication layout to use flexible viewport height instead of fixed dimensions, improving responsiveness across different screen sizes.
  * Enhanced scrolling behavior by enabling vertical scroll support while maintaining horizontal overflow restriction for better content handling.
  * Added vertical padding to the authentication interface for improved spacing and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->