### PR TITLE
Refactor interest tag validation to use helper function

### DIFF
--- a/supabase/migrations/00056_profile_interests.sql
+++ b/supabase/migrations/00056_profile_interests.sql
@@ -7,15 +7,26 @@ ALTER TABLE public.users
   ADD COLUMN IF NOT EXISTS activity_visibility TEXT NOT NULL DEFAULT 'public'
     CHECK (activity_visibility IN ('public', 'friends', 'private'));
 
+-- Helper function to validate all interest tags (subqueries not allowed in CHECK constraints)
+CREATE OR REPLACE FUNCTION public.validate_interests(tags TEXT[])
+RETURNS BOOLEAN
+LANGUAGE sql
+IMMUTABLE
+SET search_path = ''
+AS $$
+  SELECT COALESCE(
+    bool_and(length(tag) <= 30 AND tag ~ '^[a-z0-9][a-z0-9\-]*[a-z0-9]?$'),
+    true
+  )
+  FROM unnest(tags) AS tag;
+$$;
+
 -- Enforce max 15 tags per user, each tag ≤ 30 chars and slug-like
 ALTER TABLE public.users
   ADD CONSTRAINT users_interests_max_count
     CHECK (cardinality(interests) <= 15),
   ADD CONSTRAINT users_interests_tag_length
-    CHECK (array_length(interests, 1) IS NULL OR NOT EXISTS (
-      SELECT 1 FROM unnest(interests) AS tag
-      WHERE length(tag) > 30 OR tag !~ '^[a-z0-9][a-z0-9\-]*[a-z0-9]?$'
-    ));
+    CHECK (public.validate_interests(interests));
 
 COMMENT ON COLUMN public.users.interests IS 'Interest tags displayed on the user profile, max 15, slug format';
 COMMENT ON COLUMN public.users.activity_visibility IS 'Who can see the recent activity feed: public | friends | private';


### PR DESCRIPTION
## Summary
Refactored the interest tag validation logic in the users table to use a dedicated SQL function instead of a NOT EXISTS subquery in the CHECK constraint. This improves code maintainability and works around PostgreSQL limitations with complex constraint expressions.

## Key Changes
- Created `public.validate_interests()` helper function to validate interest tags
  - Validates that each tag is ≤ 30 characters
  - Enforces slug-like format: `^[a-z0-9][a-z0-9\-]*[a-z0-9]?$`
  - Handles NULL/empty arrays gracefully with COALESCE
- Replaced complex NOT EXISTS subquery in `users_interests_tag_length` constraint with a call to the new validation function
- Function is marked as IMMUTABLE and has search_path set for security and performance

## Implementation Details
- The helper function uses `unnest()` to iterate over array elements and `bool_and()` to aggregate validation results
- COALESCE ensures NULL arrays pass validation (consistent with previous behavior)
- This approach avoids PostgreSQL's restriction on subqueries in CHECK constraints while maintaining the same validation logic

https://claude.ai/code/session_01GyBc29jDvKiEkz65HUvn5a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now add interests to their profile for better personalization
  * Activity visibility settings allow users to control who sees their activity (public, friends, or private)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->