### PR TITLE
Fix broken themes: scope color-mode overrides to twilight only

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1171,13 +1171,14 @@ html[data-line-height] body { line-height: var(--vortex-line-height); }
   --theme-presence-offline: #585b70;
 }
 
-/* ── Color mode overrides — placed after presets with :root prefix for higher
-   specificity so they reliably override preset tokens when the user forces a
-   color scheme that differs from the selected preset. ───────────────────── */
+/* ── Color mode overrides — scoped to the default "twilight" preset so they
+   do NOT clobber themes that already define a complete token set.  Each theme
+   preset declares every token it needs, so a generic light/dark override must
+   not interfere. ────────────────────────────────────────────────────────── */
 
 /* System: follow OS preference */
 @media (prefers-color-scheme: light) {
-  :root[data-color-mode="system"] {
+  :root[data-color-mode="system"][data-theme-preset="twilight"] {
     --background: 0 0% 100%;
     --foreground: 0 0% 9%;
     --card: 0 0% 98%;
@@ -1218,7 +1219,7 @@ html[data-line-height] body { line-height: var(--vortex-line-height); }
 }
 
 @media (prefers-color-scheme: dark) {
-  :root[data-color-mode="system"] {
+  :root[data-color-mode="system"][data-theme-preset="twilight"] {
     --background: 223 7% 20%;
     --foreground: 220 9% 95%;
     --card: 220 7% 18%;
@@ -1255,8 +1256,8 @@ html[data-line-height] body { line-height: var(--vortex-line-height); }
   }
 }
 
-/* Forced light mode */
-:root[data-color-mode="light"] {
+/* Forced light mode — only for the default theme; other presets are self-contained */
+:root[data-color-mode="light"][data-theme-preset="twilight"] {
   --background: 0 0% 100%;
   --foreground: 0 0% 9%;
   --card: 0 0% 98%;
@@ -1295,8 +1296,8 @@ html[data-line-height] body { line-height: var(--vortex-line-height); }
   color-scheme: light;
 }
 
-/* Forced dark mode */
-:root[data-color-mode="dark"] {
+/* Forced dark mode — only for the default theme; other presets are self-contained */
+:root[data-color-mode="dark"][data-theme-preset="twilight"] {
   --background: 223 7% 20%;
   --foreground: 220 9% 95%;
   --card: 220 7% 18%;


### PR DESCRIPTION
## Summary\n\n- **Root cause**: The color-mode CSS overrides (`:root[data-color-mode=\"dark\"]`) had higher specificity (0,2,0) than theme preset selectors (`[data-theme-preset=\"oled-black\"]` at 0,1,0). Since the default `colorMode` is `\"dark\"`, the generic dark-mode variables always clobbered every theme's custom variables.\n- **Fix**: Added `[data-theme-preset=\"twilight\"]` to all 4 color-mode override selectors so they only affect the default theme. All other presets (OLED Black, Synthwave, Frost, Carbon, etc.) already declare a complete token set and are self-contained.\n- **Result**: OLED Black, Midnight Neon, Synthwave, Carbon, Frost, Clarity, and Velvet Dusk all render with their intended colors again.\n\n## Test plan\n\n- [ ] Select OLED Black theme — background should be true black (#000000), accent Tiffany Blue (#0abab5)\n- [ ] Select Synthwave theme — background should be purple (#2a1e46), accent pink (#f92aad)\n- [ ] Select Frost theme — background should be slate-blue (#1a2332), accent amber (#e0a526)\n- [ ] Select Clarity theme — background should be white (#ffffff)\n- [ ] Select Twilight theme with color-mode \"dark\" — should still apply dark overrides correctly\n- [ ] Select Twilight theme with color-mode \"light\" — should still switch to light mode\n\nhttps://claude.ai/code/session_015gePFUN2Xou9QaRP8RPA4h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved theme color mode handling by refining how light and dark mode overrides apply to the twilight preset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->