### PR TITLE
Improve iOS PWA install banner for push notification onboarding funnel

### DIFF
--- a/apps/web/components/pwa-install-banner.tsx
+++ b/apps/web/components/pwa-install-banner.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
-import { X, Share } from "lucide-react"
+import { Share } from "lucide-react"
 
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>
@@ -10,6 +10,8 @@ interface BeforeInstallPromptEvent extends Event {
 }
 
 const STORAGE_KEY = "pwa-install-banner-dismissed"
+const IOS_DISMISS_KEY = "pwa-install-banner-ios-dismissed-at"
+const IOS_REDISPLAY_DAYS = 7
 
 /** Detect iOS Safari (not Chrome/Firefox on iOS which also can't install PWAs but show differently) */
 function isIosSafari(): boolean {
@@ -38,6 +40,12 @@ export function PwaInstallBanner() {
 
     // iOS Safari path — show manual install instructions
     if (isIosSafari()) {
+      // Re-show after IOS_REDISPLAY_DAYS if previously dismissed (not permanently hidden)
+      const dismissedAt = localStorage.getItem(IOS_DISMISS_KEY)
+      if (dismissedAt) {
+        const daysSince = (Date.now() - Number(dismissedAt)) / (1000 * 60 * 60 * 24)
+        if (daysSince < IOS_REDISPLAY_DAYS) return
+      }
       setShowIosGuide(true)
       setVisible(true)
       return
@@ -54,8 +62,13 @@ export function PwaInstallBanner() {
     return () => window.removeEventListener("beforeinstallprompt", handler)
   }, [])
 
-  function dismiss() {
-    localStorage.setItem(STORAGE_KEY, "1")
+  function dismiss(permanent = false): void {
+    if (showIosGuide && !permanent) {
+      // iOS: soft dismiss — re-show after IOS_REDISPLAY_DAYS
+      localStorage.setItem(IOS_DISMISS_KEY, String(Date.now()))
+    } else {
+      localStorage.setItem(STORAGE_KEY, "1")
+    }
     setVisible(false)
   }
 
@@ -88,9 +101,14 @@ export function PwaInstallBanner() {
       <div className="min-w-0 flex-1">
         <p className="text-sm font-semibold text-foreground">Add VortexChat to Home Screen</p>
         {showIosGuide ? (
-          <p className="text-xs text-muted-foreground">
-            Tap <Share className="inline h-3.5 w-3.5 -mt-0.5 mx-0.5" aria-label="Share" /> then &quot;Add to Home Screen&quot;
-          </p>
+          <>
+            <p className="text-xs text-muted-foreground">
+              Get notifications, offline access &amp; a full-screen experience.
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Tap <Share className="inline h-3.5 w-3.5 -mt-0.5 mx-0.5" aria-label="Share" /> below, scroll down, then tap &quot;Add to Home Screen&quot;.
+            </p>
+          </>
         ) : (
           <p className="text-xs text-muted-foreground">
             Get the full app experience — offline support &amp; fast launch.
@@ -100,12 +118,17 @@ export function PwaInstallBanner() {
 
       <div className="flex shrink-0 gap-2">
         {showIosGuide ? (
-          <Button variant="outline" size="sm" onClick={dismiss} aria-label="Dismiss install banner">
-            <X className="h-4 w-4" />
-          </Button>
+          <>
+            <Button variant="outline" size="sm" onClick={() => dismiss(false)} aria-label="Dismiss install banner">
+              Not now
+            </Button>
+            <Button variant="default" size="sm" onClick={() => dismiss(true)} aria-label="Acknowledge install instructions">
+              Got it
+            </Button>
+          </>
         ) : (
           <>
-            <Button variant="outline" size="sm" onClick={dismiss} aria-label="Dismiss install banner">
+            <Button variant="outline" size="sm" onClick={() => dismiss(false)} aria-label="Dismiss install banner">
               Not now
             </Button>
             <Button variant="default" size="sm" onClick={install} aria-label="Install VortexChat app">


### PR DESCRIPTION
- Add value prop text mentioning notifications, offline access, and full-screen
- Clarify share sheet instructions ("scroll down, then tap Add to Home Screen")
- Add "Got it" (permanent dismiss) vs "Not now" (soft dismiss, re-shows after 7 days)
- Fix event-as-argument bug where React MouseEvent would be passed as `permanent`

https://claude.ai/code/session_01DsHrz8ifBwURMsSj5yk384