### PR TITLE
Add slash command keybinding support to composer

### DIFF
--- a/apps/web/lib/composer-keybindings.test.ts
+++ b/apps/web/lib/composer-keybindings.test.ts
@@ -6,9 +6,12 @@ const baseState = {
   hasMentionSelection: false,
   isEmojiOpen: false,
   hasEmojiSelection: false,
+  isSlashOpen: false,
+  hasSlashSelection: false,
   hasDraftContent: false,
   mentionHandledNavigation: false,
   emojiHandledNavigation: false,
+  slashHandledNavigation: false,
 }
 
 describe("resolveComposerKeybinding", () => {
@@ -21,6 +24,8 @@ describe("resolveComposerKeybinding", () => {
       closeMention: false,
       acceptEmoji: false,
       closeEmoji: false,
+      acceptSlash: false,
+      closeSlash: false,
       clearDraft: false,
     })
   })


### PR DESCRIPTION
## Summary
Extended the composer keybinding test suite to include support for slash command interactions, mirroring the existing mention and emoji keybinding patterns.

## Key Changes
- Added `isSlashOpen` and `hasSlashSelection` state properties to track slash command menu state
- Added `slashHandledNavigation` state property to track navigation handling for slash commands
- Added `acceptSlash` and `closeSlash` keybinding response properties to handle slash command acceptance and dismissal

## Implementation Details
The changes follow the established patterns for mention and emoji keybindings, ensuring consistency across the composer's interactive features. The test base state now includes all necessary properties to support slash command keybinding resolution alongside existing mention and emoji functionality.

https://claude.ai/code/session_015R4k8d6SWCGQtnMWMBqLxm