### PR TITLE
fix: move Gemini API key from URL query parameter to x-goog-api-key h…

### DIFF
--- a/apps/web/app/api/servers/[serverId]/channels/[channelId]/summarize/route.ts
+++ b/apps/web/app/api/servers/[serverId]/channels/[channelId]/summarize/route.ts
@@ -106,9 +106,9 @@ export async function POST(req: NextRequest, { params }: Params) {
   }
 
   try {
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`, {
+    const response = await fetch("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "x-goog-api-key": apiKey },
       body: JSON.stringify({
         systemInstruction: {
           parts: [

--- a/apps/web/lib/voice/vortex-recap-service.ts
+++ b/apps/web/lib/voice/vortex-recap-service.ts
@@ -121,10 +121,10 @@ Be concise and factual. Use only information from the transcript.`
 
   try {
     const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`,
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "x-goog-api-key": apiKey },
         body: JSON.stringify({
           systemInstruction: { parts: [{ text: systemPrompt }] },
           contents: [


### PR DESCRIPTION
…eader

API keys in URLs are logged by proxies, CDNs, and load balancers. Using the x-goog-api-key header prevents accidental exposure in access logs.

Fixes #552

https://claude.ai/code/session_01FKpQP9pMGSxmf8qWFwrpN8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API authentication handling in summarization and voice recap services to follow current security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->