### PR TITLE
Add AI Settings tab to server settings modal

### DIFF
--- a/apps/web/components/modals/server-settings-modal.tsx
+++ b/apps/web/components/modals/server-settings-modal.tsx
@@ -219,7 +219,7 @@ export function ServerSettingsModal({ open, onClose, server, isOwner, canManageA
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent
-        className="max-w-5xl max-h-[90vh] w-[calc(100vw-1rem)] md:w-auto overflow-hidden p-0"
+        className="sm:max-w-5xl sm:max-h-[90vh] w-[calc(100vw-1rem)] md:w-auto sm:overflow-hidden p-0"
         style={{ background: 'var(--theme-bg-primary)', borderColor: 'var(--theme-bg-tertiary)' }}
         aria-describedby={undefined}
       >


### PR DESCRIPTION
## Summary
Added a new AI Settings tab to the server settings modal, accessible only to server owners. This includes importing the new `AiSettingsTab` component and integrating it into the settings interface.

## Key Changes
- Added `Sparkles` icon import from lucide-react for the AI Settings tab
- Imported new `AiSettingsTab` component from `@/components/settings/ai-settings-tab`
- Added a new "AI" section in the settings tabs list with an "AI Settings" trigger, visible only to server owners
- Implemented the AI Settings tab content that renders the `AiSettingsTab` component with the server ID
- Applied consistent styling to match existing tab design patterns

## Implementation Details
- The AI Settings tab is conditionally rendered only when `isOwner` is true, restricting access to server owners
- Added a section header "AI" above the tab trigger to organize the settings hierarchy
- Used the `Sparkles` icon to visually distinguish the AI Settings tab from other settings
- Passed `serverId` prop to the `AiSettingsTab` component to scope settings to the current server

https://claude.ai/code/session_01Kc7yzf3vrc8AeTnt253F7z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server owners now have access to an AI Settings tab within the server configuration options.

* **UI Improvements**
  * Enhanced dialog responsiveness across different screen sizes for improved user experience on mobile and tablet devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->