### PR TITLE
Fix 500 errors on /api/voice/sessions

### DIFF
--- a/apps/web/app/api/voice/sessions/[id]/end/route.ts
+++ b/apps/web/app/api/voice/sessions/[id]/end/route.ts
@@ -21,85 +21,100 @@ type Params = { params: Promise<{ id: string }> }
  *
  * Required scope: voice:sessions:modify (must be session starter or participant).
  */
-export async function POST(req: NextRequest, { params }: Params) {
-  const { id: sessionId } = await params
-  const supabase = await createServerSupabaseClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-  }
-
-  let body: EndSessionRequest = {}
+export async function POST(req: NextRequest, { params }: Params): Promise<NextResponse> {
   try {
-    body = await req.json()
-  } catch {
-    // Optional body
-  }
+    const { id: sessionId } = await params
+    const supabase = await createServerSupabaseClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
 
-  const endedAt = body.endedAt ?? new Date().toISOString()
-
-  const { data: session } = await supabase
-    .from("voice_call_sessions")
-    .select("id, ended_at, started_by, summary_status, scope_type, scope_id")
-    .eq("id", sessionId)
-    .maybeSingle()
-
-  if (!session) {
-    return NextResponse.json({ error: "Session not found" }, { status: 404 })
-  }
-
-  // Idempotency: already ended
-  if (session.ended_at) {
-    return NextResponse.json({ session }, { status: 200 })
-  }
-
-  // Mark participant left_at
-  await supabase
-    .from("voice_call_participants")
-    .update({ left_at: endedAt })
-    .eq("session_id", sessionId)
-    .eq("user_id", user.id)
-    .is("left_at", null)
-
-  // Only the session starter can formally end the whole session
-  if (session.started_by !== user.id) {
-    return NextResponse.json({ session }, { status: 200 })
-  }
-
-  // End the session
-  const { data: updatedSession, error: updateError } = await supabase
-    .from("voice_call_sessions")
-    .update({ ended_at: endedAt })
-    .eq("id", sessionId)
-    .select()
-    .single()
-
-  if (updateError) {
-    return NextResponse.json({ error: updateError.message }, { status: 500 })
-  }
-
-  // Resolve the server-level Gemini API key for summary generation
-  let geminiApiKey: string | null = null
-  if (session.scope_type === "server_channel") {
-    const { data: channel } = await supabase
-      .from("channels")
-      .select("server_id")
-      .eq("id", session.scope_id)
-      .single()
-    if (channel?.server_id) {
-      geminiApiKey = await resolveGeminiApiKey(supabase, channel.server_id)
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
+
+    let body: EndSessionRequest = {}
+    try {
+      body = await req.json()
+    } catch {
+      // Optional body
+    }
+
+    const endedAt = body.endedAt ?? new Date().toISOString()
+
+    const { data: session, error: fetchError } = await supabase
+      .from("voice_call_sessions")
+      .select("id, ended_at, started_by, summary_status, scope_type, scope_id")
+      .eq("id", sessionId)
+      .maybeSingle()
+
+    if (fetchError) {
+      console.error("[voice/sessions/end] fetch session failed", { sessionId, userId: user.id, error: fetchError.message })
+      return NextResponse.json({ error: "Failed to fetch session" }, { status: 500 })
+    }
+
+    if (!session) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 })
+    }
+
+    // Idempotency: already ended
+    if (session.ended_at) {
+      return NextResponse.json({ session }, { status: 200 })
+    }
+
+    // Mark participant left_at
+    const { error: leaveError } = await supabase
+      .from("voice_call_participants")
+      .update({ left_at: endedAt })
+      .eq("session_id", sessionId)
+      .eq("user_id", user.id)
+      .is("left_at", null)
+
+    if (leaveError) {
+      console.error("[voice/sessions/end] participant leave failed", { sessionId, userId: user.id, error: leaveError.message })
+    }
+
+    // Only the session starter can formally end the whole session
+    if (session.started_by !== user.id) {
+      return NextResponse.json({ session }, { status: 200 })
+    }
+
+    // End the session
+    const { data: updatedSession, error: updateError } = await supabase
+      .from("voice_call_sessions")
+      .update({ ended_at: endedAt })
+      .eq("id", sessionId)
+      .select()
+      .single()
+
+    if (updateError) {
+      console.error("[voice/sessions/end] update session failed", { sessionId, userId: user.id, error: updateError.message })
+      return NextResponse.json({ error: "Failed to end session" }, { status: 500 })
+    }
+
+    // Resolve the server-level Gemini API key for summary generation
+    let geminiApiKey: string | null = null
+    if (session.scope_type === "server_channel") {
+      const { data: channel } = await supabase
+        .from("channels")
+        .select("server_id")
+        .eq("id", session.scope_id)
+        .single()
+      if (channel?.server_id) {
+        geminiApiKey = await resolveGeminiApiKey(supabase, channel.server_id)
+      }
+    }
+
+    // Trigger summary generation asynchronously (fire-and-forget from this request)
+    generateSummary(sessionId, user.id, geminiApiKey).catch((err) => {
+      console.error("[voice/sessions/end] generateSummary failed", { sessionId, userId: user.id, error: err })
+    })
+
+    return NextResponse.json({ session: updatedSession }, { status: 200 })
+  } catch (err) {
+    console.error("[voice/sessions/end] unexpected error", err)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
   }
