### PR TITLE
Fix clone() race: clone response synchronously before async cache.open()

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -66,7 +66,8 @@ self.addEventListener("fetch", (event) => {
         const fetchPromise = fetch(request)
           .then((response) => {
             if (response.ok) {
-              caches.open(RUNTIME).then((c) => c.put(request, response.clone()))
+              const copy = response.clone()
+              caches.open(RUNTIME).then((c) => c.put(request, copy))
             }
             return response
           })

--- a/apps/web/sw.src.js
+++ b/apps/web/sw.src.js
@@ -91,7 +91,8 @@ self.addEventListener("fetch", (event) => {
           cached ||
           fetch(request).then((response) => {
             if (response.ok) {
-              caches.open(PRECACHE).then((c) => c.put(request, response.clone()))
+              const copy = response.clone()
+              caches.open(PRECACHE).then((c) => c.put(request, copy))
             }
             return response
           })
@@ -107,7 +108,8 @@ self.addEventListener("fetch", (event) => {
         const fetchPromise = fetch(request)
           .then((response) => {
             if (response.ok) {
-              caches.open(RUNTIME).then((c) => c.put(request, response.clone()))
+              const copy = response.clone()
+              caches.open(RUNTIME).then((c) => c.put(request, copy))
             }
             return response
           })


### PR DESCRIPTION
The response.clone() was inside caches.open().then() — a nested async callback that runs after `return response` hands the body to the browser. By the time the cache opens, the body is already consumed and clone() throws "Response body is already used".

Fix: call clone() synchronously in the fetch .then(), before the async caches.open() callback runs.

https://claude.ai/code/session_01K6G3CEHuZ5npwvFYNBHpLN