### PR TITLE
fix: show error feedback on registration signup failure

### DIFF
--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -40,7 +40,7 @@ export default function RegisterPage() {
   })
   const supabase = createClientSupabaseClient()
 
-  async function handleRegister(e: React.FormEvent) {
+  async function handleRegister(e: React.FormEvent): Promise<void> {
     e.preventDefault()
 
     setFormError(null)
@@ -66,7 +66,6 @@ export default function RegisterPage() {
     }
 
     setLoading(true)
-    setFormError(null)
     try {
       const { data, error } = await supabase.auth.signUp({
         email: form.email,
@@ -83,7 +82,7 @@ export default function RegisterPage() {
 
       // Supabase returns a fake success (200, no error) for duplicate emails
       // when email confirmation is enabled — detect via empty identities array
-      if (data.user && data.user.identities && data.user.identities.length === 0) {
+      if (data.user?.identities?.length === 0) {
         const msg = "An account with this email already exists. Try logging in instead."
         setFormError(msg)
         toast({ variant: "destructive", title: "Registration failed", description: msg })


### PR DESCRIPTION
## Summary
- **Detect Supabase's "fake success" for duplicate emails**: When email confirmation is enabled, Supabase returns a 200 with an empty `identities` array instead of an error for already-registered emails. Now detected and surfaced to the user.
- **Add inline error banner**: A visible `role="alert"` error div appears above the submit button so users see feedback even if they miss the toast.
- **Map raw errors to friendly messages**: Common Supabase error messages (duplicate email, weak password, rate limiting, disabled signups) are translated to clear, actionable descriptions.
- **Fix TypeScript safety**: Replaced `catch (error: any)` with `catch (error: unknown)` and proper `instanceof Error` narrowing.

## Test plan
- [ ] Navigate to `/register`, submit with an already-registered email — verify inline error + toast appear
- [ ] Submit with a new valid email — verify success toast and redirect to `/login?registered=true`
- [ ] Trigger a Supabase 400 (e.g. weak password if configured in Supabase dashboard) — verify friendly error shown
- [ ] Submit form, see error, then re-submit — verify previous error clears before new attempt
- [ ] Verify error banner has `role="alert"` for screen reader accessibility

Closes #510

https://claude.ai/code/session_01YDw3go6gQEyJBujtRJqJ4r

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signup error handling with user-friendly messages for duplicate accounts, weak/short passwords, rate limiting, invalid email formats, and disabled registrations.
  * Validation errors now appear directly in the registration form as an alert.
  * Duplicate-email cases and other failures surface a clear destructive toast and halt progression to avoid misleading navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->