### PR TITLE
Consolidate CI workflows and pin Node.js version to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,14 @@ jobs:
       - run: npm ci
       - run: npm audit --audit-level=critical
 
-  lint:
-    name: Lint (Node ${{ matrix.node-version }})
+  checks:
+    name: Lint & Type Check
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
           cache: npm
       - run: npm ci
       # Run ESLint only. The style-guardrails check uses a locally-generated
@@ -42,51 +39,20 @@ jobs:
       # Style-guardrail regressions are caught in local dev via `npm run lint`.
       - run: npx eslint . --max-warnings 0
         working-directory: apps/web
-
-  type-check:
-    name: Type Check (Node ${{ matrix.node-version }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20, 22]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: npm
-      - run: npm ci
       - run: npm run type-check --workspace=apps/web
       - run: npm run type-check --workspace=apps/signal
 
   test:
-    name: Tests (Node ${{ matrix.node-version }})
+    name: Tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm test --workspace=apps/web
-
-  parity-gates:
-    name: Parity Gates (Node ${{ matrix.node-version }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20, 22]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: npm
-      - run: npm ci
       - run: npm run test:parity:critical --workspace=apps/web
       - run: npm run test:a11y:focus --workspace=apps/web
       - run: npm test --workspace=apps/signal
@@ -158,7 +124,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, type-check, test, parity-gates]
+    needs: [checks, test]
     env:
       # Dummy values so Next.js build doesn't fail on missing env vars
       NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co


### PR DESCRIPTION
## Summary
Streamlined the CI/CD pipeline by consolidating multiple separate workflow jobs into fewer, more efficient jobs while standardizing on Node.js 22.

## Key Changes
- **Merged `lint` and `type-check` jobs** into a single `checks` job that runs both ESLint and TypeScript type checking
- **Consolidated `parity-gates` tests** into the main `test` job, combining all test-related checks in one place
- **Removed Node.js version matrix** (20, 22) from all jobs and pinned to Node.js 22 exclusively
- **Updated build job dependencies** from `[lint, type-check, test, parity-gates]` to `[checks, test]`

## Benefits
- Reduced CI execution time by eliminating redundant setup steps across multiple jobs
- Simplified workflow maintenance with fewer job definitions
- Clearer job organization with logical grouping of related checks
- Standardized on a single Node.js version (22) for consistency and reduced testing matrix complexity

https://claude.ai/code/session_01W1CrB5G9QKPdSTEizXrYWk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the continuous integration pipeline by consolidating multiple jobs into a unified checks workflow. Fixed Node.js version for consistency across build and test processes, reducing pipeline complexity and improving deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->