### PR TITLE
Fix SW pushsubscriptionchange VAPID encoding and sync dev fallback

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -187,9 +187,11 @@ self.addEventListener("pushsubscriptionchange", (event) => {
             const keyRes = await fetch("/api/push/vapid-key")
             if (keyRes.ok) {
               const { key } = await keyRes.json()
-              subscribeOptions = {
-                userVisibleOnly: true,
-                applicationServerKey: urlBase64ToUint8Array(key),
+              if (typeof key === "string" && key) {
+                subscribeOptions = {
+                  userVisibleOnly: true,
+                  applicationServerKey: urlBase64ToUint8Array(key),
+                }
               }
             }
           } catch {

--- a/apps/web/sw.src.js
+++ b/apps/web/sw.src.js
@@ -231,9 +231,11 @@ self.addEventListener("pushsubscriptionchange", (event) => {
             const keyRes = await fetch("/api/push/vapid-key")
             if (keyRes.ok) {
               const { key } = await keyRes.json()
-              subscribeOptions = {
-                userVisibleOnly: true,
-                applicationServerKey: urlBase64ToUint8Array(key),
+              if (typeof key === "string" && key) {
+                subscribeOptions = {
+                  userVisibleOnly: true,
+                  applicationServerKey: urlBase64ToUint8Array(key),
+                }
               }
             }
           } catch {


### PR DESCRIPTION
Three targeted fixes for push notification reliability:

1. Add urlBase64ToUint8Array() to service worker and use it in pushsubscriptionchange handler — iOS Safari requires BufferSource for applicationServerKey, the raw string form is not universally supported. This was the root cause of resubscription failures on iOS PWA.

2. Delete old subscription endpoint on push key rotation before creating the new one, preventing stale endpoint accumulation and reducing 410 error noise on delivery.

3. Sync public/sw.js (dev fallback) with sw.src.js to eliminate divergence — fixes badge API crash (navigator vs self.navigator) and adds missing offline fallback Response in dev mode.

https://claude.ai/code/session_01P3jiKeLnH2K9Nuvo7VoNqD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push subscription reliability and re-subscription handling, including best-effort cleanup of stale subscriptions.
  * Fixed app badge updates when offline and returned an explicit "Service Unavailable" offline response when no cached route exists.

* **Improvements**
  * Ensured push encryption keys are converted to the correct binary format for subscriptions.
  * Notified clients when subscriptions change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->