### PR TITLE
Add haptic feedback to mobile bottom tab bar

### DIFF
--- a/apps/web/components/layout/mobile-bottom-tab-bar.tsx
+++ b/apps/web/components/layout/mobile-bottom-tab-bar.tsx
@@ -52,6 +52,7 @@ export function MobileBottomTabBar() {
             <li key={label}>
               <Link
                 href={href}
+                onClick={() => navigator.vibrate?.(10)}
                 aria-current={active ? "page" : undefined}
                 className={cn("h-full w-full flex flex-col items-center justify-center gap-1 text-[11px]", active && "font-semibold")}
                 style={{ color: active ? "var(--theme-accent)" : "var(--theme-text-secondary)" }}


### PR DESCRIPTION
Light 10ms vibration on tab tap for tactile feedback on mobile.
Uses navigator.vibrate which is a no-op on desktop/unsupported browsers.

https://claude.ai/code/session_01DBETibDUNzzGphG3DL7z2T

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile navigation now includes haptic feedback, providing tactile confirmation when interacting with tab buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->