### PR TITLE
Fix custom element attribute handling in markdown renderer

### DIFF
--- a/apps/web/components/chat/markdown-renderer.tsx
+++ b/apps/web/components/chat/markdown-renderer.tsx
@@ -426,12 +426,12 @@ function buildComponents(currentUserId: string, serverId: string | null, bigEmoj
 
     // Custom elements from our remark plugins (passed through rehype-raw)
     "vortex-emoji": ({ node, ...props }: any) => {
-      const name = props["data-name"] ?? node?.properties?.dataName ?? ""
+      const name = props.dataName ?? props["data-name"] ?? node?.properties?.dataName ?? ""
       return <ServerEmojiImage name={name} size={emojiSize} />
     },
 
     "vortex-mention": ({ node, ...props }: any) => {
-      const uid = props["data-uid"] ?? node?.properties?.dataUid ?? ""
+      const uid = props.dataUid ?? props["data-uid"] ?? node?.properties?.dataUid ?? ""
       const isSelfMention = uid === currentUserId
       const member = members.find((m) => m.user_id === uid)
       const displayLabel = member?.nickname ?? member?.display_name ?? member?.username ?? uid
@@ -451,8 +451,8 @@ function buildComponents(currentUserId: string, serverId: string | null, bigEmoj
     },
 
     "vortex-timestamp": ({ node, ...props }: any) => {
-      const epoch = parseInt(props["data-epoch"] ?? node?.properties?.dataEpoch ?? "0", 10)
-      const format = props["data-format"] ?? node?.properties?.dataFormat ?? "f"
+      const epoch = parseInt(props.dataEpoch ?? props["data-epoch"] ?? node?.properties?.dataEpoch ?? "0", 10)
+      const format = props.dataFormat ?? props["data-format"] ?? node?.properties?.dataFormat ?? "f"
       return <TimestampDisplay epoch={epoch} format={format} />
     },
 
@@ -492,9 +492,9 @@ const sanitizeSchema = {
   ],
   attributes: {
     ...defaultSchema.attributes,
-    "vortex-emoji": ["data-name"],
-    "vortex-mention": ["data-uid"],
-    "vortex-timestamp": ["data-epoch", "data-format"],
+    "vortex-emoji": ["dataName"],
+    "vortex-mention": ["dataUid"],
+    "vortex-timestamp": ["dataEpoch", "dataFormat"],
     // Allow only src and alt on img — className/draggable/loading are hardcoded
     // in the component handler, not parsed from HTML attributes
     img: ["src", "alt"],


### PR DESCRIPTION
## Summary
Updated the markdown renderer to properly handle custom element attributes by checking for camelCase property names before falling back to kebab-case attribute names. This ensures attributes are correctly parsed regardless of how they're passed through the rehype pipeline.

## Key Changes
- **vortex-emoji component**: Updated to check `dataName` property before `data-name` attribute
- **vortex-mention component**: Updated to check `dataUid` property before `data-uid` attribute  
- **vortex-timestamp component**: Updated to check `dataEpoch` and `dataFormat` properties before their kebab-case equivalents
- **sanitizeSchema**: Updated allowed attributes to use camelCase names (`dataName`, `dataUid`, `dataEpoch`, `dataFormat`) instead of kebab-case

## Implementation Details
The changes follow a consistent pattern of checking the camelCase property name first (which is how rehype-raw passes through custom properties), then falling back to the kebab-case attribute name for backward compatibility, and finally checking the node properties as a last resort. This ensures robust attribute handling across different processing stages of the markdown-to-React pipeline.

https://claude.ai/code/session_01Bosq3KKyysaPfBB9i2ECaq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved markdown rendering system with enhanced attribute handling capabilities for message components while maintaining full backward compatibility with existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->