### PR TITLE
Add Stoat to feature parity audit comparison matrix

### DIFF
--- a/docs/feature-parity-audit.md
+++ b/docs/feature-parity-audit.md
@@ -56,7 +56,7 @@ Gap severity:
 | Feature | VortexChat | Slack | Teams | Discord | Stoat | Notes / Gap Severity |
 |---|---|---|---|---|---|---|
 | Unicode emoji picker | ✅ frimousse picker with search, categories, skin tones | ✅ | ✅ | ✅ | ✅ | Parity |
-| Emoji reactions on messages | ✅ `reactions-client.ts`, real-time sync | ✅ | ✅ | ✅ | ✅ React perm | Parity |
+| Emoji reactions on messages | ✅ `reactions-client.ts`, real-time sync | ✅ | ✅ | ✅ | ⚠️ Partial (React perm exists, implementation limited) | **VortexChat ahead** of Stoat |
 | Custom server emoji (upload) | ✅ PNG/GIF/WEBP, 256 KB, management page, attribution | ✅ | ❌ | ✅ | ✅ | Parity |
 | Emoji autocomplete (`:name:`) | ✅ `use-emoji-autocomplete` hook | ✅ | ✅ | ✅ | ✅ | Parity |
 | GIF picker (Giphy/Tenor) | ✅ Dual provider, trending, search, suggestions | ✅ | ✅ | ✅ | ❌ | **VortexChat ahead** of Stoat |
@@ -86,7 +86,7 @@ Gap severity:
 |---|---|---|---|---|---|---|
 | Voice channels (always-on) | ✅ WebRTC P2P + LiveKit SFU dual mode | ❌ | ❌ | ✅ | ✅ Connect+Speak perms | Parity (Discord model) |
 | DM voice calls | ✅ `dm-call.tsx`, `incoming-call-ui.tsx` | ✅ | ✅ | ✅ | ✅ | Parity |
-| Multi-participant video | ✅ Camera toggle, 720p, adaptive grid | ✅ | ✅ | ✅ | ✅ Video perm | Parity |
+| Multi-participant video | ✅ Camera toggle, 720p, adaptive grid | ✅ | ✅ | ✅ | ⚠️ Built but not deployed on flagship | **VortexChat ahead** of Stoat |
 | Voice activity detection | ✅ hark.js speaking indicators | ✅ | ✅ | ✅ | ⚠️ Basic | Parity |
 | Noise suppression | ✅ Audio pipeline compressor + noise gate; LiveKit native | ✅ | ✅ | ✅ | ❌ | **VortexChat ahead** of Stoat |
 | Stage channels (speaker/audience) | ✅ `stage` channel type, request-to-speak | ❌ | ❌ | ✅ | ❌ | **VortexChat ahead** of Stoat |
@@ -101,7 +101,7 @@ Gap severity:
 
 | Feature | VortexChat | Slack | Teams | Discord | Stoat | Notes / Gap Severity |
 |---|---|---|---|---|---|---|
-| Screen sharing (getDisplayMedia) | ✅ Separate screen stream track | ✅ | ✅ | ✅ | ✅ | Parity |
+| Screen sharing (getDisplayMedia) | ✅ Separate screen stream track | ✅ | ✅ | ✅ | ⚠️ Built but not deployed on flagship | **VortexChat ahead** of Stoat |
 | Spotlight / focus view | ✅ Click to enlarge, compact tile view | ✅ | ✅ | ✅ | ⚠️ Basic | Parity |
 | Annotation / drawing on screen | ❌ | ❌ | ✅ | ❌ | ❌ | 🟢 Teams-only feature — skip |
 | Multi-presenter (concurrent shares) | ❌ One share at a time | ❌ | ✅ | ❌ | ❌ | 🟢 Teams-only — skip |
