### PR TITLE
fix: switch auth to PKCE flow for magic links

### DIFF
--- a/apps/web/lib/supabase/client.ts
+++ b/apps/web/lib/supabase/client.ts
@@ -4,6 +4,7 @@ import type { Database } from "@/types/database"
 export function createClientSupabaseClient() {
   return createBrowserClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { auth: { flowType: "pkce" } }
   )
 }


### PR DESCRIPTION
## Summary
- Adds `flowType: "pkce"` to the browser Supabase client
- Magic links were using implicit flow (token in URL hash fragment), which never reached the server-side `/auth/callback` route — users landed on the home page instead of `/channels/me`
- PKCE flow sends a `code` query param that the existing callback handler exchanges server-side and redirects correctly

## Test plan
- [ ] Send a magic link login email and verify the link redirects to `/channels/me`
- [ ] Verify password login still works
- [ ] Verify OAuth login still works
- [ ] Verify password reset flow still works