### PR TITLE
Add blob: worker-src to CSP for WebRTC voice processing

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -78,6 +78,8 @@ const nextConfig = {
               // Allow WebSocket connections (Supabase Realtime, Livekit) and external APIs
               "connect-src 'self' wss: https:",
               "media-src 'self' blob: https:",
+              // Allow blob: workers for WebRTC voice processing
+              "worker-src 'self' blob:",
               // Allow embedded YouTube streams for Stage channels
               "frame-src 'self' https://www.youtube.com https://youtube.com https://www.youtube-nocookie.com",
               // Prevent <frame>/<iframe> embedding


### PR DESCRIPTION
## Summary
Updated the Content Security Policy (CSP) configuration to allow blob: workers, enabling WebRTC voice processing functionality.

## Key Changes
- Added `worker-src 'self' blob:` directive to the CSP headers in `next.config.js`
- This permits the application to create and execute Web Workers from blob URLs, which is necessary for WebRTC audio processing operations

## Implementation Details
The new CSP directive follows the existing pattern in the configuration and is placed alongside other media-related policies. This change allows the application to offload WebRTC voice processing to background workers without violating the Content Security Policy, improving performance and user experience for real-time audio features.

https://claude.ai/code/session_01TxZDEDRMXshfEmX4jqYzmL