-
-  // Trigger summary generation asynchronously (fire-and-forget from this request)
-  generateSummary(sessionId, user.id, geminiApiKey).catch((err) => {
-    console.error("[voice/sessions/end] generateSummary failed", { sessionId, userId: user.id, error: err })
-  })
-
-  return NextResponse.json({ session: updatedSession }, { status: 200 })
 }
 
 async function generateSummary(sessionId: string, actorUserId: string, geminiApiKey: string | null): Promise<void> {

--- a/apps/web/app/api/voice/sessions/route.ts
+++ b/apps/web/app/api/voice/sessions/route.ts
@@ -12,76 +12,97 @@ import type { StartSessionRequest } from "@/types/vortex-recap"
  *
  * Required scope: authenticated user (voice:sessions:create implied by auth).
  */
-export async function POST(req: NextRequest) {
-  const supabase = await createServerSupabaseClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-  }
-
-  let body: StartSessionRequest
+export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
-    body = await req.json()
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    const supabase = await createServerSupabaseClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    let body: StartSessionRequest
+    try {
+      body = await req.json()
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+
+    const { scopeType, scopeId, transcriptionMode } = body
+
+    if (!scopeType || !scopeId) {
+      return NextResponse.json({ error: "scopeType and scopeId are required" }, { status: 400 })
+    }
+
+    if (!["server_channel", "dm_call"].includes(scopeType)) {
+      return NextResponse.json({ error: "Invalid scopeType" }, { status: 400 })
+    }
+
+    const mode = transcriptionMode ?? "off"
+    if (!["off", "manual_opt_in", "server_policy_required"].includes(mode)) {
+      return NextResponse.json({ error: "Invalid transcriptionMode" }, { status: 400 })
+    }
+
+    // Idempotency: return an existing active session for this user + scope
+    const { data: existing, error: existingError } = await supabase
+      .from("voice_call_sessions")
+      .select("*")
+      .eq("started_by", user.id)
+      .eq("scope_id", scopeId)
+      .is("ended_at", null)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (existingError) {
+      console.error("[voice/sessions] idempotency check failed", { userId: user.id, scopeId, error: existingError.message })
+      return NextResponse.json({ error: "Failed to check existing session" }, { status: 500 })
+    }
+
+    if (existing) {
+      return NextResponse.json({ session: existing }, { status: 200 })
+    }
+
+    const { data: session, error } = await supabase
+      .from("voice_call_sessions")
+      .insert({
+        scope_type: scopeType,
+        scope_id: scopeId,
+        started_by: user.id,
+        transcription_mode: mode,
+        summary_status: "pending",
+      })
+      .select()
+      .single()
+
+    if (error) {
+      console.error("[voice/sessions] insert failed", { userId: user.id, scopeId, error: error.message })
+      return NextResponse.json({ error: "Failed to create session" }, { status: 500 })
+    }
+
+    // Auto-join the creator as a participant
+    const { error: participantError } = await supabase
+      .from("voice_call_participants")
+      .upsert(
+        {
+          session_id: session.id,
+          user_id: user.id,
+          consent_transcription: false,
+          consent_translation: false,
+        },
+        { onConflict: "session_id,user_id" }
+      )
+
+    if (participantError) {
+      console.error("[voice/sessions] participant upsert failed", { sessionId: session.id, userId: user.id, error: participantError.message })
+      // Session was created — return it even if participant join failed
+    }
+
+    return NextResponse.json({ session }, { status: 201 })
+  } catch (err) {
+    console.error("[voice/sessions] unexpected error", err)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
   }
-
-  const { scopeType, scopeId, transcriptionMode } = body
-
-  if (!scopeType || !scopeId) {
-    return NextResponse.json({ error: "scopeType and scopeId are required" }, { status: 400 })
-  }
-
-  if (!["server_channel", "dm_call"].includes(scopeType)) {
-    return NextResponse.json({ error: "Invalid scopeType" }, { status: 400 })
-  }
-
-  const mode = transcriptionMode ?? "off"
-  if (!["off", "manual_opt_in", "server_policy_required"].includes(mode)) {
-    return NextResponse.json({ error: "Invalid transcriptionMode" }, { status: 400 })
-  }
-
-  // Idempotency: return an existing active session for this user + scope
-  const { data: existing } = await supabase
-    .from("voice_call_sessions")
-    .select("*")
-    .eq("started_by", user.id)
-    .eq("scope_id", scopeId)
-    .is("ended_at", null)
-    .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle()
-
-  if (existing) {
-    return NextResponse.json({ session: existing }, { status: 200 })
-  }
-
-  const { data: session, error } = await supabase
-    .from("voice_call_sessions")
-    .insert({
-      scope_type: scopeType,
-      scope_id: scopeId,
-      started_by: user.id,
-      transcription_mode: mode,
-      summary_status: "pending",
-    })
-    .select()
-    .single()
-
-  if (error) {
-    return NextResponse.json({ error: "Failed to create session" }, { status: 500 })
-  }
-
-  // Auto-join the creator as a participant
-  await supabase.from("voice_call_participants").upsert({
-    session_id: session.id,
-    user_id: user.id,
-    consent_transcription: false,
-    consent_translation: false,
-  })
-
-  return NextResponse.json({ session }, { status: 201 })
 }


### PR DESCRIPTION
## Summary

- Wraps both `POST /api/voice/sessions` and `POST /api/voice/sessions/{id}/end` in top-level try/catch blocks so unexpected throws return structured JSON errors instead of raw 500s
- Adds `onConflict: "session_id,user_id"` to the participant upsert, fixing constraint violations when the same user joins twice (e.g. React strict mode double-mount, mobile retry)
- Adds error handling for the idempotency query and participant upsert — previously these had no error checks and any failure propagated as an unhandled 500
- Stops exposing raw Supabase error messages to the client (end route was returning `updateError.message` directly)

## Test plan

- [ ] Join a voice channel on mobile — verify no 500 errors in console for `/api/voice/sessions`
- [ ] Join and disconnect from a voice channel — verify both session creation and end work without errors
- [ ] Rapidly double-tap a voice channel to trigger concurrent requests — verify idempotency returns the existing session
- [ ] Verify voice session tracking works: other users can see who is in the voice channel

Closes #520

https://claude.ai/code/session_01Ao9Aw5ZUc9ts9tZ2WbCGPX