### PR TITLE
fix: prevent horizontal scrolling on mobile

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -114,6 +114,8 @@
     overscroll-behavior-x: none;
     /* Prevent double-tap zoom on mobile — keeps the app feeling native */
     touch-action: manipulation;
+    /* Prevent any child element from causing horizontal scroll on mobile */
+    overflow-x: hidden;
   }
 
   /* iOS Safari auto-zooms inputs with font-size < 16px — force 16px on mobile


### PR DESCRIPTION
Add overflow-x: hidden to the body element to prevent any child elements from causing unwanted horizontal scroll on mobile devices.

Closes #500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated mobile scrolling behavior to prevent unintended horizontal scroll on the app container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->