### PR TITLE
Fix Giveaway Bot and Reminder Bot not showing in app marketplace

### DIFF
--- a/docs/mvp-core-features.md
+++ b/docs/mvp-core-features.md
@@ -156,4 +156,4 @@
 
 ---
 
-*Last updated: 2026-03-18*
+*Last updated: 2026-03-19*

--- a/supabase/migrations/00071_fix_giveaway_reminder_bot_visibility.sql
+++ b/supabase/migrations/00071_fix_giveaway_reminder_bot_visibility.sql
@@ -22,13 +22,14 @@ VALUES (
   TRUE
 )
 ON CONFLICT (slug) DO UPDATE SET
-  name        = EXCLUDED.name,
-  description = EXCLUDED.description,
-  category    = EXCLUDED.category,
-  permissions = EXCLUDED.permissions,
-  trust_badge = EXCLUDED.trust_badge,
-  identity    = EXCLUDED.identity,
-  is_published = TRUE;
+  name           = EXCLUDED.name,
+  description    = EXCLUDED.description,
+  category       = EXCLUDED.category,
+  install_scopes = EXCLUDED.install_scopes,
+  permissions    = EXCLUDED.permissions,
+  trust_badge    = EXCLUDED.trust_badge,
+  identity       = EXCLUDED.identity,
+  is_published   = TRUE;
 
 INSERT INTO public.app_catalog (slug, name, description, category, install_scopes, permissions, trust_badge, identity, is_published)
 VALUES (
@@ -43,13 +44,14 @@ VALUES (
   TRUE
 )
 ON CONFLICT (slug) DO UPDATE SET
-  name        = EXCLUDED.name,
-  description = EXCLUDED.description,
-  category    = EXCLUDED.category,
-  permissions = EXCLUDED.permissions,
-  trust_badge = EXCLUDED.trust_badge,
-  identity    = EXCLUDED.identity,
-  is_published = TRUE;
+  name           = EXCLUDED.name,
+  description    = EXCLUDED.description,
+  category       = EXCLUDED.category,
+  install_scopes = EXCLUDED.install_scopes,
+  permissions    = EXCLUDED.permissions,
+  trust_badge    = EXCLUDED.trust_badge,
+  identity       = EXCLUDED.identity,
+  is_published   = TRUE;
 
 -- Ensure rate limits exist for both apps
 INSERT INTO public.app_rate_limits (app_id, requests_per_minute, burst)


### PR DESCRIPTION
Migrations 00066/00068 used ON CONFLICT (slug) DO NOTHING when seeding these catalog entries. If rows with those slugs already existed with is_published = false, the inserts were silently skipped and the apps stayed invisible. New migration 00071 upserts both entries to guarantee is_published = TRUE and correct metadata.

https://claude.ai/code/session_01Vf8wWLKUaGG2j1Eb1kucck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Documented Reminder Bot MVP features including personal reminders with a 24-hour cap and per-user limits.
  * Added Reminder Bot slash commands: `/reminder`, `/reminders`, `/rcancel`.
  * Updated marketplace visibility documentation for Giveaway Bot and Reminder Bot.

* **Bug Fixes**
  * Corrected publication status for Giveaway Bot and Reminder Bot in the app marketplace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->