### PR TITLE
Remove keyboard icon from message input helper text

### DIFF
--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useRef, useEffect, useCallback, useMemo } from "react"
-import { Send, X, Smile, Reply, Keyboard, FileUp, BarChart3, Plus, MessageSquare } from "lucide-react"
+import { Send, X, Smile, Reply, FileUp, BarChart3, Plus, MessageSquare } from "lucide-react"
 import type { MessageWithAuthor } from "@/types/database"
 import { cn } from "@/lib/utils/cn"
 import { useAppStore } from "@/lib/stores/app-store"
@@ -1573,10 +1573,7 @@ export function MessageInput({ channelName, draft, replyTo, onCancelReply, onSen
         className="mt-1 px-1 hidden md:flex items-center justify-between text-[11px]"
         style={{ color: "var(--theme-text-muted)" }}
       >
-        <div className="flex items-center gap-1.5">
-          <Keyboard className="w-3 h-3" />
-          <span>Enter send · Shift+Enter newline</span>
-        </div>
+        <span>Enter send · Shift+Enter newline</span>
         {mention.isOpen && <span>↑↓ navigate · Tab/Enter accept · Esc dismiss</span>}
       </div>
     </div>


### PR DESCRIPTION
## Summary
Simplified the message input helper text by removing the keyboard icon and its wrapper div, keeping only the text instruction.

## Changes
- Removed `Keyboard` icon import from lucide-react
- Removed the flex container wrapping the keyboard icon and helper text
- Kept the helper text "Enter send · Shift+Enter newline" as a simple span element
- Maintained all other functionality including mention navigation hints

## Details
This change reduces visual clutter in the message input component's helper text while preserving the keyboard shortcut instructions. The helper text now displays as plain text without an accompanying icon, making the UI cleaner and more minimal.

https://claude.ai/code/session_01P3ZBkRFABMvzsA6c6nF4pv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the message composer help text by removing the keyboard icon display while retaining the keyboard shortcut information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->