### PR TITLE
Fix channel search crash caused by DialogTitle used outside Dialog

### DIFF
--- a/apps/web/components/modals/search-modal.tsx
+++ b/apps/web/components/modals/search-modal.tsx
@@ -144,6 +144,7 @@ export function SearchModal({ serverId, onClose, onJumpToMessage }: Props) {
       style={{ background: "rgba(0,0,0,0.7)" }}
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
       role="dialog"
+      aria-modal="true"
       aria-labelledby="search-modal-title"
       aria-describedby="search-modal-desc"
     >


### PR DESCRIPTION
Replace Radix UI DialogTitle/DialogDescription with plain HTML elements
(h2/p) since SearchModal uses a custom overlay, not a Radix Dialog wrapper.
Added proper role="dialog" and aria attributes for accessibility.

Fixes #511

https://claude.ai/code/session_01VrgTsY2cgJdiAaebnWE4MS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search modal accessibility: replaced inaccessible title/description wiring with proper heading and description elements and added explicit ARIA attributes to the modal container for better screen reader support and dialog semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->