### PR TITLE
fix: resolve mobile login error after successful authentication

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { useRouter, useSearchParams } from "next/navigation"
+import { useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { createClientSupabaseClient } from "@/lib/supabase/client"
 import { Button } from "@/components/ui/button"
@@ -39,7 +39,6 @@ function AccentBadge({
 }
 
 export default function LoginPage() {
-  const router = useRouter()
   const searchParams = useSearchParams()
   const isNewUser = searchParams.get("registered") === "true"
   const { toast } = useToast()
@@ -79,8 +78,11 @@ export default function LoginPage() {
       }
 
       await supabase.from("users").update({ status: "online" }).eq("id", data.userId)
-      router.push("/channels/me")
-      router.refresh()
+      // Hard navigation ensures session cookies set by the login API are fully
+      // committed by the browser before the next page's server render fires.
+      // router.push() (client-side nav) can race against Set-Cookie processing
+      // on mobile — window.location.href matches what the passkey flow does.
+      window.location.href = "/channels/me"
     } catch (error: any) {
       toast({ variant: "destructive", title: "Login failed", description: error.message || "Something went wrong" })
     } finally {
@@ -110,8 +112,7 @@ export default function LoginPage() {
       if (user) {
         await supabase.from("users").update({ status: "online" }).eq("id", user.id)
       }
-      router.push("/channels/me")
-      router.refresh()
+      window.location.href = "/channels/me"
     } catch (error: any) {
       toast({ variant: "destructive", title: "Verification failed", description: error.message })
     } finally {

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { createServerClient } from "@supabase/ssr"
 
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url)
@@ -11,7 +11,32 @@ export async function GET(request: NextRequest) {
       : "/channels/me"
 
   if (code) {
-    const supabase = await createServerSupabaseClient()
+    // Build the redirect response first so we can attach cookies directly to it.
+    // Using the cached createServerSupabaseClient() here would set cookies via
+    // cookieStore.set(), but those aren't guaranteed to appear on a separately
+    // constructed NextResponse — especially on mobile browsers that are strict
+    // about Set-Cookie headers on redirects.  Creating a dedicated client that
+    // writes straight to the response object is the pattern recommended by
+    // @supabase/ssr for Route Handler callbacks.
+    const redirectResponse = NextResponse.redirect(`${origin}${next}`)
+
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return request.cookies.getAll()
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              redirectResponse.cookies.set(name, value, options)
+            })
+          },
+        },
+      }
+    )
+
     const { error } = await supabase.auth.exchangeCodeForSession(code)
     if (error) {
       console.error("Auth callback: code exchange failed", error)
@@ -25,7 +50,7 @@ export async function GET(request: NextRequest) {
           console.error("Auth callback: failed to set user status to online", statusError)
         }
       }
-      return NextResponse.redirect(`${origin}${next}`)
+      return redirectResponse
     }
   }
 

--- a/apps/web/app/channels/layout.tsx
+++ b/apps/web/app/channels/layout.tsx
@@ -35,7 +35,8 @@ export default async function ChannelsLayout({
   if (profileError || !profile) redirect("/login")
 
   if (serverMembersError) {
-    throw new Error(`Failed to load server memberships: ${serverMembersError.message}`)
+    console.error("Failed to load server memberships:", serverMembersError.message)
+    redirect("/login")
   }
 
   const membershipIds = (serverMembers ?? []).map((membership) => membership.server_id)
@@ -46,7 +47,8 @@ export default async function ChannelsLayout({
   serverListTimer.end()
 
   if (serversError) {
-    throw new Error(`Failed to load servers for membershipIds (${membershipIds.join(", ")}): ${serversError.message}`)
+    console.error("Failed to load servers:", serversError.message)
+    redirect("/login")
   }
 
   const serversById = new Map((serverRows ?? []).map((server) => [server.id, server]))


### PR DESCRIPTION
After password/MFA login, router.push() + router.refresh() initiated a client-side navigation before the browser finished committing the Set-Cookie headers from the /api/auth/login response.  On mobile this race caused the channels layout's server render to run without a valid session, resulting in the 'Something went wrong / Try Again' error boundary on every login attempt.

Changes:
- login/page.tsx: replace router.push + router.refresh with window.location.href (hard navigation), consistent with the passkey flow, so the browser fully commits cookies before the next request
- auth/callback/route.ts: rewrite to attach session cookies directly to the redirect response object instead of relying on cookieStore.set() being merged into a separately constructed NextResponse — fixes magic link login on mobile where this propagation was unreliable
- channels/layout.tsx: convert serverMembersError/serversError throws into redirect("/login") so a transient DB failure sends the user back to login rather than crashing into the error boundary

https://claude.ai/code/session_01MPNUH8u9SinPu64GacT5Fk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session cookie handling during authentication flows to ensure proper session establishment before navigation.
  * Enhanced authentication callback to better preserve cookie headers, particularly benefiting mobile browser users.
  * Improved error handling with proper redirects to login when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->