### PR TITLE
Fix message bar and tab pill positioned too high on mobile

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -28,7 +28,7 @@
     --radius: 0.5rem;
     /* ── Mobile bottom-nav pill geometry ──────────────────────────────────── */
     --mobile-tabbar-height: 56px;
-    --mobile-tabbar-gap: 8px;
+    --mobile-tabbar-gap: 4px;
     --mobile-tabbar-reserve: calc(var(--mobile-tabbar-height) + var(--mobile-tabbar-gap) + env(safe-area-inset-bottom));
     /* ── Motion timing tokens ─────────────────────────────────────────────── */
     --motion-duration-instant: 80ms;

--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -795,7 +795,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
 
   return (
     <div
-      className="px-4 pb-4 flex-shrink-0 relative"
+      className="px-4 pb-2 md:pb-4 flex-shrink-0 relative"
       onDrop={handleDrop}
       onDragOver={(e) => e.preventDefault()}
       onDragEnter={(e) => { e.preventDefault(); if (e.dataTransfer.types.includes("Files")) { dragCounterRef.current += 1; setIsDraggingOver(true) } }}

--- a/apps/web/components/dm/dm-channel-area.tsx
+++ b/apps/web/components/dm/dm-channel-area.tsx
@@ -1960,7 +1960,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
       <TypingIndicator users={typingUsers.map((user) => user.displayName)} />
 
       {/* Input */}
-      <div className="px-4 pb-4 flex-shrink-0">
+      <div className="px-4 pb-2 md:pb-4 flex-shrink-0">
         {/* Reply indicator */}
         {replyTo && (
           <div

--- a/apps/web/components/layout/channels-shell.tsx
+++ b/apps/web/components/layout/channels-shell.tsx
@@ -22,7 +22,7 @@ export function ChannelsShell({ children }: { children: React.ReactNode }) {
       style={{
         background: "var(--app-bg-primary)",
         paddingTop: "env(safe-area-inset-top)",
-        paddingBottom: isFullScreen ? undefined : "var(--mobile-tabbar-reserve)",
+        paddingBottom: isFullScreen ? "env(safe-area-inset-bottom)" : "var(--mobile-tabbar-reserve)",
       }}
     >
       {/* Guild rail: desktop only — mobile uses bottom tab bar */}


### PR DESCRIPTION
- Reduce mobile message input bottom padding from pb-4 to pb-2 (keeps pb-4 on desktop)
- Add env(safe-area-inset-bottom) padding in full-screen channel views so the
  message bar sits just above the home indicator instead of floating high
- Reduce mobile tab bar gap from 8px to 4px to bring the pill nav closer to
  the bottom edge
- Both chat and DM message inputs now use consistent positioning

https://claude.ai/code/session_01SggfpbSrZ4sDcTjk2FoHFQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized mobile layout spacing by reducing gaps and padding on small screens while maintaining original spacing on larger devices.
  * Improved full-screen mode to properly account for safe area insets on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->