### PR TITLE
Add Skyrim-inspired custom CSS theme

### DIFF
--- a/apps/web/public/themes/frosthearth.css
+++ b/apps/web/public/themes/frosthearth.css
@@ -19,6 +19,7 @@
   /* ── App shell backgrounds — dark hewn stone ─────────────────────────── */
   --app-bg-primary: #1c1e1f;
   --app-bg-secondary: #161819;
+  --app-bg-deepest: #1a1b1d;
 
   /* ── Surface palette — weathered stone & iron ────────────────────────── */
   --theme-bg-primary: #1c1e1f;
@@ -27,7 +28,10 @@
   --theme-surface-elevated: #2a2c2e;
   --theme-surface-input: #242627;
   --theme-surface-elevation-1: #212324;
+  --theme-surface-elevation-2: #2a2c2e;
   --theme-surface-elevation-3: #303234;
+  --theme-surface-elevation-4: #383a3c;
+  --theme-surface-elevation-5: #404244;
   --theme-surface-passive: var(--theme-surface-elevation-1);
   --theme-surface-active: var(--theme-surface-elevation-3);
   --theme-focus-shift: color-mix(in srgb, var(--theme-accent) 30%, transparent);
@@ -49,6 +53,50 @@
   --theme-warning: #d4a740;
   --theme-danger: #a83c3c;
   --theme-presence-offline: #6b6459;
+
+  /* ── Mention-self tokens ─────────────────────────────────────────────── */
+  --theme-mention-self-color: color-mix(in srgb, var(--theme-warning) 60%, white);
+  --theme-mention-self-bg: color-mix(in srgb, var(--theme-warning) 24%, transparent);
+  --theme-mention-self-border: color-mix(in srgb, var(--theme-warning) 55%, transparent);
+
+  /* ── Shadow elevations ───────────────────────────────────────────────── */
+  --theme-shadow-elevation-1: 0 1px 2px color-mix(in srgb, black 22%, transparent),
+    0 0 0 1px color-mix(in srgb, white 4%, transparent) inset;
+  --theme-shadow-elevation-2: 0 4px 12px color-mix(in srgb, black 28%, transparent),
+    0 1px 0 color-mix(in srgb, white 6%, transparent) inset;
+  --theme-shadow-elevation-3: 0 8px 24px color-mix(in srgb, black 34%, transparent),
+    0 1px 0 color-mix(in srgb, white 8%, transparent) inset;
+  --theme-shadow-elevation-4: 0 14px 32px color-mix(in srgb, black 38%, transparent),
+    0 1px 0 color-mix(in srgb, white 10%, transparent) inset;
+  --theme-shadow-elevation-5: 0 24px 42px color-mix(in srgb, black 45%, transparent),
+    0 1px 0 color-mix(in srgb, white 12%, transparent) inset;
+
+  /* ── Opacity & misc design tokens ────────────────────────────────────── */
+  --theme-opacity-overlay: 0.72;
+  --theme-opacity-muted: 0.7;
+  --color-tertiary-metadata: #8a806e;
+  --radius: 0.5rem;
+
+  /* ── Motion timing & easing ──────────────────────────────────────────── */
+  --motion-duration-instant: 80ms;
+  --motion-duration-fast: 120ms;
+  --motion-duration-standard: 180ms;
+  --motion-duration-panel: 220ms;
+  --motion-duration-slow: 320ms;
+  --motion-duration-skeleton: 1600ms;
+  --motion-ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --motion-ease-emphasized: cubic-bezier(0.16, 1, 0.3, 1);
+  --motion-ease-decelerate: cubic-bezier(0, 0, 0.2, 1);
+  --motion-ease-accelerate: cubic-bezier(0.4, 0, 1, 1);
+  --motion-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* ── Interaction state tokens ────────────────────────────────────────── */
+  --motion-hover-bg: color-mix(in srgb, var(--theme-text-primary) 5%, transparent);
+  --motion-hover-bg-md: color-mix(in srgb, var(--theme-text-primary) 8%, transparent);
+  --motion-press-scale: 0.97;
+  --motion-select-bg: color-mix(in srgb, var(--theme-accent) 14%, var(--theme-surface-elevated));
+  --motion-skeleton-base: color-mix(in srgb, var(--theme-text-primary) 6%, transparent);
+  --motion-skeleton-shimmer: color-mix(in srgb, var(--theme-text-primary) 12%, transparent);
 
   /* ── Tailwind design tokens (HSL — no hsl() wrapper) ─────────────── */
   --background: 200 4% 11%;
