### PR TITLE
Fix mobile @mention tagging by handling IME composition events

### DIFF
--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -523,7 +523,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     // During IME composition (mobile predictive text, CJK input, etc.),
     // let the browser handle all keys — intervening here would break input.
-    if (e.nativeEvent.isComposing) return
+    if (composingRef.current || e.nativeEvent.isComposing) return
 
     const mentionHandledNavigation = mention.handleKeyDown(e)
     const emojiHandledNavigation = emoji.handleKeyDown(e)
@@ -719,7 +719,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
     setCursorPosition(e.currentTarget.selectionStart)
   }
 
-  function handleSelect(e: React.SyntheticEvent<HTMLTextAreaElement>) {
+  function handleSelect(e: React.SyntheticEvent<HTMLTextAreaElement>): void {
     if (!composingRef.current) {
       setCursorPosition(e.currentTarget.selectionStart)
     }


### PR DESCRIPTION
Mobile keyboards use IME composition for predictive text, which causes selectionStart to be unreliable during onChange. This meant cursorPosition stayed stale and findMentionQuery could never locate the @ trigger.

Three fixes:
- Track composition state (onCompositionStart/End) and defer cursor reads during active composition, syncing the real position on compositionend
- Skip keyDown handling during composition (isComposing) to avoid interfering with mobile IME input
- Add onTouchEnd handler on textarea to sync cursor position after taps, since onSelect doesn't fire reliably on mobile browsers

https://claude.ai/code/session_01TkRtiganZ39yevKYC1fBuB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of IME composition mode so typing with input methods (e.g., Asian languages, emoji pickers) no longer triggers navigation or command shortcuts.
  * Fixed cursor tracking so caret position stays accurate during and immediately after text composition.
  * Enhanced mobile behavior to reliably update cursor/selection after touch interactions, improving mention and emoji detection on touch devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->