### PR TITLE
Fix marketplace apps list truncated to only 6 entries

### DIFF
--- a/apps/web/components/settings/apps-tab.tsx
+++ b/apps/web/components/settings/apps-tab.tsx
@@ -241,7 +241,7 @@ export function AppsTab({ serverId, canManageApps }: AppsTabProps) {
                       <div className="flex items-center gap-2">
                         <p style={{ color: "var(--theme-text-bright)" }}>{app.name}</p>
                         {app.trust_badge && (
-                          <BadgeCheck className="w-4 h-4" style={{ color: "var(--theme-success)" }} aria-label={`${app.trust_badge!.charAt(0).toUpperCase()}${app.trust_badge!.slice(1)} app`} />
+                          <BadgeCheck className="w-4 h-4" style={{ color: "var(--theme-success)" }} aria-label={`${app.trust_badge.charAt(0).toUpperCase()}${app.trust_badge.slice(1)} app`} />
                         )}
                       </div>
                       <p className="text-xs" style={{ color: "var(--theme-text-muted)" }}>


### PR DESCRIPTION
The apps-tab was using .slice(0, 6) which arbitrarily hid marketplace apps beyond the first 6. Removed the limit and now filter out already-installed apps instead, so all available apps are visible.

https://claude.ai/code/session_01PMh4moCinKEACNo7CMAFki

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Marketplace quick-install no longer lists apps that are already installed, preventing duplicates.
  * Shows a muted message when no uninstalled apps remain: “All discoverable apps are installed.”
  * Install button consistently reads “Install” and is disabled only when app management is not allowed or the app is actively busy.

* **Accessibility**
  * Trust badge aria-label updated to reflect the specific badge type (e.g., Verified, Partner, Internal).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->