@@ -239,7 +239,7 @@ Gap severity:
 | iOS splash screens | ✅ 8 device sizes | ✅ | ✅ | ❌ | ❌ | **VortexChat ahead** of Stoat |
 | Web Share API | ✅ `navigator.share()` in context menu | ✅ | ✅ | ❌ | ❌ | **VortexChat ahead** of Stoat |
 | Input modes (`inputmode`) | ✅ Search, email, numeric | ✅ | ✅ | ❌ | ❌ | **VortexChat ahead** of Stoat |
-| Native mobile app | ❌ PWA only | ✅ | ✅ | ✅ | ⚠️ Third-party (Clerotri) | 🟢 Intentional — PWA-first strategy |
+| Native mobile app | ❌ PWA only | ✅ | ✅ | ✅ | ✅ Android (Kotlin) + iOS | 🟢 Intentional — PWA-first strategy |
 | Push on PWA (iOS 16.4+) | ✅ VAPID-based | ❌ | ❌ | ❌ | ❌ | **Ahead** on PWA push |
 
 ---
@@ -322,9 +322,11 @@ Full implementation plans for all gaps below are in [critical-gap-implementation
 
 | Feature | Stoat | VortexChat |
 |---|---|---|
-| Public bot SDK (multi-language) | ✅ revolt.js, revolt.py, Rust crate | ❌ Internal API only |
-| Self-hostable (open source) | ✅ Docker Compose, full FOSS | ❌ SaaS only |
+| Public bot SDK (multi-language) | ✅ JS, Python, Rust, Go, C#, Swift + community libs | ❌ Internal API only |
+| Self-hostable (open source) | ✅ Docker Compose, full FOSS (AGPL-3.0) | ❌ SaaS only |
 | Masquerade (alt identity posting) | ✅ Unique feature | ❌ |
+| Platform bridges (Discord, Matrix) | ✅ revcord, matrix-appservice-revolt | ❌ |
+| Native mobile apps | ✅ Android (Kotlin) + iOS | ❌ PWA only |
 
 ---
 


### PR DESCRIPTION
## Summary
Updated the feature parity audit document to include Stoat (formerly Revolt, an open-source Discord alternative) as a fourth comparison platform alongside Slack, Teams, and Discord. This provides a more comprehensive competitive analysis and highlights areas where VortexChat leads or lags behind an emerging open-source alternative.

## Key Changes

- **Expanded comparison scope**: Added Stoat column to all 15 feature comparison tables (Messaging, Threads, Reactions, File & Media, Voice & Video, Screen Share, Search, Notifications, Bots & Integrations, Channels, Server Management, Moderation, Accessibility, Mobile/PWA, and API & Developer Tools)

- **Updated audit metadata**: 
  - Changed audit date from 2026-03-17 to 2026-03-18
  - Added Stoat source reference with GitHub link and description
  - Updated scope note to include Stoat analysis

- **Added Stoat-specific findings**:
  - Identified areas where Stoat excels (public bot SDKs in multiple languages, self-hosting via Docker, masquerade feature, platform bridges)
  - Documented Stoat's gaps (no threads/forums, lacks AutoMod, limited search filters, no GIF picker, no slash commands, no polls)
  - Marked several VortexChat features as ahead of Stoat (threads, AutoMod, advanced search, voice intelligence, moderation timeline)

- **New summary sections**:
  - Expanded "Areas Where VortexChat Is Ahead" table with Stoat context
  - Added new "Areas Where Stoat Is Ahead" table highlighting Stoat's open-source advantages and unique features

- **Updated notes**: Refined gap severity assessments to account for Stoat's capabilities (e.g., "Discord/Stoat don't" instead of just "Discord doesn't")

## Notable Details

- Stoat's open-source nature (AGPL-3.0) and self-hosting capability represent a different deployment model than VortexChat's SaaS approach
- Stoat's public bot SDK ecosystem (revolt.js, revolt.py, Rust crate) is a significant advantage for developer adoption
- VortexChat maintains clear leads in voice/video features (noise suppression, stage channels), moderation (AutoMod, timeline), and advanced search capabilities
- Both platforms share a "all features free" philosophy, differentiating them from Slack/Discord/Teams

https://claude.ai/code/session_01HE3H4TARJU1hmCmbjK7mMU