### PR TITLE
Fix chat reply overflow, emoji picker focus, typing indicator width, and channel auto-scroll

### DIFF
--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -707,7 +707,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     if (messages.length === 0) return
     shouldAutoScrollToLatestRef.current = false
     scrollToLatest("auto")
-  }, [jumpToMessageId, messages.length, openThreadId, scrollToLatest])
+  }, [channel.id, jumpToMessageId, messages.length, openThreadId, scrollToLatest])
 
   useEffect(() => {
     const newestMessage = messages[messages.length - 1]

--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -629,7 +629,9 @@ export const MessageItem = memo(function MessageItem({
           onMouseLeave={() => { setShowActions(false) }}
           onFocus={() => setShowActions(true)}
           onBlur={(e) => {
-            if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+            const relatedTarget = e.relatedTarget as HTMLElement | null
+            const focusMovedIntoEmojiPortal = Boolean(relatedTarget?.closest?.("[data-emoji-picker-portal]"))
+            if (!e.currentTarget.contains(relatedTarget) && !focusMovedIntoEmojiPortal) {
               setShowActions(false)
               setShowEmojiPicker(false)
               setEmojiPickerPos(null)
@@ -642,24 +644,24 @@ export const MessageItem = memo(function MessageItem({
               <button
                 type="button"
                 onClick={() => onReplyJump(message.reply_to_id!)}
-                className="w-full text-left flex items-center gap-2 mb-1 ml-10 text-xs tertiary-metadata rounded px-1 py-0.5 surface-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--theme-accent)]"
+                className="w-[calc(100%-2.5rem)] min-w-0 text-left flex items-center gap-2 mb-1 ml-10 text-xs tertiary-metadata rounded px-1 py-0.5 surface-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--theme-accent)]"
                 aria-label={message.reply_to ? "Jump to replied message" : "Jump to original message"}
               >
                 <Reply className="w-3 h-3 -scale-x-100" />
-                <span className="font-medium" style={{ color: 'var(--theme-text-secondary)' }}>
+                <span className="font-medium shrink-0" style={{ color: 'var(--theme-text-secondary)' }}>
                   {message.reply_to?.author?.display_name || message.reply_to?.author?.username || "Original message"}
                 </span>
-                <span className="truncate">{message.reply_to?.content || "Message unavailable"}</span>
+                <span className="truncate min-w-0">{message.reply_to?.content || "Message unavailable"}</span>
               </button>
             ) : (
               <div
-                className="w-full text-left flex items-center gap-2 mb-1 ml-10 text-xs tertiary-metadata rounded px-1 py-0.5"
+                className="w-[calc(100%-2.5rem)] min-w-0 text-left flex items-center gap-2 mb-1 ml-10 text-xs tertiary-metadata rounded px-1 py-0.5"
               >
                 <Reply className="w-3 h-3 -scale-x-100" />
-                <span className="font-medium" style={{ color: 'var(--theme-text-secondary)' }}>
+                <span className="font-medium shrink-0" style={{ color: 'var(--theme-text-secondary)' }}>
                   {message.reply_to?.author?.display_name || message.reply_to?.author?.username || "Original message"}
                 </span>
-                <span className="truncate">{message.reply_to?.content || "Message unavailable"}</span>
+                <span className="truncate min-w-0">{message.reply_to?.content || "Message unavailable"}</span>
               </div>
             )
           )}

--- a/apps/web/components/chat/typing-indicator.tsx
+++ b/apps/web/components/chat/typing-indicator.tsx
@@ -21,13 +21,13 @@ export function TypingIndicator({ users }: TypingIndicatorProps) {
   }
 
   return (
-    <div className="px-4 py-1 flex items-center gap-1.5 flex-shrink-0 composer-presence-rail" style={{ minHeight: "24px" }} aria-hidden="true">
+    <div className="px-4 py-1 flex items-center gap-1.5 flex-shrink-0 composer-presence-rail overflow-hidden" style={{ minHeight: "24px" }} aria-hidden="true">
       <span className="flex gap-0.5 items-end" aria-hidden="true">
         <span className="typing-dot" />
         <span className="typing-dot" />
         <span className="typing-dot" />
       </span>
-      <span className="text-xs text-muted-foreground">
+      <span className="text-xs text-muted-foreground truncate min-w-0 block">
         {buildTypingText(users)}
       </span>
     </div>


### PR DESCRIPTION
### Motivation
- Prevent long replied-message previews from forcing horizontal scrollbars in the message list.  
- Stop the emoji picker from closing when focus moves into its portaled search input so users can search without the picker disappearing.  
- Ensure typing text is constrained to the composer width and make the channel view reliably auto-scroll to latest when switching channels.

### Description
- Constrain the reply preview row and make its author/content spans shrink/truncate correctly by adding `w-[calc(100%-2.5rem)]`, `min-w-0`, `shrink-0`, and `truncate` adjustments in `apps/web/components/chat/message-item.tsx`.  
- Keep the emoji picker open when focus moves into the portaled picker by checking `e.relatedTarget` and allowing focus into elements matching `[data-emoji-picker-portal]` in `message-item.tsx`.  
- Limit the typing indicator width by adding `overflow-hidden` and `truncate min-w-0 block` to `apps/web/components/chat/typing-indicator.tsx`.  
- Make auto-scroll-on-load also respond to channel changes by including `channel.id` in the effect dependency array in `apps/web/components/chat/chat-area.tsx`.

### Testing
- Ran targeted ESLint on the modified files with `npx eslint` which produced only config/ignore warnings for direct file invocations (no new lint errors introduced by this patch).  
- Ran full repository lint with `cd apps/web && npm run lint`, which failed due to pre-existing style-guardrail violations unrelated to these changes.  
- Ran full type-check with `cd apps/web && npm run type-check`, which failed due to pre-existing TypeScript test-suite issues unrelated to this patch.  
- Attempted `cd apps/web && npm run dev` and a Playwright screenshot run; the dev server reported missing Supabase env vars in this environment and the browser run crashed (SIGSEGV), so UI verification could not be captured here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af285141048325ac1c33a6eeaed0c3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat auto-scroll behavior when switching between channels
  * Improved emoji picker interaction—no longer closes unexpectedly during use
  * Enhanced text truncation in message metadata and typing indicators
  * Optimized message layout for better display on narrow viewports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->