### PR TITLE
Fix profile pic upload RLS violation by correcting storage path

### DIFF
--- a/apps/web/components/settings/profile-settings-page.tsx
+++ b/apps/web/components/settings/profile-settings-page.tsx
@@ -224,7 +224,7 @@ export function ProfileSettingsPage({ user }: Props) {
         const ALLOWED_EXTS = new Set(["jpg", "jpeg", "png", "gif", "webp"])
         const rawExt = avatarFile.name.split(".").pop()?.toLowerCase() ?? ""
         const ext = ALLOWED_EXTS.has(rawExt) ? rawExt : "jpg"
-        const path = `avatars/${user.id}.${ext}`
+        const path = `${user.id}/avatar.${ext}`
         const { error: uploadError } = await supabase.storage
           .from("avatars")
           .upload(path, avatarFile, { upsert: true })


### PR DESCRIPTION
The profile-settings-page was uploading avatars to `avatars/{userId}.{ext}` but the storage RLS policy expects the first folder to be the user's ID (`{userId}/avatar.{ext}`). This mismatch caused "new row violates row-level security policy" errors on upload.

https://claude.ai/code/session_015Fr4uUT26BRb76EJrnr4fo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the storage organization for user profile avatars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->