### PR TITLE
Fix theme preview not updating on settings page

### DIFF
--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation"
 import { createServerSupabaseClient, getAuthUser } from "@/lib/supabase/server"
 import { SettingsResponsiveContent } from "@/components/settings/settings-responsive-content"
+import { SettingsAppearanceProvider } from "@/components/settings/settings-appearance-provider"
 
 /** Full-page settings layout — two-panel on desktop, stacked nav on mobile */
 export default async function SettingsLayout({ children }: { children: React.ReactNode }) {
@@ -20,13 +21,15 @@ export default async function SettingsLayout({ children }: { children: React.Rea
   if (profileError || !profile) redirect("/login")
 
   return (
-    <div
-      className="flex h-screen overflow-hidden"
-      style={{ background: "var(--theme-bg-primary)", paddingTop: "env(safe-area-inset-top)" }}
-    >
-      <SettingsResponsiveContent user={profile}>
-        {children}
-      </SettingsResponsiveContent>
-    </div>
+    <SettingsAppearanceProvider>
+      <div
+        className="flex h-screen overflow-hidden"
+        style={{ background: "var(--theme-bg-primary)", paddingTop: "env(safe-area-inset-top)" }}
+      >
+        <SettingsResponsiveContent user={profile}>
+          {children}
+        </SettingsResponsiveContent>
+      </div>
+    </SettingsAppearanceProvider>
   )
 }

--- a/apps/web/components/layout/app-provider.tsx
+++ b/apps/web/components/layout/app-provider.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react"
 import { useAppStore } from "@/lib/stores/app-store"
 import { useShallow } from "zustand/react/shallow"
 import { useAppearanceStore } from "@/lib/stores/appearance-store"
+import { useApplyAppearance } from "@/hooks/use-apply-appearance"
 import { usePresenceSync } from "@/hooks/use-presence-sync"
 import { usePushNotifications } from "@/hooks/use-push-notifications"
 import { useTabUnreadTitle } from "@/hooks/use-tab-unread-title"
@@ -21,23 +22,15 @@ export function AppProvider({ user, servers, children }: AppProviderProps) {
   const { setCurrentUser, setServers, setIsLoadingServers, loadNotificationSettings } = useAppStore(
     useShallow((s) => ({ setCurrentUser: s.setCurrentUser, setServers: s.setServers, setIsLoadingServers: s.setIsLoadingServers, loadNotificationSettings: s.loadNotificationSettings }))
   )
-  const {
-    messageDisplay, fontScale, saturation, themePreset, reducedMotion, customCss,
-    fontFamily, lineHeight, codeFont, colorMode, chatBubbleStyle, messageGrouping,
-    emojiSize, accentColorOverride, highContrast, gifAutoplay, linkPreviews,
-    imagePreviews, notificationBadgeStyle, focusIndicator, hydrateFromSettings,
-  } = useAppearanceStore(
+  const { gifAutoplay, hydrateFromSettings } = useAppearanceStore(
     useShallow((s) => ({
-      messageDisplay: s.messageDisplay, fontScale: s.fontScale, saturation: s.saturation,
-      themePreset: s.themePreset, reducedMotion: s.reducedMotion, customCss: s.customCss,
-      fontFamily: s.fontFamily, lineHeight: s.lineHeight, codeFont: s.codeFont,
-      colorMode: s.colorMode, chatBubbleStyle: s.chatBubbleStyle, messageGrouping: s.messageGrouping,
-      emojiSize: s.emojiSize, accentColorOverride: s.accentColorOverride, highContrast: s.highContrast,
-      gifAutoplay: s.gifAutoplay, linkPreviews: s.linkPreviews, imagePreviews: s.imagePreviews,
-      notificationBadgeStyle: s.notificationBadgeStyle, focusIndicator: s.focusIndicator,
+      gifAutoplay: s.gifAutoplay,
       hydrateFromSettings: s.hydrateFromSettings,
     }))
   )
+
+  // Apply all appearance data-attributes and CSS custom properties to <html>
+  useApplyAppearance()
 
   useEffect(() => {
     setCurrentUser(user)
@@ -46,54 +39,6 @@ export function AppProvider({ user, servers, children }: AppProviderProps) {
     hydrateFromSettings(user?.appearance_settings as Parameters<typeof hydrateFromSettings>[0], user?.id ?? null)
     if (user) void loadNotificationSettings()
   }, [user, servers, setCurrentUser, setServers, setIsLoadingServers, hydrateFromSettings, loadNotificationSettings])
-
-  // Apply appearance data-attributes to <html> so CSS selectors can pick them up
-  useEffect(() => {
-    const root = document.documentElement
-    root.dataset.messageDisplay = messageDisplay
-    root.dataset.fontScale = fontScale
-    root.dataset.saturation = saturation
-    root.dataset.themePreset = themePreset
-    root.dataset.reducedMotion = reducedMotion
-    root.dataset.fontFamily = fontFamily
-    root.dataset.lineHeight = lineHeight
-    root.dataset.codeFont = codeFont
-    root.dataset.colorMode = colorMode
-    root.dataset.chatBubbleStyle = chatBubbleStyle
-    root.dataset.messageGrouping = messageGrouping
-    root.dataset.emojiSize = emojiSize
-    root.dataset.highContrast = String(highContrast)
-    root.dataset.gifAutoplay = String(gifAutoplay)
-    root.dataset.linkPreviews = String(linkPreviews)
-    root.dataset.imagePreviews = String(imagePreviews)
-    root.dataset.notificationBadgeStyle = notificationBadgeStyle
-    root.dataset.focusIndicator = focusIndicator
-
-    // Apply accent color override as a CSS variable
-    if (accentColorOverride) {
-      root.style.setProperty("--theme-accent-override", accentColorOverride)
-      root.style.setProperty("--theme-accent", accentColorOverride)
-    } else {
-      root.style.removeProperty("--theme-accent-override")
-      root.style.removeProperty("--theme-accent")
-    }
-
-    const customCssStyleId = "vortex-custom-theme-css"
-    let styleTag = document.getElementById(customCssStyleId) as HTMLStyleElement | null
-    if (!styleTag) {
-      styleTag = document.createElement("style")
-      styleTag.id = customCssStyleId
-      document.head.appendChild(styleTag)
-    }
-    styleTag.textContent = customCss.trim()
-    // No cleanup: attributes and style tag persist until the app unmounts (page unload).
-    // Removing them on every dependency change caused a visible theme flash on each re-render.
-  }, [
-    messageDisplay, fontScale, saturation, themePreset, reducedMotion, customCss,
-    fontFamily, lineHeight, codeFont, colorMode, chatBubbleStyle, messageGrouping,
-    emojiSize, accentColorOverride, highContrast, gifAutoplay, linkPreviews,
-    imagePreviews, notificationBadgeStyle, focusIndicator,
-  ])
 
   // Auto-sync presence: marks user online on mount, offline on tab close
   usePresenceSync(user?.id ?? null, user?.status ?? "online")

--- a/apps/web/components/settings/settings-appearance-provider.tsx
+++ b/apps/web/components/settings/settings-appearance-provider.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+import { useApplyAppearance } from "@/hooks/use-apply-appearance"
+
+/** Thin client wrapper that applies appearance data-attributes to <html> on the settings pages. */
+export function SettingsAppearanceProvider({ children }: { children: React.ReactNode }): React.ReactElement {
+  useApplyAppearance()
+  return <>{children}</>
+}

--- a/apps/web/hooks/use-apply-appearance.ts
+++ b/apps/web/hooks/use-apply-appearance.ts
@@ -1,0 +1,76 @@
+"use client"
+
+import { useEffect } from "react"
+import { useAppearanceStore } from "@/lib/stores/appearance-store"
+import { useShallow } from "zustand/react/shallow"
+
+/**
+ * Applies appearance settings from the Zustand store to the <html> element
+ * as data-attributes and CSS custom properties so theme CSS selectors work.
+ *
+ * Must be called in any layout tree where theme changes should take effect
+ * (e.g. /channels, /settings).
+ */
+export function useApplyAppearance(): void {
+  const {
+    messageDisplay, fontScale, saturation, themePreset, reducedMotion, customCss,
+    fontFamily, lineHeight, codeFont, colorMode, chatBubbleStyle, messageGrouping,
+    emojiSize, accentColorOverride, highContrast, gifAutoplay, linkPreviews,
+    imagePreviews, notificationBadgeStyle, focusIndicator,
+  } = useAppearanceStore(
+    useShallow((s) => ({
+      messageDisplay: s.messageDisplay, fontScale: s.fontScale, saturation: s.saturation,
+      themePreset: s.themePreset, reducedMotion: s.reducedMotion, customCss: s.customCss,
+      fontFamily: s.fontFamily, lineHeight: s.lineHeight, codeFont: s.codeFont,
+      colorMode: s.colorMode, chatBubbleStyle: s.chatBubbleStyle, messageGrouping: s.messageGrouping,
+      emojiSize: s.emojiSize, accentColorOverride: s.accentColorOverride, highContrast: s.highContrast,
+      gifAutoplay: s.gifAutoplay, linkPreviews: s.linkPreviews, imagePreviews: s.imagePreviews,
+      notificationBadgeStyle: s.notificationBadgeStyle, focusIndicator: s.focusIndicator,
+    }))
+  )
+
+  useEffect(() => {
+    const root = document.documentElement
+    root.dataset.messageDisplay = messageDisplay
+    root.dataset.fontScale = fontScale
+    root.dataset.saturation = saturation
+    root.dataset.themePreset = themePreset
+    root.dataset.reducedMotion = reducedMotion
+    root.dataset.fontFamily = fontFamily
+    root.dataset.lineHeight = lineHeight
+    root.dataset.codeFont = codeFont
+    root.dataset.colorMode = colorMode
+    root.dataset.chatBubbleStyle = chatBubbleStyle
+    root.dataset.messageGrouping = messageGrouping
+    root.dataset.emojiSize = emojiSize
+    root.dataset.highContrast = String(highContrast)
+    root.dataset.gifAutoplay = String(gifAutoplay)
+    root.dataset.linkPreviews = String(linkPreviews)
+    root.dataset.imagePreviews = String(imagePreviews)
+    root.dataset.notificationBadgeStyle = notificationBadgeStyle
+    root.dataset.focusIndicator = focusIndicator
+
+    // Apply accent color override as a CSS variable
+    if (accentColorOverride) {
+      root.style.setProperty("--theme-accent-override", accentColorOverride)
+      root.style.setProperty("--theme-accent", accentColorOverride)
+    } else {
+      root.style.removeProperty("--theme-accent-override")
+      root.style.removeProperty("--theme-accent")
+    }
+
+    const customCssStyleId = "vortex-custom-theme-css"
+    let styleTag = document.getElementById(customCssStyleId) as HTMLStyleElement | null
+    if (!styleTag) {
+      styleTag = document.createElement("style")
+      styleTag.id = customCssStyleId
+      document.head.appendChild(styleTag)
+    }
+    styleTag.textContent = customCss.trim()
+  }, [
+    messageDisplay, fontScale, saturation, themePreset, reducedMotion, customCss,
+    fontFamily, lineHeight, codeFont, colorMode, chatBubbleStyle, messageGrouping,
+    emojiSize, accentColorOverride, highContrast, gifAutoplay, linkPreviews,
+    imagePreviews, notificationBadgeStyle, focusIndicator,
+  ])
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `AppProvider` (which applies `data-theme-preset` and other appearance data-attributes to `<html>`) was only mounted under `/channels`. The `/settings` layout had no equivalent, so selecting a new theme updated the Zustand store but never wrote the DOM attribute — CSS variables stayed stale and the preview didn't change.
- **Fix**: Extracted the appearance-application `useEffect` into a reusable `useApplyAppearance` hook (`hooks/use-apply-appearance.ts`) and call it from both `AppProvider` and a new `SettingsAppearanceProvider` wrapper in the settings layout.
- No behavior change for `/channels` routes — `AppProvider` delegates to the same hook now.

## Test plan

- [ ] Navigate to `/settings/appearance` and click different theme cards — the preview and surrounding UI should update instantly
- [ ] Verify accent color override, custom CSS, and other appearance toggles also apply in real time on the settings page
- [ ] Navigate back to `/channels` and confirm the selected theme persists and renders correctly
- [ ] Reload the settings page — theme should be restored from Zustand persist (localStorage)

https://claude.ai/code/session_014HJzJ9dCaegqe8Rs5NYyFA