### PR TITLE
fix: include @everyone default role in permission checks

### DIFF
--- a/apps/web/lib/permissions.ts
+++ b/apps/web/lib/permissions.ts
@@ -39,7 +39,7 @@ export async function getMemberPermissions(
   serverId: string,
   userId: string
 ): Promise<MemberPerms> {
-  const [{ data: server, error: serverError }, { data: member, error: memberError }] = await Promise.all([
+  const [{ data: server, error: serverError }, { data: member, error: memberError }, { data: defaultRole, error: defaultRoleError }] = await Promise.all([
     supabase.from("servers").select("owner_id, screening_enabled").eq("id", serverId).single(),
     supabase
       .from("server_members")
@@ -47,10 +47,12 @@ export async function getMemberPermissions(
       .eq("server_id", serverId)
       .eq("user_id", userId)
       .maybeSingle(),
+    supabase.from("roles").select("permissions").eq("server_id", serverId).eq("is_default", true).maybeSingle(),
   ])
 
   if (serverError) throw new Error(`Failed to fetch server: ${serverError.message}`)
   if (memberError) throw new Error(`Failed to fetch member: ${memberError.message}`)
+  if (defaultRoleError) throw new Error(`Failed to fetch default role: ${defaultRoleError.message}`)
 
   const ownerId: string | null = server?.owner_id ?? null
   const isOwner = ownerId === userId
@@ -60,6 +62,8 @@ export async function getMemberPermissions(
     (member as any)?.member_roles?.flatMap((mr: any) =>
       mr.roles?.permissions != null ? [mr.roles.permissions] : []
     ) ?? []
+
+  if (defaultRole?.permissions != null) rawPerms.push(defaultRole.permissions)
 
   const permissions = computePermissions(rawPerms)
   const isAdmin = isOwner || !!(permissions & PERMISSIONS.ADMINISTRATOR)

--- a/apps/web/lib/server-auth.ts
+++ b/apps/web/lib/server-auth.ts
@@ -86,14 +86,23 @@ export async function requireServerPermission(serverId: string, permission: Perm
   if (server.owner_id === user.id)
     return { supabase, user, error: null }
 
-  // Look up member roles and aggregate permissions
-  const { data: memberRoles } = await supabase
-    .from("member_roles")
-    .select("roles(permissions)")
-    .eq("user_id", user.id)
-    .eq("server_id", serverId)
+  // Look up member roles and default (@everyone) role permissions
+  const [{ data: memberRoles }, { data: defaultRole }] = await Promise.all([
+    supabase
+      .from("member_roles")
+      .select("roles(permissions)")
+      .eq("user_id", user.id)
+      .eq("server_id", serverId),
+    supabase
+      .from("roles")
+      .select("permissions")
+      .eq("server_id", serverId)
+      .eq("is_default", true)
+      .maybeSingle(),
+  ])
 
-  const permissions = aggregateMemberPermissions(memberRoles)
+  let permissions = aggregateMemberPermissions(memberRoles)
+  if (defaultRole?.permissions != null) permissions |= defaultRole.permissions
 
   if (!hasPermission(permissions, permission))
     return { supabase, user, error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) }


### PR DESCRIPTION
## Summary
- `getMemberPermissions()` in `lib/permissions.ts` and `requireServerPermission()` in `lib/server-auth.ts` only aggregated permissions from explicit `member_roles` entries
- New members who join a server have no `member_roles` rows, so they got `permissions = 0` and were denied basic actions like SEND_MESSAGES
- Both functions now also fetch the server's `is_default = true` role (@everyone) and OR its permission bits into the result
- The database-side `get_member_permissions()` SQL function already handled this correctly via a LEFT JOIN; this fix aligns the application layer

## Test plan
- [ ] New user joins a server via invite → can send messages in general channel
- [ ] Existing users with explicit roles still have correct permissions
- [ ] Server owner still bypasses all permission checks
- [ ] Channel-level permission overwrites still apply correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permission calculation to properly include default role permissions when evaluating member and server permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->