@@ -75,23 +123,23 @@
 /* ── Frosthearth accents ───────────────────────────────────────────────── */
 
 /* Cold stone hover on messages */
-.message-hover:hover {
-  background: rgba(110, 175, 200, 0.05) !important;
+[data-message].message-hover:hover {
+  background: color-mix(in srgb, var(--theme-accent) 5%, transparent);
 }
 
 /* Weathered iron scrollbar */
-::-webkit-scrollbar-thumb {
-  background: rgba(176, 165, 144, 0.25) !important;
+:root ::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--theme-text-secondary) 25%, transparent);
   border-radius: 2px;
 }
-::-webkit-scrollbar-thumb:hover {
-  background: rgba(176, 165, 144, 0.4) !important;
+:root ::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--theme-text-secondary) 40%, transparent);
 }
 
 /* Frost glow on focused inputs */
-input:focus,
-textarea:focus {
-  box-shadow: 0 0 0 2px rgba(110, 175, 200, 0.2) !important;
+:root input:focus,
+:root textarea:focus {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--theme-accent) 20%, transparent);
 }
 
 /* Parchment-colored links */
@@ -102,28 +150,28 @@ textarea:focus {
 /* ── Stone & iron embellishments (optional decorative touches) ─────── */
 
 /* Subtle top-border accent on the chat header — like a carved stone lintel */
-.chat-area-header-surface {
-  border-bottom: 1px solid rgba(110, 175, 200, 0.12) !important;
+.chat-area .chat-area-header-surface {
+  border-bottom: 1px solid color-mix(in srgb, var(--theme-accent) 12%, transparent);
 }
 
 /* Channel sidebar items get a warm hearthfire hover */
-.interactive-list-item:hover {
-  background: rgba(200, 162, 78, 0.08) !important;
+nav .interactive-list-item:hover {
+  background: color-mix(in srgb, var(--theme-accent-secondary) 8%, transparent);
 }
 
 /* Active channel — faint gold underline like an enchantment glow */
-.channel-active {
-  background: rgba(200, 162, 78, 0.12) !important;
-  border-left: 2px solid #c8a24e !important;
+nav .channel-active {
+  background: color-mix(in srgb, var(--theme-accent-secondary) 12%, transparent);
+  border-left: 2px solid var(--theme-accent-secondary);
 }
 
-/* Server sidebar icon backgrounds — darkest stone, like a dungeon wall */
-.server-sidebar-icon-bg {
-  background: #1a1b1d !important;
+/* Server sidebar icon backgrounds — darkest stone */
+aside .server-sidebar-icon-bg {
+  background: var(--app-bg-deepest);
 }
 
-/* Mention highlights — warm enchantment amber */
-.mention-highlight {
-  background: rgba(200, 162, 78, 0.1) !important;
-  border-left-color: #c8a24e !important;
+/* Mention highlights — warm amber */
+.message-content .mention-highlight {
+  background: color-mix(in srgb, var(--theme-accent-secondary) 10%, transparent);
+  border-left-color: var(--theme-accent-secondary);
 }


### PR DESCRIPTION
A Nord/Elder Scrolls V aesthetic with dark stone grays, aged parchment
text, frosty blue accents, and warm hearthfire gold highlights. Users
can apply it via Profile Settings → Appearance → Custom CSS.

https://claude.ai/code/session_01L1K7sSS9AZNFvXTupvCkMk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Frosthearth" custom theme with a complete design system: refined colors for backgrounds, surfaces, text, accents, semantic states, shadows, radii, and motion.
  * UI polish across the app: message hover/mention highlights, link and input focus styling, scrollbar theming, active channel and sidebar icon accents, and warm hover states for navigation items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->