### PR TITLE
Test CI workflows against multiple Node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,16 @@ jobs:
       - run: npm audit --audit-level=critical
 
   lint:
-    name: Lint
+    name: Lint (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
       # Run ESLint only. The style-guardrails check uses a locally-generated
@@ -41,38 +44,47 @@ jobs:
         working-directory: apps/web
 
   type-check:
-    name: Type Check
+    name: Type Check (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
       - run: npm run type-check --workspace=apps/web
       - run: npm run type-check --workspace=apps/signal
 
   test:
-    name: Tests
+    name: Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
       - run: npm test --workspace=apps/web
 
   parity-gates:
-    name: Parity Gates (A11y, Focus, Critical Regressions)
+    name: Parity Gates (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
       - run: npm run test:parity:critical --workspace=apps/web


### PR DESCRIPTION
## Summary
Updated the CI workflow to test against multiple Node.js versions (20 and 22) instead of only Node 22. This ensures compatibility across different Node versions that users may be running.

## Key Changes
- Added matrix strategy to `lint`, `type-check`, `test`, and `parity-gates` jobs to run against Node versions 20 and 22
- Updated job names to include the Node version being tested via `${{ matrix.node-version }}`
- Changed hardcoded `node-version: 22` to use `${{ matrix.node-version }}` in the `setup-node` action for all affected jobs

## Implementation Details
Each job now uses a matrix strategy that will spawn parallel job runs for each specified Node version. This allows us to catch version-specific issues early while maintaining fast feedback by running tests in parallel rather than sequentially.

https://claude.ai/code/session_0195vWHdrShmH1TiqCVQWx6X