### PR TITLE
Increase VortexLogo size in server sidebar from 24 to 32

### DIFF
--- a/apps/web/components/layout/server-sidebar.tsx
+++ b/apps/web/components/layout/server-sidebar.tsx
@@ -112,7 +112,7 @@ export function ServerSidebar() {
                   : 'var(--theme-bg-primary)',
               }}
             >
-              <VortexLogo size={24} />
+              <VortexLogo size={32} />
             </Link>
           </TooltipTrigger>
           <TooltipContent side="right">Direct Messages</TooltipContent>


### PR DESCRIPTION
## Summary
Increased the size of the VortexLogo component in the server sidebar to improve visibility and visual hierarchy.

## Changes
- Updated VortexLogo size prop from `24` to `32` in the Direct Messages tooltip trigger within the server sidebar navigation

## Details
This change makes the logo more prominent in the sidebar navigation, enhancing the visual presence of the Direct Messages section while maintaining the existing layout and tooltip functionality.

https://claude.ai/code/session_012yr5E9D6ssjh8Hb2cVoxtU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the size of the Direct Messages navigation icon in the sidebar for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->