### PR TITLE
Add bottom user settings panel to DMs sidebar

### DIFF
--- a/apps/web/components/dm/me-shell.tsx
+++ b/apps/web/components/dm/me-shell.tsx
@@ -1,9 +1,21 @@
 "use client"
 
 import { DMList } from "./dm-list"
+import { UserPanel } from "@/components/layout/user-panel"
 import { MobileNavProvider, MobileOverlay, MobileSwipeArea } from "@/components/layout/mobile-nav"
 import { useMobileNav } from "@/components/layout/mobile-nav"
 import { useSwipe } from "@/hooks/use-swipe"
+
+function DMNavContent({ onNavigate }: { onNavigate?: () => void }) {
+  return (
+    <>
+      <div className="flex-1 min-h-0">
+        <DMList onNavigate={onNavigate} />
+      </div>
+      <UserPanel />
+    </>
+  )
+}
 
 function DMListPanel() {
   const { sidebarOpen, setSidebarOpen } = useMobileNav()
@@ -15,7 +27,7 @@ function DMListPanel() {
         className="hidden md:flex w-60 flex-shrink-0 flex-col overflow-hidden"
         style={{ background: "var(--app-bg-secondary)" }}
       >
-        <DMList />
+        <DMNavContent />
       </div>
 
       {/* Mobile: slide-in drawer */}
@@ -25,7 +37,7 @@ function DMListPanel() {
           style={{ background: "var(--app-bg-secondary)" }}
           {...swipe}
         >
-          <DMList onNavigate={() => setSidebarOpen(false)} />
+          <DMNavContent onNavigate={() => setSidebarOpen(false)} />
         </div>
       )}
     </>


### PR DESCRIPTION
### Motivation
- Ensure the username/microphone/settings cog user-controls that appear at the bottom of channel sidebars are also present on the Direct Messages (DMs) page for consistent UX.

### Description
- Import `UserPanel` and add a new `DMNavContent` wrapper in `apps/web/components/dm/me-shell.tsx` that renders `DMList` and `UserPanel` together.
- Replace the previous direct `DMList` usage in both the desktop and mobile DM sidebar variants with `DMNavContent` so the bottom user controls appear in DMs as well.

### Testing
- Ran `npm run -w apps/web type-check` which completed successfully.
- Attempted `npm run -w apps/web dev` and a Playwright screenshot of `/channels/me`, but the dev server could not start due to missing Supabase environment variables (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`), so runtime verification and screenshots were not produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae2b72ac808325a14a092e654a7543)