### PR TITLE
Refocus feature parity audit: Discord & Stoat only

### DIFF
--- a/docs/feature-parity-audit.md
+++ b/docs/feature-parity-audit.md
@@ -275,6 +275,8 @@ Gap severity:
 | **7** | **Thread auto-archive** | Medium | Low | Discord-style auto-archive with configurable durations (1h/24h/3d/1w), cron job, auto-unarchive on message send. |
 | **10** | **Sticker packs** | Low | Medium | Klipy sticker API (search + trending) with tabbed picker in channels + DMs. |
 
+Note: ranks 6, 8, and 9 are intentionally omitted here because they remain open — see the "Open Gaps" section below.
+
 ### Open Gaps
 
 | Rank | Gap | Severity | Impact | Effort | Rationale |
@@ -285,17 +287,17 @@ Gap severity:
 
 ### All 🟡 Nice-to-Have Gaps (with implementation plans)
 
-Full implementation plans for all gaps below are in [critical-gap-implementation-plans.md](./critical-gap-implementation-plans.md).
+Full implementation plans for most gaps below are in [critical-gap-implementation-plans.md](./critical-gap-implementation-plans.md).
 
 | # | Gap | Severity | Complexity | Plan Section |
 |---|---|---|---|---|
-| 21 | Raid protection | 🟡 | M | Gap 21 — extends automod system |
-| 22 | Verification levels | 🟡 | S | Gap 22 — server setting + join gate |
-| 16 | Mobile push (native app) | 🟡 | L | Gap 16 — deferred (Capacitor wrapper) |
-| 20 | Vanity invite URLs | 🟡 | S | Gap 20 — single column + route |
 | 14 | OAuth app installs | 🟡 | M | No plan yet — Discord-style OAuth app marketplace |
+| 16 | Mobile push (native app) | 🟡 | L | Gap 16 — deferred (Capacitor wrapper) |
 | 17 | Zapier / Make connector | 🟡 | S | Gap 17 — depends on public API (#6) |
 | 18 | OAuth2 for third-party apps | 🟡 | L | Gap 18 — OAuth2 server, depends on #6 |
+| 20 | Vanity invite URLs | 🟡 | S | Gap 20 — single column + route |
+| 21 | Raid protection | 🟡 | M | Gap 21 — extends automod system |
+| 22 | Verification levels | 🟡 | S | Gap 22 — server setting + join gate |
 
 ---
 


### PR DESCRIPTION
## Summary
Refactored the feature parity audit document to focus on VortexChat's comparison against Discord and Stoat, removing Slack and Teams from all comparison tables. This reflects a more targeted competitive analysis aligned with VortexChat's actual market positioning.

## Changes Made

- **Removed Slack and Teams columns** from all 15 feature comparison tables (Messaging, Threads, Reactions, File & Media, Voice & Video, Screen Share, Search, Notifications, Bots & Integrations, Channels, Server Management, Moderation, Accessibility, Mobile/PWA, and API)

- **Updated gap severity notes** to reflect parity/gaps only against Discord and Stoat:
  - Features previously marked as gaps vs. Slack/Teams (e.g., rich-text toolbar, message scheduling) are now marked "Not a gap" since neither Discord nor Stoat has them
  - Clarified which gaps are Stoat-specific vs. Discord-specific

- **Reorganized critical gaps section** (top 10 priorities):
  - Removed gaps that were only relevant to Slack/Teams comparison
  - Reordered priorities to focus on Discord/Stoat competitive positioning
  - Added "Bot SDK / library" and "Raid protection" as higher-priority gaps

- **Simplified nice-to-have gaps list** from 24 items to 16, removing enterprise-focused features (SSO/SAML, high contrast mode, skip navigation) that are outside VortexChat's target market

- **Updated "Areas Where VortexChat Is Ahead"** section to reflect Discord/Stoat-only comparison, removing references to Slack/Teams

- **Updated footer timestamp** to document the refocus rationale

## Rationale
Slack and Teams are enterprise platforms with different feature sets and pricing models. Focusing the audit on Discord and Stoat provides a clearer competitive analysis for VortexChat's actual target market and helps prioritize development efforts accordingly.

https://claude.ai/code/session_01FB5p45iUkk65nTwUuJKXab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the feature parity audit to focus comparisons on VortexChat, Discord, and Stoat.
  * Removed Slack and Teams columns and references throughout the document.
  * Reorganized headers and collapsed per-platform parity rows into streamlined VortexChat vs. Discord/Stoat comparisons.
  * Moved per-feature tables from a five-column layout to a simplified three-column layout.
  * Consolidated and simplified the “Notes / Gap Severity” column and refreshed summary and conclusion text to match the narrower scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->