### PR TITLE
Fix install banner overlapping notification prompt

### DIFF
--- a/apps/web/components/push-permission-prompt.tsx
+++ b/apps/web/components/push-permission-prompt.tsx
@@ -69,7 +69,7 @@ export function PushPermissionPrompt() {
   return (
     <div
       role="alert"
-      className="fixed bottom-20 left-4 right-4 z-banner-low mx-auto max-w-sm rounded-xl border p-4 shadow-xl md:left-auto md:right-6 md:bottom-6"
+      className="fixed bottom-20 left-4 right-4 z-banner-high mx-auto max-w-sm rounded-xl border p-4 shadow-xl md:left-auto md:right-6 md:bottom-6"
       style={{
         background: "var(--theme-bg-secondary)",
         borderColor: "var(--theme-bg-tertiary)",

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -85,8 +85,8 @@ const config = {
        *  sticky headers           →  z-sticky      (100)
        *  overlays / modals        →  z-overlay     (200)
        *  toasts / notifications   →  z-toast       (500)
-       *  push-permission prompt   →  z-banner-low  (9998)
-       *  PWA install banner       →  z-banner      (9999)
+       *  PWA install banner       →  z-banner      (9998)
+       *  push-permission prompt   →  z-banner-high (9999)
        *  splash screen            →  z-splash      (99999)
        */
       zIndex: {
@@ -94,8 +94,8 @@ const config = {
         sticky: "100",
         overlay: "200",
         toast: "500",
-        "banner-low": "9998",
-        banner: "9999",
+        banner: "9998",
+        "banner-high": "9999",
         splash: "99999",
       },
       borderRadius: {


### PR DESCRIPTION
## Summary
- Swaps the z-index stacking so the push-permission prompt (`z-banner-high`: 9999) renders above the PWA install banner (`z-banner`: 9998)
- Both prompts are now independently dismissible without overlap on the `/register` page

## Test plan
- [ ] Navigate to `/register` on first visit (or cleared cookies) so both banners appear
- [ ] Verify the notification prompt's "Not now" button is clickable even when the install banner is visible
- [ ] Verify dismissing either prompt works independently
- [ ] Verify no z-index regressions on other pages (splash screen still above both)

Closes #513

https://claude.ai/code/session_01JLQ7MKKMWvFEhyYQ7UWkib