### PR TITLE
Frosthearth theme: add interaction tokens, focus-visible, scrollbar parity, and decorative styles

### DIFF
--- a/apps/web/public/themes/frosthearth.css
+++ b/apps/web/public/themes/frosthearth.css
@@ -118,28 +118,48 @@
   --ring: 200 40% 60%;
   --destructive: 0 48% 45%;
   --destructive-foreground: 36 30% 95%;
+
+  /* ── Frosthearth interaction helpers ─────────────────────────────────── */
+  --frosthearth-focus-ring: color-mix(in srgb, var(--theme-accent) 26%, transparent);
+  --frosthearth-focus-outline: color-mix(in srgb, var(--theme-accent) 72%, white);
+  --frosthearth-scrollbar-thumb: color-mix(in srgb, var(--theme-text-secondary) 25%, transparent);
+  --frosthearth-scrollbar-thumb-hover: color-mix(in srgb, var(--theme-text-secondary) 40%, transparent);
+  --frosthearth-hover-cool: color-mix(in srgb, var(--theme-accent) 5%, transparent);
+  --frosthearth-hover-warm: color-mix(in srgb, var(--theme-accent-secondary) 8%, transparent);
+  --frosthearth-active-warm: color-mix(in srgb, var(--theme-accent-secondary) 12%, transparent);
+  --frosthearth-aurora: color-mix(in srgb, var(--theme-accent) 18%, transparent);
+  --frosthearth-hearth: color-mix(in srgb, var(--theme-accent-secondary) 14%, transparent);
+  --frosthearth-engraving: color-mix(in srgb, var(--theme-text-bright) 8%, transparent);
 }
 
 /* ── Frosthearth accents ───────────────────────────────────────────────── */
 
 /* Cold stone hover on messages */
 [data-message].message-hover:hover {
-  background: color-mix(in srgb, var(--theme-accent) 5%, transparent);
+  background: var(--frosthearth-hover-cool);
 }
 
 /* Weathered iron scrollbar */
 :root ::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--theme-text-secondary) 25%, transparent);
+  background: var(--frosthearth-scrollbar-thumb);
   border-radius: 2px;
 }
 :root ::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--theme-text-secondary) 40%, transparent);
+  background: var(--frosthearth-scrollbar-thumb-hover);
 }
 
-/* Frost glow on focused inputs */
-:root input:focus,
-:root textarea:focus {
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--theme-accent) 20%, transparent);
+/* Firefox scrollbar parity */
+* {
+  scrollbar-color: var(--frosthearth-scrollbar-thumb) transparent;
+}
+
+/* Frost glow on keyboard-focused inputs only */
+:root input:focus-visible,
+:root textarea:focus-visible,
+:root [contenteditable="true"]:focus-visible {
+  box-shadow: 0 0 0 2px var(--frosthearth-focus-ring);
+  outline: 1px solid var(--frosthearth-focus-outline);
+  outline-offset: 1px;
 }
 
 /* Parchment-colored links */
@@ -152,17 +172,23 @@
 /* Subtle top-border accent on the chat header — like a carved stone lintel */
 .chat-area .chat-area-header-surface {
   border-bottom: 1px solid color-mix(in srgb, var(--theme-accent) 12%, transparent);
+  background:
+    linear-gradient(180deg, var(--frosthearth-engraving), transparent 45%),
+    linear-gradient(90deg, var(--frosthearth-aurora), transparent 45%, var(--frosthearth-hearth));
 }
 
 /* Channel sidebar items get a warm hearthfire hover */
 nav .interactive-list-item:hover {
-  background: color-mix(in srgb, var(--theme-accent-secondary) 8%, transparent);
+  background: var(--frosthearth-hover-warm);
 }
 
 /* Active channel — faint gold underline like an enchantment glow */
 nav .channel-active {
-  background: color-mix(in srgb, var(--theme-accent-secondary) 12%, transparent);
+  background: var(--frosthearth-active-warm);
   border-left: 2px solid var(--theme-accent-secondary);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--theme-text-bright) 12%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, var(--theme-accent-secondary) 20%, transparent);
 }
 
 /* Server sidebar icon backgrounds — darkest stone */
@@ -174,4 +200,50 @@ aside .server-sidebar-icon-bg {
 .message-content .mention-highlight {
   background: color-mix(in srgb, var(--theme-accent-secondary) 10%, transparent);
   border-left-color: var(--theme-accent-secondary);
+}
+
+/* Subtle skyfire + hearth ambience in the shell background */
+body {
+  background-image:
+    radial-gradient(1200px 480px at 82% -12%, var(--frosthearth-aurora), transparent 62%),
+    radial-gradient(900px 360px at 10% 120%, var(--frosthearth-hearth), transparent 70%);
+  background-attachment: fixed;
+}
+
+/* Message cards gain a carved-stone edge on hover */
+[data-message].message-hover:hover {
+  box-shadow: inset 2px 0 0 color-mix(in srgb, var(--theme-accent) 35%, transparent);
+}
+
+/* “Runed parchment” look for inline/preformatted code inside messages */
+.message-content :is(code, pre) {
+  border: 1px solid color-mix(in srgb, var(--theme-accent-secondary) 20%, transparent);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--theme-accent-secondary) 5%, transparent), transparent 45%),
+    color-mix(in srgb, var(--theme-bg-tertiary) 88%, black);
+}
+
+.message-content code {
+  color: color-mix(in srgb, var(--theme-text-bright) 90%, var(--theme-accent-secondary));
+}
+
+/* Respect reduced motion preference in custom CSS too */
+@media (prefers-reduced-motion: reduce) {
+  [data-message].message-hover:hover,
+  nav .interactive-list-item:hover,
+  nav .channel-active,
+  :root input:focus-visible,
+  :root textarea:focus-visible,
+  :root [contenteditable="true"]:focus-visible {
+    transition-duration: 0ms !important;
+  }
+
+  body {
+    background-attachment: initial;
+  }
+}
+
+/* Higher contrast users get stronger active/focus affordances */
+[data-high-contrast="true"] nav .channel-active {
+  border-left-width: 3px;
 }


### PR DESCRIPTION
### Motivation

- Centralize and reuse interaction colors and helpers for the Frosthearth theme to reduce duplication and make future adjustments easier.  
- Improve keyboard accessibility by using `:focus-visible` and adding a visible outline for focused inputs and editable content.  
- Bring visual parity and richer decorative styling across scrollbars, message cards, headers, and inline code while honoring reduced-motion and high-contrast preferences.

### Description

- Introduced a set of new CSS custom properties (e.g. `--frosthearth-focus-ring`, `--frosthearth-scrollbar-thumb`, `--frosthearth-aurora`, etc.) and replaced repeated `color-mix` usages with these tokens.  
- Replaced `:focus` rules with `:focus-visible` and added an outline and boxed shadow using the new tokens to improve keyboard focus visibility.  
- Added Firefox scrollbar parity using `scrollbar-color` and replaced WebKit scrollbar colors to use the new variables.  
- Added decorative background gradients on `body`, enhanced chat header background, hover/active box-shadows for messages and channels, styling for inline `code`/`pre`, and a small high-contrast tweak for active channel borders.  
- Added a `prefers-reduced-motion: reduce` media query to disable transitions and make background attachment state-friendly for reduced-motion users.

### Testing

- Ran CSS linting with `npm run lint:css` (stylelint) and it passed.  
- Built the web assets with `npm run build:web` and the build completed successfully.  
- Executed frontend unit tests via `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c201e53164832580a694720ae01881)