### PR TITLE
Fix connection lost banner: remove broken postgres_changes subscription

### DIFF
--- a/apps/web/components/layout/member-list.tsx
+++ b/apps/web/components/layout/member-list.tsx
@@ -177,13 +177,6 @@ export function MemberList({ serverId, initialMembers }: Props) {
     }
   }, [serverId, initialMembers, memberFetchKey])
 
-  // Keep a ref of current member IDs for the DB-change listener (avoids
-  // re-subscribing on every member list change).
-  const memberUserIdsRef = useRef<Set<string>>(new Set())
-  useEffect(() => {
-    memberUserIdsRef.current = new Set(members.map((m) => m.user_id))
-  }, [members])
-
   // Presence subscription (always runs regardless of SSR data)
   useEffect(() => {
     const channel = supabase.channel(`presence:${serverId}`)
@@ -248,49 +241,9 @@ export function MemberList({ serverId, initialMembers }: Props) {
         }
       })
 
-    // ── DB-level status change listener ──────────────────────────────────
-    // When the cron marks a user offline (or any server-side status update),
-    // the Realtime presence channel may lag behind. This postgres_changes
-    // listener catches DB-level status updates and merges them into the
-    // presence state immediately, ensuring the member list is always accurate.
-    const dbChannel = supabase
-      .channel(`presence-db:${serverId}`)
-      .on(
-        "postgres_changes",
-        {
-          event: "UPDATE",
-          schema: "public",
-          table: "users",
-          filter: "status=in.(online,idle,dnd,invisible,offline)",
-        },
-        (payload: { new: Record<string, unknown> }) => {
-          const updatedUser = payload.new as { id?: string; status?: string }
-          if (!updatedUser?.id || !updatedUser?.status) return
-          // Only process if this user is a member of the current server
-          if (!memberUserIdsRef.current.has(updatedUser.id)) return
-
-          setPresence((prev) => {
-            const existing = prev[updatedUser.id!]
-            const newStatus = updatedUser.status!
-            // If Realtime presence already has the correct status, skip
-            if (existing?.status === newStatus) return prev
-            return {
-              ...prev,
-              [updatedUser.id!]: {
-                status: newStatus,
-                speaking: newStatus === "offline" ? undefined : existing?.speaking,
-                voice_channel_id: newStatus === "offline" ? undefined : existing?.voice_channel_id,
-              },
-            }
-          })
-        }
-      )
-      .subscribe()
-
     return () => {
       channelRef.current = null
       supabase.removeChannel(channel)
-      supabase.removeChannel(dbChannel)
       for (const timer of recentActivityTimersRef.current.values()) {
         clearTimeout(timer)
       }


### PR DESCRIPTION
The postgres_changes subscription on the users table used an unsupported `in` filter syntax (status=in.(online,idle,...)) which caused the Supabase Realtime channel to error. This cascaded into the "Connection lost — retrying" banner appearing immediately on page load.

Supabase postgres_changes filters only support `eq` — not `in`. The subscription was also unnecessary since:
- The heartbeat + cron system handles DB-level offline detection
- The Supabase presence channel handles real-time status distribution
- The status inconsistency between user panel and member list was caused by this broken subscription preventing the presence channel from working

https://claude.ai/code/session_01JDatQ5x5MU4fANo5tphjrH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified member presence state management by removing realtime database listeners and streamlining automatic status update synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->