### PR TITLE
Improve service worker cache handling and bump cache versions

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -2,9 +2,9 @@
 // In production this file is replaced by the output of `scripts/build-sw.mjs`
 // (workbox-build injectManifest), which precaches all /_next/static/ chunks.
 
-const PRECACHE = "vortexchat-precache-v3"
-const RUNTIME = "vortexchat-runtime-v3"
-const APP_SHELL = "vortexchat-shell-v3"
+const PRECACHE = "vortexchat-precache-v4"
+const RUNTIME = "vortexchat-runtime-v4"
+const APP_SHELL = "vortexchat-shell-v4"
 const ALL_CACHES = [PRECACHE, RUNTIME, APP_SHELL]
 
 const APP_SHELL_ASSETS = [
@@ -46,8 +46,10 @@ self.addEventListener("fetch", (event) => {
     event.respondWith(
       fetch(request)
         .then((response) => {
-          const copy = response.clone()
-          caches.open(APP_SHELL).then((c) => c.put("/channels/me", copy))
+          if (response.ok && response.type !== "error") {
+            const copy = response.clone()
+            caches.open(APP_SHELL).then((c) => c.put("/channels/me", copy))
+          }
           return response
         })
         .catch(async () => {
@@ -63,7 +65,9 @@ self.addEventListener("fetch", (event) => {
       caches.match(request).then((cached) => {
         const fetchPromise = fetch(request)
           .then((response) => {
-            caches.open(RUNTIME).then((c) => c.put(request, response.clone()))
+            if (response.ok) {
+              caches.open(RUNTIME).then((c) => c.put(request, response.clone()))
+            }
             return response
           })
           .catch(() => cached)

--- a/apps/web/sw.src.js
+++ b/apps/web/sw.src.js
@@ -5,9 +5,9 @@
 // In development, public/sw.js is used directly as a fallback.
 
 // ─── Cache names ────────────────────────────────────────────────────────────
-const PRECACHE = "vortexchat-precache-v3"
-const RUNTIME = "vortexchat-runtime-v3"
-const APP_SHELL = "vortexchat-shell-v3"
+const PRECACHE = "vortexchat-precache-v4"
+const RUNTIME = "vortexchat-runtime-v4"
+const APP_SHELL = "vortexchat-shell-v4"
 const ALL_CACHES = [PRECACHE, RUNTIME, APP_SHELL]
 
 // ─── Precache manifest ───────────────────────────────────────────────────────
@@ -69,8 +69,10 @@ self.addEventListener("fetch", (event) => {
     event.respondWith(
       fetch(request)
         .then((response) => {
-          const copy = response.clone()
-          caches.open(APP_SHELL).then((c) => c.put("/channels/me", copy))
+          if (response.ok && response.type !== "error") {
+            const copy = response.clone()
+            caches.open(APP_SHELL).then((c) => c.put("/channels/me", copy))
+          }
           return response
         })
         .catch(async () => {
@@ -88,7 +90,9 @@ self.addEventListener("fetch", (event) => {
         (cached) =>
           cached ||
           fetch(request).then((response) => {
-            caches.open(PRECACHE).then((c) => c.put(request, response.clone()))
+            if (response.ok) {
+              caches.open(PRECACHE).then((c) => c.put(request, response.clone()))
+            }
             return response
           })
       )
@@ -102,7 +106,9 @@ self.addEventListener("fetch", (event) => {
       caches.match(request).then((cached) => {
         const fetchPromise = fetch(request)
           .then((response) => {
-            caches.open(RUNTIME).then((c) => c.put(request, response.clone()))
+            if (response.ok) {
+              caches.open(RUNTIME).then((c) => c.put(request, response.clone()))
+            }
             return response
           })
           .catch(() => cached)


### PR DESCRIPTION
## Summary
Updated the service worker to be more robust when caching responses by validating response status before storing in cache, and bumped all cache version identifiers from v3 to v4 to invalidate existing caches.

## Key Changes
- **Cache version bump**: Updated `PRECACHE`, `RUNTIME`, and `APP_SHELL` cache names from v3 to v4 across both `sw.src.js` and `public/sw.js`
- **Response validation for `/channels/me` endpoint**: Added checks to ensure `response.ok` and `response.type !== "error"` before caching the response
- **Response validation for PRECACHE strategy**: Added `response.ok` check before caching responses in the cache-first strategy
- **Response validation for RUNTIME strategy**: Added `response.ok` check before caching responses in the stale-while-revalidate strategy

## Implementation Details
These changes prevent caching of failed HTTP responses (4xx, 5xx status codes) and error responses, which could lead to serving stale error pages to users. The cache version bump ensures all users get fresh caches on their next service worker update, clearing out any potentially problematic cached responses from the previous version.

https://claude.ai/code/session_01K6G3CEHuZ5npwvFYNBHpLN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced service worker caching to only cache successful responses, preventing failed requests from being stored and served to users, improving app reliability.

* **Updates**
  * Updated cache versioning to clear stale cached data and ensure fresh content delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->