### PR TITLE
Hide shift+enter hint and keybinds setting on mobile

### DIFF
--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -1436,7 +1436,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
         )}
       </div>
       <div
-        className="mt-1 px-1 flex items-center justify-between text-[11px]"
+        className="mt-1 px-1 hidden md:flex items-center justify-between text-[11px]"
         style={{ color: "var(--theme-text-muted)" }}
       >
         <div className="flex items-center gap-1.5">

--- a/apps/web/components/settings/settings-sidebar.tsx
+++ b/apps/web/components/settings/settings-sidebar.tsx
@@ -33,7 +33,7 @@ const NAV_SECTIONS = [
       { href: "/settings/notifications", label: "Notifications", icon: Bell },
       { href: "/settings/voice", label: "Voice & Video", icon: Volume2 },
       { href: "/settings/security", label: "Security & Privacy", icon: Shield },
-      { href: "/settings/keybinds", label: "Keybinds", icon: Keyboard },
+      { href: "/settings/keybinds", label: "Keybinds", icon: Keyboard, hideOnMobile: true },
     ],
   },
 ]
@@ -112,13 +112,13 @@ export function SettingsSidebar({ user }: Props) {
             >
               {section.label}
             </p>
-            {section.items.map(({ href, label, icon: Icon }) => {
+            {section.items.map(({ href, label, icon: Icon, hideOnMobile }) => {
               const active = pathname === href || pathname.startsWith(`${href}/`)
               return (
                 <Link
                   key={href}
                   href={href}
-                  className="flex items-center gap-2.5 px-2 py-1.5 rounded-md text-sm transition-colors mb-0.5 focus-ring"
+                  className={`${hideOnMobile ? "hidden md:flex" : "flex"} items-center gap-2.5 px-2 py-1.5 rounded-md text-sm transition-colors mb-0.5 focus-ring`}
                   style={{
                     background: active ? "color-mix(in srgb, var(--theme-accent) 15%, transparent)" : "transparent",
                     color: active ? "var(--theme-text-bright)" : "var(--theme-text-secondary)",


### PR DESCRIPTION
The keyboard shortcut hint below the chat input and the keybinds settings nav item are not useful on mobile devices. Both are now hidden on screens smaller than md breakpoint.

https://claude.ai/code/session_01RWLmhbxLk8273XSXUWNhkb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile responsiveness by hiding keyboard navigation hints on small screens
  * Hidden Keybinds navigation section on mobile devices for a cleaner interface on smaller viewports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->