### PR TITLE
Fix mobile top cutoff on settings/appeals pages and hide UserPanel on…

### DIFF
--- a/apps/web/app/appeals/page.tsx
+++ b/apps/web/app/appeals/page.tsx
@@ -53,7 +53,7 @@ export default function AppealsPage() {
   }
 
   return (
-    <main className="mx-auto max-w-3xl p-6 text-white">
+    <main className="mx-auto max-w-3xl p-6 text-white" style={{ paddingTop: "max(24px, calc(env(safe-area-inset-top) + 24px))" }}>
       <h1 className="text-2xl font-semibold">Ban appeal</h1>
       <p className="mt-2 text-sm text-zinc-300">Submit one active appeal per server and track review status.</p>
 

--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -22,7 +22,7 @@ export default async function SettingsLayout({ children }: { children: React.Rea
   return (
     <div
       className="flex h-screen overflow-hidden"
-      style={{ background: "var(--theme-bg-primary)" }}
+      style={{ background: "var(--theme-bg-primary)", paddingTop: "env(safe-area-inset-top)" }}
     >
       <SettingsResponsiveContent user={profile}>
         {children}

--- a/apps/web/components/layout/user-panel.tsx
+++ b/apps/web/components/layout/user-panel.tsx
@@ -107,7 +107,7 @@ export function UserPanel() {
 
   return (
     <div
-      className="flex items-center gap-2 p-2"
+      className="hidden md:flex items-center gap-2 p-2"
       style={{
         background: 'var(--theme-bg-secondary)',
         boxShadow: '0 -1px 0 var(--theme-bg-tertiary), inset 0 1px 0 color-mix(in srgb, var(--theme-accent) 7%, transparent)',


### PR DESCRIPTION
… mobile

- Add paddingTop: env(safe-area-inset-top) to settings layout so content doesn't render behind the iOS notch/Dynamic Island
- Add safe-area-inset-top to appeals page which had top-aligned content with insufficient padding for notch devices
- Hide UserPanel (bottom profile bar) on mobile via hidden md:flex since the "You" tab in the mobile bottom tab bar already provides profile access

https://claude.ai/code/session_01S5V2oGaHcks6aMdAMQv1E7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
- Adjusted top padding across application pages to properly respect device safe areas and display notches, ensuring improved visual spacing and consistent presentation for all users
- Updated navigation panel visibility to be hidden on mobile devices while displayed on medium-sized screens and larger devices, enhancing responsive design and optimizing screen space utilization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->