### PR TITLE
Hide message textbox during DM voice/video calls

### DIFF
--- a/apps/web/components/dm/dm-channel-area.tsx
+++ b/apps/web/components/dm/dm-channel-area.tsx
@@ -1960,8 +1960,8 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
       {/* Typing indicator */}
       <TypingIndicator users={typingUsers.map((user) => user.displayName)} />
 
-      {/* Input */}
-      <div className="px-4 pb-2 md:pb-4 flex-shrink-0">
+      {/* Input — hidden during active/ringing calls */}
+      {!activeCall && !ringing && <div className="px-4 pb-2 md:pb-4 flex-shrink-0">
         {/* Reply indicator */}
         {replyTo && (
           <div
@@ -2315,7 +2315,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
             </button>
           )}
         </div>
-      </div>
+      </div>}
 
       {/* Local search modal for encrypted DM channels */}
       {showLocalSearch && channel?.is_encrypted && (


### PR DESCRIPTION
The message input was visible behind the call overlay during active and ringing DM calls. Conditionally render the input section only when there is no active call or ringing state.

https://claude.ai/code/session_017ZFAQU14LtzELVwkehJeqC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message input field now automatically hides during active calls and incoming calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->