### PR TITLE
Fix ServerSidebar visibility on mobile full-screen channel views

### DIFF
--- a/apps/web/components/layout/channels-shell.tsx
+++ b/apps/web/components/layout/channels-shell.tsx
@@ -22,8 +22,10 @@ export function ChannelsShell({ children }: { children: React.ReactNode }) {
       {/* pb-16 md:pb-0 reserves space for the fixed MobileBottomTabBar on mobile; omitted in full-screen channel view */}
       <div className={`flex h-screen overflow-hidden md:pb-0 ${isFullScreen ? "" : "pb-16"}`} style={{ background: "var(--app-bg-primary)", paddingTop: "env(safe-area-inset-top)" }}>
         <ConnectionBanner />
-        {/* Guild rail: always visible inline; hidden in full-screen channel views on mobile */}
-        {!isFullScreen && <ServerSidebarWrapper />}
+        {/* Guild rail: always visible on desktop; hidden in full-screen channel views on mobile */}
+        <div className={isFullScreen ? "hidden md:flex" : "flex"}>
+          <ServerSidebarWrapper />
+        </div>
         <div className="flex flex-1 overflow-hidden min-w-0">
           {children}
         </div>


### PR DESCRIPTION
## Summary
Updated the ServerSidebarWrapper visibility logic to properly hide the sidebar on mobile devices when in full-screen channel view mode, while keeping it visible on desktop at all times.

## Key Changes
- Replaced conditional rendering with a wrapper div using Tailwind CSS classes for responsive visibility control
- Changed from `{!isFullScreen && <ServerSidebarWrapper />}` to always render the component but control visibility with `hidden md:flex` / `flex` classes
- Updated the comment to clarify that the guild rail is always visible on desktop, not just "inline"

## Implementation Details
The new approach uses Tailwind's responsive utilities:
- `hidden md:flex` - hides the sidebar on mobile (< md breakpoint) and shows it on desktop (≥ md breakpoint) when in full-screen mode
- `flex` - shows the sidebar normally when not in full-screen mode

This ensures the ServerSidebarWrapper component remains mounted in the DOM while controlling its display based on screen size and full-screen state, which may be important for maintaining state or event listeners.

https://claude.ai/code/session_01Cj3NgT4arV9QinRBWkepMV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated sidebar rendering approach in full-screen mode to use CSS-controlled visibility instead of conditional component rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->