### PR TITLE
Allow LiveKit tokens for Stage channels and enable YouTube embeds

### DIFF
--- a/apps/web/app/api/servers/[serverId]/channels/[channelId]/voice-token/route.ts
+++ b/apps/web/app/api/servers/[serverId]/channels/[channelId]/voice-token/route.ts
@@ -7,7 +7,7 @@ type Params = { params: Promise<{ serverId: string; channelId: string }> }
 /**
  * POST /api/servers/[serverId]/channels/[channelId]/voice-token
  *
- * Generates a Livekit access token for a user joining a voice channel.
+ * Generates a Livekit access token for a user joining a voice/stage channel.
  * The room name is derived from the channel ID to ensure isolation.
  * Requires CONNECT_VOICE permission.
  *
@@ -31,7 +31,7 @@ export async function POST(req: NextRequest, { params }: Params) {
     )
   }
 
-  // Verify channel belongs to this server and is a voice channel
+  // Verify channel belongs to this server and is a real-time audio channel
   const { data: channel, error: channelError } = await supabase
     .from("channels")
     .select("id, name, type, server_id")
@@ -47,8 +47,8 @@ export async function POST(req: NextRequest, { params }: Params) {
     return NextResponse.json({ error: "Channel not found" }, { status: 404 })
   }
 
-  if (channel.type !== "voice") {
-    return NextResponse.json({ error: "Channel is not a voice channel" }, { status: 400 })
+  if (channel.type !== "voice" && channel.type !== "stage") {
+    return NextResponse.json({ error: "Channel is not a voice/stage channel" }, { status: 400 })
   }
 
   // Fetch user profile for display name

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -44,6 +44,8 @@ const nextConfig = {
               // Allow WebSocket connections (Supabase Realtime, Livekit) and external APIs
               "connect-src 'self' wss: https:",
               "media-src 'self' blob: https:",
+              // Allow embedded YouTube streams for Stage channels
+              "frame-src 'self' https://www.youtube.com https://youtube.com https://www.youtube-nocookie.com",
               // Prevent <frame>/<iframe> embedding
               "frame-ancestors 'none'",
             ].join("; "),


### PR DESCRIPTION
### Motivation
- Joining a Stage channel with a configured YouTube stream failed because the voice token endpoint rejected `stage` channels and the browser blocked YouTube iframes via CSP, producing 400/500 and CSP framing errors.

### Description
- Update the voice token API so it accepts both `voice` and `stage` channel types and adjust the error message to reflect `voice/stage` support.
- Add an explicit `frame-src` directive in `next.config.js` to allow YouTube origins (`https://www.youtube.com`, `https://youtube.com`, `https://www.youtube-nocookie.com`) for embedded Stage streams.
- Minor docstring/comment updates to clarify the endpoint purpose for real-time audio channels.

### Testing
- Ran TypeScript checks with `npm --prefix apps/web run type-check` which completed successfully.
- Ran the parity critical unit test via `npm --prefix apps/web run test -- __tests__/parity-acceptance-critical-flows.test.ts` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae4813ca0c832598d8aebce6255bb8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended voice functionality to stage channels, enabling voice token generation for both channel types.
  * Enabled YouTube video embedding support for enhanced multimedia content integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->