### PR TITLE
Fix service worker Response clone error and CSP blocking Google Fonts

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -72,9 +72,9 @@ const nextConfig = {
               "default-src 'self'",
               // Next.js requires unsafe-inline/unsafe-eval for its runtime
               "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-              "style-src 'self' 'unsafe-inline'",
+              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               "img-src 'self' blob: data: https:",
-              "font-src 'self' data:",
+              "font-src 'self' data: https://fonts.gstatic.com",
               // Allow WebSocket connections (Supabase Realtime, Livekit) and external APIs
               "connect-src 'self' wss: https:",
               "media-src 'self' blob: https:",

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -51,7 +51,8 @@ self.addEventListener("fetch", (event) => {
       caches.match(request).then((cached) => {
         const fetchPromise = fetch(request)
           .then((response) => {
-            caches.open(CACHE_NAME).then((cache) => cache.put(request, response.clone()))
+            const clone = response.clone()
+            caches.open(CACHE_NAME).then((cache) => cache.put(request, clone))
             return response
           })
           .catch(() => cached)


### PR DESCRIPTION
Clone the fetch response synchronously before returning it, so the
deferred cache.put() doesn't race against the browser consuming the
body. Also add fonts.googleapis.com to style-src and fonts.gstatic.com
to font-src in the Content-Security-Policy header.

https://claude.ai/code/session_01MUS71GNVgp2VV9M6rBeuUR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced content security policies to enable seamless integration with Google Fonts, allowing the application to load font resources from Google's content delivery network without restrictions.

* **Chores**
  * Optimized internal service worker caching mechanism for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->