### PR TITLE
Fix: Attachment download returns 500 for optimistic IDs

### DIFF
--- a/apps/web/app/api/attachments/[attachmentId]/download/route.ts
+++ b/apps/web/app/api/attachments/[attachmentId]/download/route.ts
@@ -2,11 +2,18 @@ import { NextRequest, NextResponse } from "next/server"
 import { requireAuth } from "@/lib/utils/api-helpers"
 import { maybeRenewExpiry } from "@vortex/shared"
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ attachmentId: string }> }
 ): Promise<NextResponse> {
   const { attachmentId } = await params
+
+  if (!UUID_RE.test(attachmentId)) {
+    return NextResponse.json({ error: "Attachment not found" }, { status: 404 })
+  }
+
   const { supabase, user, error: authError } = await requireAuth()
   if (authError) return authError
 

--- a/apps/web/app/api/dm/attachments/[attachmentId]/download/route.ts
+++ b/apps/web/app/api/dm/attachments/[attachmentId]/download/route.ts
@@ -6,8 +6,15 @@ export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ attachmentId: string }> }
 ): Promise<NextResponse> {
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
   try {
     const { attachmentId } = await params
+
+    if (!UUID_RE.test(attachmentId)) {
+      return NextResponse.json({ error: "Attachment not found" }, { status: 404 })
+    }
+
     const { supabase, user, error: authError } = await requireAuth()
     if (authError) return authError
     if (!user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })

--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -1265,7 +1265,7 @@ function AttachmentGallery({ attachments, canManageMessages }: { attachments: At
               >
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
-                  src={`/api/attachments/${currentAttachment.id}/download`}
+                  src={currentAttachment.id.startsWith("local-") ? currentAttachment.url : `/api/attachments/${currentAttachment.id}/download`}
                   alt={currentAttachment.filename}
                   className="object-contain"
                   draggable={false}
@@ -1307,7 +1307,10 @@ function AttachmentDisplay({ attachment, onOpenImage, canManageMessages, serverI
   const isImage = attachment.content_type?.startsWith("image/")
   const isVideo = attachment.content_type?.startsWith("video/")
   const isAudio = attachment.content_type?.startsWith("audio/")
-  const downloadUrl = `/api/attachments/${attachment.id}/download`
+  // Optimistic attachments have local-* IDs and no server-side record yet;
+  // use their direct signed URL instead of the download API endpoint.
+  const isOptimistic = attachment.id.startsWith("local-")
+  const downloadUrl = isOptimistic ? attachment.url : `/api/attachments/${attachment.id}/download`
 
   if (isImage) {
     return (

--- a/apps/web/components/dm/dm-channel-area.tsx
+++ b/apps/web/components/dm/dm-channel-area.tsx
@@ -48,6 +48,7 @@ interface DmAttachment {
   filename: string
   size: number
   content_type: string
+  url?: string
 }
 
 interface DmReaction {
@@ -1610,7 +1611,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
                   ) : hasDbAttachments ? (
                     <div className="mt-1 space-y-1">
                       {dbAttachments.map((att) => {
-                        const proxyUrl = `/api/dm/attachments/${att.id}/download`
+                        const proxyUrl = att.id.startsWith("local-") && att.url ? att.url : `/api/dm/attachments/${att.id}/download`
                         const isImg = att.content_type?.startsWith("image/")
                         const isVid = att.content_type?.startsWith("video/")
                         const isAud = att.content_type?.startsWith("audio/")


### PR DESCRIPTION
## Summary

- **Server**: Both `/api/attachments/[id]/download` and `/api/dm/attachments/[id]/download` now validate that `attachmentId` is a valid UUID before querying Supabase, returning 404 early for invalid IDs (e.g. optimistic `local-*` IDs) instead of letting PostgreSQL throw a 500
- **Client**: Optimistic attachments (with `local-*` IDs) now use their direct signed Supabase URL for rendering instead of the download API endpoint — applied in channel messages, DM messages, and the image viewer dialog

## Test plan

- [ ] Upload an image in a channel — verify it renders inline immediately (optimistic) without 500 errors in the console
- [ ] After the message is confirmed by the server, verify clicking the image opens it and the download link works
- [ ] Upload an image in a DM — same checks as above
- [ ] Manually hit `/api/attachments/not-a-uuid/download` — verify it returns 404, not 500
- [ ] Verify existing attachment downloads still work for previously uploaded files

Fixes #512

https://claude.ai/code/session_01AZMMTfjyonxxrdw7yGfC9p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to attachment requests to ensure proper format compliance.

* **Improvements**
  * Enhanced attachment handling to display files seamlessly in both chat and direct messages, with better support for files during upload and after server processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->