### PR TITLE
Fix mobile PWA content overlapping status bar

### DIFF
--- a/apps/web/components/layout/channels-shell.tsx
+++ b/apps/web/components/layout/channels-shell.tsx
@@ -20,7 +20,7 @@ export function ChannelsShell({ children }: { children: React.ReactNode }) {
   return (
     <MobileNavProvider>
       {/* pb-16 md:pb-0 reserves space for the fixed MobileBottomTabBar on mobile; omitted in full-screen channel view */}
-      <div className={`flex h-screen overflow-hidden md:pb-0 ${isFullScreen ? "" : "pb-16"}`} style={{ background: "var(--app-bg-primary)", paddingTop: "env(safe-area-inset-top)" }}>
+      <div className={`flex h-screen overflow-hidden md:pb-0 ${isFullScreen ? "" : "pb-16"}`} style={{ background: "var(--app-bg-primary)", paddingTop: isFullScreen ? undefined : "env(safe-area-inset-top)" }}>
         <ConnectionBanner />
         <ServerSidebarWrapper />
         <MobileSwipeArea />


### PR DESCRIPTION
Add padding-top: env(safe-area-inset-top) to the ChannelsShell wrapper so page content (Servers header, Messages/Friends tabs) is pushed below the iOS status bar in standalone PWA mode with black-translucent style.

https://claude.ai/code/session_019rCexNKKBoZTn8NcfxwBqW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mobile overlay functionality for improved mobile experience
  * Enhanced safe area handling to properly support non-full-screen display modes

* **Style**
  * Improved layout structure with optimized flex container properties for better content organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->