### PR TITLE
Fix YouTube OAuth redirect_uri_mismatch

### DIFF
--- a/apps/web/app/api/users/connections/youtube/callback/route.ts
+++ b/apps/web/app/api/users/connections/youtube/callback/route.ts
@@ -121,8 +121,18 @@ export async function GET(request: Request): Promise<NextResponse> {
       return NextResponse.redirect(buildRedirect(url, nextPath, "youtube_no_code"))
     }
 
+    let origin = url.origin
     const appUrl = process.env.NEXT_PUBLIC_APP_URL
-    const origin = appUrl ? appUrl.replace(/\/+$/, "") : url.origin
+    if (appUrl) {
+      try {
+        const parsed = new URL(appUrl)
+        if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+          origin = parsed.origin
+        }
+      } catch {
+        // Invalid NEXT_PUBLIC_APP_URL — fall back to request origin
+      }
+    }
     const redirectUri = `${origin}/api/users/connections/youtube/callback`
     const accessToken = await exchangeCodeForToken(code, redirectUri)
     if (!accessToken) {

--- a/apps/web/app/api/users/connections/youtube/start/route.ts
+++ b/apps/web/app/api/users/connections/youtube/start/route.ts
@@ -24,8 +24,18 @@ export async function GET(request: Request): Promise<NextResponse> {
     }
 
     const url = new URL(request.url)
+    let origin = url.origin
     const appUrl = process.env.NEXT_PUBLIC_APP_URL
-    const origin = appUrl ? appUrl.replace(/\/+$/, "") : url.origin
+    if (appUrl) {
+      try {
+        const parsed = new URL(appUrl)
+        if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+          origin = parsed.origin
+        }
+      } catch {
+        // Invalid NEXT_PUBLIC_APP_URL — fall back to request origin
+      }
+    }
     const next = sanitizeNextPath(url.searchParams.get("next") || "/")
     const state = randomBytes(16).toString("hex")
 


### PR DESCRIPTION
## Summary
- Fix `redirect_uri_mismatch` error when connecting YouTube via Google OAuth
- Use `NEXT_PUBLIC_APP_URL` as the origin for the OAuth redirect URI instead of deriving it from `request.url`, which can produce mismatched origins (e.g. Vercel preview URLs)

## Test plan
- [ ] Set `NEXT_PUBLIC_APP_URL=http://localhost:3000` in `.env.local`
- [ ] Ensure `http://localhost:3000/api/users/connections/youtube/callback` is registered in Google Cloud Console
- [ ] Click "Connect YouTube" and verify OAuth flow completes without `redirect_uri_mismatch`

https://claude.ai/code/session_012kzCwsCWDpsrVCWYsxvhn3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Fixed YouTube account connection issues by improving how the application determines OAuth redirect URLs, particularly in custom deployment environments where the app's public URL is configured separately from the running instance.
* Improved security for YouTube authentication by correctly detecting HTTPS requirements, ensuring authentication cookies are marked as secure when communicating over encrypted connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->