### PR TITLE
fix: resolve persistent mobile error boundary on load

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -156,7 +156,11 @@ export default function LoginPage() {
     try {
       const { error } = await supabase.auth.signInWithOtp({
         email: form.email,
-        options: { emailRedirectTo: `${window.location.origin}/channels/me` },
+        // Redirect to /auth/callback so the server-side route can exchange the
+        // PKCE code for session cookies before forwarding to the app.  Pointing
+        // directly at /channels/me means the code lands where no exchange
+        // handler exists; the server sees no session and redirects to login.
+        options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
       })
       if (error) throw error
       toast({ title: "Magic link sent!", description: `Check ${form.email} for your login link.` })

--- a/apps/web/hooks/use-push-notifications.ts
+++ b/apps/web/hooks/use-push-notifications.ts
@@ -43,8 +43,16 @@ export function usePushNotifications() {
   }, [])
 
   useEffect(() => {
-    // Auto-subscribe if already granted
-    if (typeof window !== "undefined" && Notification.permission === "granted") {
+    // Auto-subscribe if already granted.
+    // Guard typeof Notification: on iOS Safari < 16.4 and some Android WebViews
+    // the Notification global is not defined at all.  Accessing it without this
+    // check throws a ReferenceError that React 18 routes to the nearest error
+    // boundary, producing the "Something went wrong" screen on mobile.
+    if (
+      typeof window !== "undefined" &&
+      typeof Notification !== "undefined" &&
+      Notification.permission === "granted"
+    ) {
       subscribe()
     }
   }, [subscribe])


### PR DESCRIPTION
Two bugs were causing the "Something went wrong" screen on mobile:

1. use-push-notifications.ts: `Notification.permission` was accessed
   without first checking `typeof Notification !== "undefined"`.  On iOS
   Safari < 16.4 and some Android WebViews the Notification global does
   not exist at all.  React 18 catches errors thrown in useEffect passive
   effects and routes them to the nearest error boundary, so this
   ReferenceError surfaced as the error page on every mobile page load.

2. login/page.tsx (magic link): emailRedirectTo pointed at /channels/me
   directly.  With the PKCE auth flow the magic-link code lands in a page
   that has no exchange handler; the server renders the channels layout
   without a valid session and redirects to login, sometimes producing the
   error boundary in the process.  Fix: redirect to /auth/callback which
   exchanges the code server-side and sets cookies before forwarding to
   /channels/me.

https://claude.ai/code/session_01E5U8StFJ4j3UqsPFmKMe5o

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed magic link login flow to ensure proper session handling during authentication
  * Improved push notification feature stability in environments without full Notification API support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->