### PR TITLE
Add flex-wrap to friends sidebar tabs for responsive layout

### DIFF
--- a/apps/web/components/dm/friends-sidebar.tsx
+++ b/apps/web/components/dm/friends-sidebar.tsx
@@ -265,7 +265,7 @@ export function FriendsSidebar({ compact, onStartDM }: { compact?: boolean; onSt
 
       {/* Tabs */}
       <div
-        className="flex gap-1 px-4 pb-2 flex-shrink-0 border-b"
+        className="flex flex-wrap gap-1 px-4 pb-2 flex-shrink-0 border-b"
         style={{ borderColor: "var(--theme-bg-tertiary)" }}
       >
         {tabs.map((t) => (


### PR DESCRIPTION
## Summary
Updated the friends sidebar tabs container to support wrapping on smaller screens, improving the responsive behavior of the tab navigation.

## Changes
- Added `flex-wrap` class to the tabs container in the friends sidebar
  - This allows tabs to wrap to the next line when space is constrained, rather than overflowing or being cut off
  - Maintains existing styling with gap, padding, and border properties

## Implementation Details
The change is minimal and non-breaking—it only adds responsive wrapping behavior to the existing flexbox layout without altering any other visual or functional aspects of the component.

https://claude.ai/code/session_018itFWzq3BXg9thnyu5gudm