### PR TITLE
Remove Keyboard/Keybinds settings option from user settings

### DIFF
--- a/apps/web/app/channels/you/page.tsx
+++ b/apps/web/app/channels/you/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useRef } from "react"
 import { useRouter } from "next/navigation"
-import { User, Palette, Bell, Shield, Volume2, Keyboard, LogOut, Circle } from "lucide-react"
+import { User, Palette, Bell, Shield, Volume2, LogOut, Circle } from "lucide-react"
 import { useAppStore } from "@/lib/stores/app-store"
 import { useShallow } from "zustand/react/shallow"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
@@ -17,7 +17,6 @@ const SETTINGS_LINKS = [
   { href: "/settings/notifications", label: "Notifications", icon: Bell },
   { href: "/settings/voice", label: "Voice & Video", icon: Volume2 },
   { href: "/settings/security", label: "Security & Privacy", icon: Shield },
-  { href: "/settings/keybinds", label: "Keybinds", icon: Keyboard },
 ]
 
 export default function YouPage() {


### PR DESCRIPTION
## Summary
Removed the Keybinds settings option from the user settings page navigation menu.

## Changes
- Removed `Keyboard` icon import from lucide-react (no longer needed)
- Removed the keybinds settings link from `SETTINGS_LINKS` array that pointed to `/settings/keybinds`

## Details
This change simplifies the settings navigation by removing the keyboard keybinds configuration option. The keybinds settings page is no longer accessible from the main settings menu.

https://claude.ai/code/session_01QsFtTnPBaNcptBWpA7CyPf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Keybinds settings option from the settings menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->