### PR TITLE
Fix channel sidebar height layout on mobile

### DIFF
--- a/apps/web/components/layout/channel-sidebar.tsx
+++ b/apps/web/components/layout/channel-sidebar.tsx
@@ -755,7 +755,7 @@ export function ChannelSidebar({ server, channels: initialChannels, currentUserI
   return (
     <TooltipProvider delayDuration={200}>
       <div
-        className="w-full md:w-60 flex flex-col flex-shrink-0 channel-sidebar-surface"
+        className="w-full md:w-60 h-full flex flex-col flex-shrink-0 channel-sidebar-surface"
       >
         {/* Server header */}
         <button

--- a/apps/web/components/layout/server-mobile-layout.tsx
+++ b/apps/web/components/layout/server-mobile-layout.tsx
@@ -84,7 +84,7 @@ export function ServerMobileLayout({ serverId, sidebar, memberList, children }: 
     return (
       <div className="flex flex-1 overflow-hidden">
         {/* Channel sidebar */}
-        <div className="flex-shrink-0">{sidebar}</div>
+        <div className="flex-shrink-0 h-full">{sidebar}</div>
         {/* Channel content */}
         <main id="main-content" className="flex flex-1 overflow-hidden">
           {children}


### PR DESCRIPTION
## Summary
Fixed layout issues with the channel sidebar not properly filling available vertical space on mobile devices.

## Changes
- Added `h-full` class to the channel sidebar in `channel-sidebar.tsx` to ensure it takes up the full height of its container
- Added `h-full` class to the sidebar wrapper in `server-mobile-layout.tsx` to ensure proper height inheritance in the mobile layout

## Details
These changes ensure that the channel sidebar properly stretches to fill the full height of the viewport on mobile devices, preventing layout gaps and improving the visual consistency of the mobile interface.

https://claude.ai/code/session_01AA2oJ5f4kz7nsE3ArnDgz6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Improved vertical layout spacing for sidebars in channel and mobile server navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->