### PR TITLE
Send GIFs directly instead of inserting into message input

### DIFF
--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -1064,9 +1064,13 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
                         <button
                           key={gif.id}
                           onClick={async () => {
-                            const gifUrl = gif.url || gif.gifUrl
-                            setShowEmojiPicker(false)
                             if (sending) return
+                            const gifUrl = gif.url || gif.gifUrl
+                            if (!gifUrl?.trim()) {
+                              setSendError("Cannot send empty GIF.")
+                              return
+                            }
+                            setShowEmojiPicker(false)
                             setSending(true)
                             setSendError(null)
                             onSent?.()


### PR DESCRIPTION
## Summary
Changed the GIF insertion behavior to send GIFs directly as messages instead of inserting them into the message input field for manual sending.

## Key Changes
- Modified the GIF button click handler to send GIFs immediately via `onSend()` instead of appending to the message content
- Added proper async/await handling and error management for GIF sending
- Implemented sending state management to prevent duplicate submissions
- Added error handling with user-friendly error messages
- Removed the previous behavior of inserting GIF URLs into the textarea and updating draft content

## Implementation Details
- The handler now checks the `sending` state to prevent multiple concurrent sends
- Calls `onSent?.()` callback before attempting to send
- Wraps the `onSend(gifUrl)` call in try/catch/finally to handle errors and cleanup
- Sets `setSendError()` with appropriate error messages on failure
- Maintains focus on the textarea after sending completes
- Closes the emoji picker immediately when a GIF is selected

https://claude.ai/code/session_01Jox1aKd5zSk4uWe2Nmvua9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GIF sending to use asynchronous flow instead of synchronous text appending.
  * Improved error handling for failed GIF sends with user-facing error messages.
  * Enhanced state management during GIF transmission with proper loading states and focus restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->