### PR TITLE
Refactor mobile navigation: simplify tab bar and improve menu button

### DIFF
--- a/apps/web/components/layout/mobile-bottom-tab-bar.tsx
+++ b/apps/web/components/layout/mobile-bottom-tab-bar.tsx
@@ -2,16 +2,34 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Compass, MessagesSquare, Search, Shield, UserRound } from "lucide-react"
+import { Compass, MessagesSquare, Users, UserRound } from "lucide-react"
 import { cn } from "@/lib/utils/cn"
 
 const TABS = [
-  { href: "/channels/discover", label: "Servers", icon: Compass },
+  { href: "/channels/discover", label: "Discover", icon: Compass },
   { href: "/channels/me", label: "DMs", icon: MessagesSquare },
-  { href: "/channels/friends", label: "Friends", icon: Shield },
-  { href: "/channels/discover", label: "Search", icon: Search },
+  { href: "/channels/friends", label: "Friends", icon: Users },
   { href: "/channels/profile", label: "Profile", icon: UserRound },
 ]
+
+function isTabActive(href: string, pathname: string): boolean {
+  if (href === "/channels/me") return pathname.startsWith("/channels/me")
+  if (href === "/channels/friends") return pathname.startsWith("/channels/friends")
+  if (href === "/channels/profile") return pathname.startsWith("/channels/profile")
+  // Discover tab is active for the discover page and any server channel pages
+  if (href === "/channels/discover") {
+    return (
+      pathname.startsWith("/channels/discover") ||
+      // Server channel routes: /channels/[serverId]/... (not /me, /friends, /profile, /discover)
+      (pathname.startsWith("/channels/") &&
+        !pathname.startsWith("/channels/me") &&
+        !pathname.startsWith("/channels/friends") &&
+        !pathname.startsWith("/channels/profile") &&
+        !pathname.startsWith("/channels/discover"))
+    )
+  }
+  return pathname === href
+}
 
 export function MobileBottomTabBar() {
   const pathname = usePathname()
@@ -26,9 +44,9 @@ export function MobileBottomTabBar() {
       }}
       aria-label="Mobile sections"
     >
-      <ul className="grid grid-cols-5 h-16">
+      <ul className="grid grid-cols-4 h-16">
         {TABS.map(({ href, label, icon: Icon }) => {
-          const active = pathname === href || (href === "/channels/me" && pathname.startsWith("/channels/me/"))
+          const active = isTabActive(href, pathname)
           return (
             <li key={label}>
               <Link

--- a/apps/web/components/layout/mobile-nav.tsx
+++ b/apps/web/components/layout/mobile-nav.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, createContext, useContext } from "react"
-import { X } from "lucide-react"
+import { Menu, X } from "lucide-react"
 import { useSwipe } from "@/hooks/use-swipe"
 
 interface MobileNavCtx {
@@ -27,19 +27,17 @@ export function useMobileNav() {
   return useContext(MobileNavContext)
 }
 
-// Hamburger button shown in the mobile header
+// Hamburger button shown in the mobile header — opens or closes the sidebar drawer
 export function MobileMenuButton() {
   const { sidebarOpen, setSidebarOpen } = useMobileNav()
-  if (!sidebarOpen) return <div className="md:hidden w-8 h-8" aria-hidden="true" />
-
   return (
     <button
       className="md:hidden w-8 h-8 flex items-center justify-center rounded transition-colors hover:bg-white/10"
       style={{ color: "var(--theme-text-secondary)" }}
-      onClick={() => setSidebarOpen(false)}
-      aria-label="Close sidebar"
+      onClick={() => setSidebarOpen(!sidebarOpen)}
+      aria-label={sidebarOpen ? "Close sidebar" : "Open sidebar"}
     >
-      <X className="w-5 h-5" />
+      {sidebarOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
     </button>
   )
 }


### PR DESCRIPTION
## Summary
This PR improves the mobile navigation experience by simplifying the bottom tab bar layout and enhancing the mobile menu button functionality.

## Key Changes

**Mobile Bottom Tab Bar (`mobile-bottom-tab-bar.tsx`)**
- Removed the "Search" tab to reduce clutter (changed grid from 5 to 4 columns)
- Renamed "Servers" tab to "Discover" for clarity
- Updated the Friends tab icon from `Shield` to `Users` for better visual representation
- Introduced `isTabActive()` helper function to handle complex active state logic:
  - The Discover tab is now active for both the discover page and any server channel pages
  - Properly distinguishes between special routes (`/me`, `/friends`, `/profile`, `/discover`) and dynamic server channel routes

**Mobile Menu Button (`mobile-nav.tsx`)**
- Changed from display-only close button to a toggle button that shows appropriate icon based on state
- Now displays `Menu` icon when sidebar is closed and `X` icon when open
- Removed the conditional rendering that hid the button when sidebar was closed
- Updated aria-label to dynamically reflect the button's action ("Open sidebar" vs "Close sidebar")

## Implementation Details
The `isTabActive()` function uses a logical approach to determine which tab should be highlighted:
- For special routes, it checks if the pathname starts with that route
- For the Discover tab, it also matches any server channel routes (paths starting with `/channels/` that don't match the reserved routes)
- This ensures proper highlighting when navigating between servers and channels

https://claude.ai/code/session_014oP2er9k5vj4VZQE1tkL6H