### PR TITLE
Bump service worker cache version to v5 to bust stale PWA icons

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -2,9 +2,9 @@
 // In production this file is replaced by the output of `scripts/build-sw.mjs`
 // (workbox-build injectManifest), which precaches all /_next/static/ chunks.
 
-const PRECACHE = "vortexchat-precache-v4"
-const RUNTIME = "vortexchat-runtime-v4"
-const APP_SHELL = "vortexchat-shell-v4"
+const PRECACHE = "vortexchat-precache-v5"
+const RUNTIME = "vortexchat-runtime-v5"
+const APP_SHELL = "vortexchat-shell-v5"
 const ALL_CACHES = [PRECACHE, RUNTIME, APP_SHELL]
 
 const APP_SHELL_ASSETS = [

--- a/apps/web/sw.src.js
+++ b/apps/web/sw.src.js
@@ -5,9 +5,9 @@
 // In development, public/sw.js is used directly as a fallback.
 
 // ─── Cache names ────────────────────────────────────────────────────────────
-const PRECACHE = "vortexchat-precache-v4"
-const RUNTIME = "vortexchat-runtime-v4"
-const APP_SHELL = "vortexchat-shell-v4"
+const PRECACHE = "vortexchat-precache-v5"
+const RUNTIME = "vortexchat-runtime-v5"
+const APP_SHELL = "vortexchat-shell-v5"
 const ALL_CACHES = [PRECACHE, RUNTIME, APP_SHELL]
 
 // ─── Precache manifest ───────────────────────────────────────────────────────


### PR DESCRIPTION
The SW was caching icon-192.png and icon-512.png in the app shell cache. After the logo files were updated, the old cached versions continued to be served. Bumping from v4 to v5 forces the activate handler to purge old caches and re-fetch the current icon assets.

https://claude.ai/code/session_012yr5E9D6ssjh8Hb2cVoxtU