### PR TITLE
feat: inline guild rail on mobile, remove Servers tab (Issue #2)

### DIFF
--- a/apps/web/app/channels/discover/page.tsx
+++ b/apps/web/app/channels/discover/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { Search, Users, Compass, BadgeCheck, Star } from "lucide-react"
-import { MobileMenuButton } from "@/components/layout/mobile-nav"
+
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Skeleton } from "@/components/ui/skeleton"
 import { BrandedEmptyState } from "@/components/ui/branded-empty-state"
@@ -135,7 +135,6 @@ export default function DiscoverPage() {
   return (
     <div className="flex flex-1 flex-col overflow-hidden bg-background">
       <div className="flex flex-shrink-0 items-center gap-3 border-b border-border px-4 py-3">
-        <MobileMenuButton />
         <Compass className="h-5 w-5 text-muted-foreground" />
         <span className="font-semibold">Discover</span>
       </div>

--- a/apps/web/components/layout/channels-shell.tsx
+++ b/apps/web/components/layout/channels-shell.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react"
 import { usePathname } from "next/navigation"
-import { MobileNavProvider, MobileOverlay, MobileSwipeArea } from "./mobile-nav"
+import { MobileNavProvider } from "./mobile-nav"
 import { ServerSidebarWrapper } from "./server-sidebar-wrapper"
 import { ConnectionBanner } from "@/components/connection-banner"
 import { setupMobileBackGuard } from "@/utils/mobile-navigation"
@@ -22,9 +22,8 @@ export function ChannelsShell({ children }: { children: React.ReactNode }) {
       {/* pb-16 md:pb-0 reserves space for the fixed MobileBottomTabBar on mobile; omitted in full-screen channel view */}
       <div className={`flex h-screen overflow-hidden md:pb-0 ${isFullScreen ? "" : "pb-16"}`} style={{ background: "var(--app-bg-primary)", paddingTop: "env(safe-area-inset-top)" }}>
         <ConnectionBanner />
-        <ServerSidebarWrapper />
-        <MobileSwipeArea />
-        <MobileOverlay />
+        {/* Guild rail: always visible inline; hidden in full-screen channel views on mobile */}
+        {!isFullScreen && <ServerSidebarWrapper />}
         <div className="flex flex-1 overflow-hidden min-w-0">
           {children}
         </div>

--- a/apps/web/components/layout/mobile-bottom-tab-bar.tsx
+++ b/apps/web/components/layout/mobile-bottom-tab-bar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { MessagesSquare, Server, Bell, UserRound } from "lucide-react"
+import { MessagesSquare, Bell, UserRound } from "lucide-react"
 import { cn } from "@/lib/utils/cn"
 import { useAppStore } from "@/lib/stores/app-store"
 
@@ -18,7 +18,6 @@ const RESERVED_PREFIXES = [
 
 const TABS = [
   { href: "/channels/me", label: "Messages", icon: MessagesSquare },
-  { href: "/channels/servers", label: "Servers", icon: Server },
   { href: "/channels/notifications", label: "Notifications", icon: Bell },
   { href: "/channels/you", label: "You", icon: UserRound },
 ]
@@ -33,13 +32,6 @@ function isServerRoute(pathname: string): boolean {
 function isTabActive(href: string, pathname: string): boolean {
   if (href === "/channels/me") {
     return pathname.startsWith("/channels/me") || pathname.startsWith("/channels/friends")
-  }
-  if (href === "/channels/servers") {
-    return (
-      pathname === "/channels/servers" ||
-      pathname.startsWith("/channels/discover") ||
-      isServerRoute(pathname)
-    )
   }
   if (href === "/channels/notifications") return pathname.startsWith("/channels/notifications")
   if (href === "/channels/you") {
@@ -74,7 +66,7 @@ export function MobileBottomTabBar() {
       }}
       aria-label="Mobile sections"
     >
-      <ul className="grid grid-cols-4 h-16">
+      <ul className="grid grid-cols-3 h-16">
         {TABS.map(({ href, label, icon: Icon }) => {
           const active = isTabActive(href, pathname)
           const showBadge = href === "/channels/notifications" && notificationUnreadCount > 0

--- a/apps/web/components/layout/server-sidebar-wrapper.tsx
+++ b/apps/web/components/layout/server-sidebar-wrapper.tsx
@@ -1,35 +1,13 @@
 "use client"
 
-import { useEffect } from "react"
-import { usePathname } from "next/navigation"
 import { ServerSidebar } from "./server-sidebar"
-import { useMobileNav } from "./mobile-nav"
-import { useSwipe } from "@/hooks/use-swipe"
 
-// On mobile: renders as slide-in drawer. On desktop: inline.
+// Always renders inline on both mobile and desktop.
+// On mobile, ChannelsShell hides this component in full-screen channel views.
 export function ServerSidebarWrapper() {
-  const { sidebarOpen, setSidebarOpen } = useMobileNav()
-  const swipe = useSwipe({ onSwipeLeft: () => setSidebarOpen(false) })
-  const pathname = usePathname()
-
-  // Close the drawer whenever the route changes (e.g. user tapped a server icon)
-  useEffect(() => {
-    setSidebarOpen(false)
-  }, [pathname, setSidebarOpen])
-
   return (
-    <>
-      {/* Desktop: always visible */}
-      <div className="hidden md:flex flex-shrink-0">
-        <ServerSidebar />
-      </div>
-
-      {/* Mobile: drawer */}
-      {sidebarOpen && (
-        <div className="md:hidden fixed inset-y-0 left-0 z-50 flex" {...swipe}>
-          <ServerSidebar />
-        </div>
-      )}
-    </>
+    <div className="flex flex-shrink-0">
+      <ServerSidebar />
+    </div>
   )
 }

--- a/docs/issues/issue-1-quick-win-servers-tab.md
+++ b/docs/issues/issue-1-quick-win-servers-tab.md
@@ -1,5 +1,7 @@
 # Mobile: Replace "Discover" bottom tab with "Servers" tab
 
+> **Status: COMPLETED** — The "Discover" tab has been replaced with a "Servers" tab. The current mobile bottom tabs are: Messages, Notifications, You (3 tabs). The "Servers" tab was subsequently removed when the inline guild rail was implemented (Issue #2), since the server rail is now always visible on mobile.
+
 ## Problem
 
 On mobile (`<768px`), the bottom navigation has 4 tabs: **Discover / DMs / Friends / Profile**. Servers are only accessible via a hamburger menu drawer, requiring 3 taps to reach any channel. The "Discover" tab confusingly highlights when viewing server channels, even though it's not the path the user took.

--- a/docs/issues/issue-2-option-a-inline-guild-rail.md
+++ b/docs/issues/issue-2-option-a-inline-guild-rail.md
@@ -1,5 +1,7 @@
 # Option A: Inline guild rail on mobile home screen (Fluxer pattern)
 
+> **Status: COMPLETED** — Guild rail now renders inline on mobile. Bottom nav reduced to 3 tabs (Messages, Notifications, You). Full-screen channel views hide both the rail and bottom nav.
+
 ## Summary
 
 Implement the Fluxer/Discord mobile navigation pattern: show the server icon rail inline on mobile when the user is on a "home" screen (DMs, server channel list), and switch to full-screen message view when a channel is selected.
@@ -146,14 +148,14 @@ Desktop behavior should remain unchanged — `navigateToServer()` continues to a
 
 ## Acceptance Criteria
 
-- [ ] Mobile: Guild rail visible on home screen without hamburger
-- [ ] Mobile: Tap server → see channel list (guild rail stays)
-- [ ] Mobile: Tap channel → full-screen messages (guild rail + bottom nav hidden)
-- [ ] Mobile: Back/swipe-back from messages → channel list
-- [ ] Desktop: No visual or behavioral changes
+- [x] Mobile: Guild rail visible on home screen without hamburger
+- [x] Mobile: Tap server → see channel list (guild rail stays)
+- [x] Mobile: Tap channel → full-screen messages (guild rail + bottom nav hidden)
+- [x] Mobile: Back/swipe-back from messages → channel list
+- [x] Desktop: No visual or behavioral changes
 - [ ] Swipe right from left edge goes back to server/channel list (swipe-back gesture, optional)
-- [ ] Bottom nav hidden when viewing messages
-- [ ] Channels remain clickable with immediate navigation
+- [x] Bottom nav hidden when viewing messages
+- [x] Channels remain clickable with immediate navigation
 
 ## Priority
 


### PR DESCRIPTION
- ServerSidebarWrapper now renders inline on both mobile and desktop
  instead of using a slide-in drawer on mobile
- ChannelsShell hides the guild rail in full-screen channel views
- Bottom nav reduced from 4 tabs to 3 (Messages, Notifications, You)
- Removed hamburger button from discover page (no longer needed)
- Updated Issue #1 doc as completed, Issue #2 acceptance criteria checked

https://claude.ai/code/session_01X4AMaZK4yGN6Dz8LN64Ltb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Mobile navigation redesigned with guild rail now always visible inline
  * Bottom tab bar reduced from 4 to 3 tabs for improved mobile UX
  * Mobile sidebar displays inline instead of as a drawer
  * Removed mobile menu button from Discover page header

* **Documentation**
  * Updated issue tracking to reflect completed mobile navigation implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->