### PR TITLE
feat: add send state icons, volume slider, distinct notification sounds, ESLint any rule

### DIFF
--- a/apps/web/app/api/user/notification-preferences/route.ts
+++ b/apps/web/app/api/user/notification-preferences/route.ts
@@ -8,6 +8,7 @@ export type UserNotificationPreferences = {
   server_invite_notifications: boolean
   system_notifications: boolean
   sound_enabled: boolean
+  notification_volume: number
   suppress_everyone: boolean
   suppress_role_mentions: boolean
   quiet_hours_enabled: boolean
@@ -23,6 +24,7 @@ const DEFAULTS: UserNotificationPreferences = {
   server_invite_notifications: true,
   system_notifications: true,
   sound_enabled: true,
+  notification_volume: 0.5,
   suppress_everyone: false,
   suppress_role_mentions: false,
   quiet_hours_enabled: false,
@@ -40,7 +42,7 @@ export async function GET() {
 
     const { data } = await supabase
       .from("user_notification_preferences")
-      .select("mention_notifications, reply_notifications, friend_request_notifications, server_invite_notifications, system_notifications, sound_enabled, suppress_everyone, suppress_role_mentions, quiet_hours_enabled, quiet_hours_start, quiet_hours_end, quiet_hours_timezone")
+      .select("mention_notifications, reply_notifications, friend_request_notifications, server_invite_notifications, system_notifications, sound_enabled, notification_volume, suppress_everyone, suppress_role_mentions, quiet_hours_enabled, quiet_hours_start, quiet_hours_end, quiet_hours_timezone")
       .eq("user_id", user.id)
       .maybeSingle()
 
@@ -72,7 +74,7 @@ export async function PUT(req: NextRequest) {
       "quiet_hours_enabled",
     ] as const
 
-    const patch: Record<string, boolean | string> = {}
+    const patch: Record<string, boolean | string | number> = {}
     for (const key of BOOL_KEYS) {
       if (key in body) {
         if (typeof body[key] !== "boolean") {
@@ -80,6 +82,15 @@ export async function PUT(req: NextRequest) {
         }
         patch[key] = body[key] as boolean
       }
+    }
+
+    // Validate notification_volume (float 0–1)
+    if ("notification_volume" in body) {
+      const vol = body.notification_volume
+      if (typeof vol !== "number" || !Number.isFinite(vol) || vol < 0 || vol > 1) {
+        return NextResponse.json({ error: "notification_volume must be a number between 0 and 1" }, { status: 400 })
+      }
+      patch.notification_volume = vol
     }
 
     // Validate quiet hours time fields (HH:MM format)

--- a/apps/web/app/channels/notifications/page.tsx
+++ b/apps/web/app/channels/notifications/page.tsx
@@ -112,7 +112,8 @@ export default function NotificationsPage() {
             messageId: n.message_id,
           })
           if (shouldPlaySound && prefs.sound_enabled) {
-            playNotification()
+            const soundType = n.type === "mention" ? "mention" as const : "message" as const
+            playNotification(soundType)
           }
           if (shouldShowBrowserNotification && n.title) {
             const url = n.server_id && n.channel_id

--- a/apps/web/components/chat/message-item.tsx
+++ b/apps/web/components/chat/message-item.tsx
@@ -3,7 +3,7 @@
 import { memo, useCallback, useEffect, useId, useRef, useState, lazy, Suspense } from "react"
 import { createPortal } from "react-dom"
 import { format } from "date-fns"
-import { Reply, Edit2, Trash2, Smile, Clipboard, Hash, MessageSquare, RefreshCcw, CheckSquare, Flag, Pin, PinOff, Share2, Paperclip } from "lucide-react"
+import { Reply, Edit2, Trash2, Smile, Clipboard, Hash, MessageSquare, RefreshCcw, CheckSquare, Flag, Pin, PinOff, Share2, Paperclip, Clock, Loader2, AlertTriangle } from "lucide-react"
 import { EmojiPicker } from "frimousse"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { UserProfilePopover } from "@/components/user-profile-popover"
@@ -394,7 +394,8 @@ export const MessageItem = memo(function MessageItem({
   const parsedPoll = extractPoll(renderedContent)
   const messageBodyContent = parsedPoll ? parsedPoll.sanitizedContent : renderedContent
 
-  const sendStateLabel = sendState === "queued" ? "Queued" : sendState === "failed" ? "Failed" : null
+  const sendStateLabel = sendState === "queued" ? "Queued" : sendState === "sending" ? "Sending" : sendState === "failed" ? "Failed" : null
+  const SendStateIcon = sendState === "queued" ? Clock : sendState === "sending" ? Loader2 : sendState === "failed" ? AlertTriangle : null
 
 
   // Group reactions by emoji
@@ -585,8 +586,11 @@ export const MessageItem = memo(function MessageItem({
                   >
                     {format(timestamp, timestampFormat === "24h" ? "HH:mm" : "h:mm a")}
                   </span>
-                  {sendStateLabel && (
-                    <span className={cn("message-state-morph text-[10px]", sendState && `is-${sendState}`)}>{sendStateLabel}</span>
+                  {sendStateLabel && SendStateIcon && (
+                    <span className={cn("message-state-morph text-[10px] inline-flex items-center gap-0.5", sendState && `is-${sendState}`)}>
+                      <SendStateIcon className={cn("w-3 h-3", sendState === "sending" && "animate-spin")} />
+                      {sendStateLabel}
+                    </span>
                   )}
                 </div>
               )}
@@ -624,8 +628,11 @@ export const MessageItem = memo(function MessageItem({
                   <span id={messageMetaId} className="text-xs tertiary-metadata message-cozy-timestamp">
                     {format(timestamp, timestampFormat === "24h" ? "MM/dd/yyyy HH:mm" : "MM/dd/yyyy h:mm a")}
                   </span>
-                  {sendStateLabel && (
-                    <span className={cn("message-state-morph", sendState && `is-${sendState}`)}>{sendStateLabel}</span>
+                  {sendStateLabel && SendStateIcon && (
+                    <span className={cn("message-state-morph inline-flex items-center gap-1", sendState && `is-${sendState}`)}>
+                      <SendStateIcon className={cn("w-3 h-3", sendState === "sending" && "animate-spin")} />
+                      {sendStateLabel}
+                    </span>
                   )}
                   {message.edited_at && (
                     <span className="text-xs tertiary-metadata">

--- a/apps/web/components/dm/dm-channel-area.tsx
+++ b/apps/web/components/dm/dm-channel-area.tsx
@@ -760,7 +760,7 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
           const msg = payload.new as Record<string, unknown>
           // Only add if it's from someone else (we already added our own optimistically)
           if (msg.sender_id !== currentUserId) {
-            playNotification()
+            playNotification("dm")
             ;(supabase
               .from("direct_messages")
               .select("*, sender:users!direct_messages_sender_id_fkey(id, username, display_name, avatar_url, status), reply_to_id")

--- a/apps/web/components/notifications/notification-bell.tsx
+++ b/apps/web/components/notifications/notification-bell.tsx
@@ -105,7 +105,8 @@ export function NotificationBell({ userId, variant = "icon" }: Props) {
           })
 
           if (shouldPlaySound && soundEnabledRef.current) {
-            playNotification()
+            const soundType = n.type === "mention" ? "mention" as const : "message" as const
+            playNotification(soundType)
           }
 
           if (shouldShowBrowserNotification && n.title) {

--- a/apps/web/components/settings/notifications-settings-page.tsx
+++ b/apps/web/components/settings/notifications-settings-page.tsx
@@ -15,6 +15,7 @@ type NotificationSettingsRow = {
   server_invite_notifications: boolean
   system_notifications: boolean
   sound_enabled: boolean
+  notification_volume: number
   suppress_everyone: boolean
   suppress_role_mentions: boolean
   quiet_hours_enabled: boolean
@@ -41,6 +42,7 @@ const DEFAULT_SETTINGS: NotificationSettingsRow = {
   server_invite_notifications: true,
   system_notifications: true,
   sound_enabled: true,
+  notification_volume: 0.5,
   suppress_everyone: false,
   suppress_role_mentions: false,
   quiet_hours_enabled: false,
@@ -69,8 +71,9 @@ export function NotificationsSettingsPage({ userId }: Props) {
           const validated = { ...DEFAULT_SETTINGS }
           for (const key of Object.keys(DEFAULT_SETTINGS) as (keyof NotificationSettingsRow)[]) {
             const val = data[key]
-            if (typeof val === "boolean") (validated as Record<string, boolean | string>)[key] = val
-            else if (typeof val === "string") (validated as Record<string, boolean | string>)[key] = val
+            if (typeof val === "boolean") (validated as Record<string, boolean | string | number>)[key] = val
+            else if (typeof val === "string") (validated as Record<string, boolean | string | number>)[key] = val
+            else if (typeof val === "number") (validated as Record<string, boolean | string | number>)[key] = val
           }
           setSettings(validated)
           // Keep sound pref in localStorage for use-notification-sound hook
@@ -93,8 +96,9 @@ export function NotificationsSettingsPage({ userId }: Props) {
               const validated = { ...DEFAULT_SETTINGS }
               for (const key of Object.keys(DEFAULT_SETTINGS) as (keyof NotificationSettingsRow)[]) {
                 const val = parsed[key]
-                if (typeof val === "boolean") (validated as Record<string, boolean | string>)[key] = val
-                else if (typeof val === "string") (validated as Record<string, boolean | string>)[key] = val
+                if (typeof val === "boolean") (validated as Record<string, boolean | string | number>)[key] = val
+                else if (typeof val === "string") (validated as Record<string, boolean | string | number>)[key] = val
+                else if (typeof val === "number") (validated as Record<string, boolean | string | number>)[key] = val
               }
               setSettings(validated)
             }
@@ -233,6 +237,48 @@ export function NotificationsSettingsPage({ userId }: Props) {
           )
         })}
       </section>
+
+      {/* ── Volume slider (#612) ────────── */}
+      {settings.sound_enabled && (
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: "var(--theme-text-muted)" }}>
+            Notification Volume
+          </h2>
+          <div
+            className="flex items-center gap-4 px-4 py-3 rounded-lg"
+            style={{ background: "var(--theme-bg-secondary)", border: "1px solid var(--theme-bg-tertiary)" }}
+          >
+            <VolumeX className="w-4 h-4 shrink-0" style={{ color: "var(--theme-text-muted)" }} />
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={1}
+              value={Math.round(settings.notification_volume * 100)}
+              onChange={(e) => {
+                const vol = Number(e.target.value) / 100
+                setSettings((prev) => ({ ...prev, notification_volume: vol }))
+              }}
+              onPointerUp={(e) => {
+                const vol = Number((e.target as HTMLInputElement).value) / 100
+                void persistSetting({ ...settings, notification_volume: vol })
+              }}
+              className="flex-1 h-2 rounded-full appearance-none cursor-pointer"
+              style={{ accentColor: "var(--theme-accent)" }}
+              aria-label="Notification volume"
+            />
+            <Volume2 className="w-4 h-4 shrink-0" style={{ color: "var(--theme-accent)" }} />
+            <span className="text-xs font-medium tabular-nums w-8 text-right" style={{ color: "var(--theme-text-primary)" }}>
+              {Math.round(settings.notification_volume * 100)}%
+            </span>
+          </div>
+          {settings.notification_volume === 0 && (
+            <p className="text-xs px-1" style={{ color: "var(--theme-text-muted)" }}>
+              Volume is at 0% — notifications will be silent but still visible.
+            </p>
+          )}
+        </section>
+      )}
 
       {/* ── Mention suppression (#607) ────────── */}
       <section className="space-y-2">

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -2,6 +2,7 @@ import nextPlugin from "@next/eslint-plugin-next"
 import reactPlugin from "eslint-plugin-react"
 import hooksPlugin from "eslint-plugin-react-hooks"
 import jsxA11yPlugin from "eslint-plugin-jsx-a11y"
+import tsPlugin from "@typescript-eslint/eslint-plugin"
 
 export default [
   {
@@ -13,6 +14,7 @@ export default [
       "react": reactPlugin,
       "react-hooks": hooksPlugin,
       "jsx-a11y": jsxA11yPlugin,
+      "@typescript-eslint": tsPlugin,
     },
     rules: {
       ...nextPlugin.configs.recommended.rules,
@@ -25,6 +27,7 @@ export default [
       "jsx-a11y/click-events-have-key-events": "warn",
       "jsx-a11y/no-static-element-interactions": "warn",
       "jsx-a11y/role-has-required-aria-props": "warn",
+      "@typescript-eslint/no-explicit-any": "error",
     },
     settings: {
       react: {

--- a/apps/web/hooks/use-dm-notification-sound.ts
+++ b/apps/web/hooks/use-dm-notification-sound.ts
@@ -52,7 +52,7 @@ export function useDmNotificationSound(userId: string | null): void {
           })
 
           if (shouldPlaySound && isSoundEnabled()) {
-            playRef.current()
+            playRef.current("dm")
           }
 
           if (shouldShowBrowserNotification) {

--- a/apps/web/hooks/use-notification-preferences.ts
+++ b/apps/web/hooks/use-notification-preferences.ts
@@ -9,6 +9,7 @@ export interface NotificationPreferences {
   server_invite_notifications: boolean
   system_notifications: boolean
   sound_enabled: boolean
+  notification_volume: number
   quiet_hours_enabled: boolean
   quiet_hours_start: string
   quiet_hours_end: string
@@ -22,6 +23,7 @@ const DEFAULTS: NotificationPreferences = {
   server_invite_notifications: true,
   system_notifications: true,
   sound_enabled: true,
+  notification_volume: 0.5,
   quiet_hours_enabled: false,
   quiet_hours_start: "22:00",
   quiet_hours_end: "08:00",
@@ -117,6 +119,13 @@ export function useNotificationPreferences(userId: string | null): {
  */
 export function isSoundEnabled(): boolean {
   return cachedPrefs.sound_enabled
+}
+
+/**
+ * Quick read of cached notification volume (0–1). No hook needed.
+ */
+export function getNotificationVolume(): number {
+  return cachedPrefs.notification_volume
 }
 
 /**

--- a/apps/web/hooks/use-notification-sound.ts
+++ b/apps/web/hooks/use-notification-sound.ts
@@ -2,11 +2,19 @@
 
 import { useCallback, useRef, useSyncExternalStore } from "react"
 import { persistBooleanStorage } from "@/lib/utils/storage"
+import { getNotificationVolume } from "@/hooks/use-notification-preferences"
 
 const STORAGE_KEY = "vortexchat:notification-sound-enabled"
 
-// Path to the notification sound file served from /public
-const NOTIFICATION_SOUND_URL = "/sounds/notification.wav"
+/** Notification sound categories — each plays a distinct audio cue. */
+export type NotificationSoundType = "message" | "dm" | "mention"
+
+// Paths to notification sound files served from /public
+const SOUND_URLS: Record<NotificationSoundType, string> = {
+  message: "/sounds/notification.wav",
+  dm: "/sounds/notification-dm.wav",
+  mention: "/sounds/notification-mention.wav",
+}
 
 // ---------------------------------------------------------------------------
 // localStorage-backed setting with useSyncExternalStore for React sync
@@ -14,16 +22,16 @@ const NOTIFICATION_SOUND_URL = "/sounds/notification.wav"
 
 const listeners = new Set<() => void>()
 
-function notifyListeners() {
+function notifyListeners(): void {
   listeners.forEach((cb) => cb())
 }
 
 // Cross-tab sync: listen for storage events from other tabs
-function onStorageEvent(e: StorageEvent) {
+function onStorageEvent(e: StorageEvent): void {
   if (e.key === STORAGE_KEY || e.key === null) notifyListeners()
 }
 
-function subscribe(cb: () => void) {
+function subscribe(cb: () => void): () => void {
   if (listeners.size === 0 && typeof window !== "undefined") {
     window.addEventListener("storage", onStorageEvent)
   }
@@ -45,47 +53,84 @@ function getServerSnapshot(): boolean {
   return true
 }
 
-function setNotificationSoundEnabled(enabled: boolean) {
+function setNotificationSoundEnabled(enabled: boolean): void {
   persistBooleanStorage(STORAGE_KEY, enabled)
   notifyListeners()
 }
 
 // ---------------------------------------------------------------------------
-// Audio file player (replaces Web Audio API tone generator)
+// Audio file player — one preloaded template per sound type
 // ---------------------------------------------------------------------------
 
-// Preloaded Audio element — we clone it for each play to allow overlapping
-let preloadedAudio: HTMLAudioElement | null = null
+const preloadedAudios: Partial<Record<NotificationSoundType, HTMLAudioElement>> = {}
 
-function getPreloadedAudio(): HTMLAudioElement {
-  if (!preloadedAudio) {
-    preloadedAudio = new Audio(NOTIFICATION_SOUND_URL)
-    preloadedAudio.preload = "auto"
-    preloadedAudio.volume = 0.5
+function getPreloadedAudio(type: NotificationSoundType): HTMLAudioElement {
+  if (!preloadedAudios[type]) {
+    const audio = new Audio(SOUND_URLS[type])
+    audio.preload = "auto"
+    audio.volume = getNotificationVolume()
+    preloadedAudios[type] = audio
   }
-  return preloadedAudio
+  return preloadedAudios[type]
 }
 
-async function playNotificationSound(): Promise<void> {
+async function playNotificationSound(type: NotificationSoundType = "message"): Promise<void> {
   try {
-    const template = getPreloadedAudio()
+    const volume = getNotificationVolume()
+    const template = getPreloadedAudio(type)
     // Clone so we can play overlapping sounds if rapid notifications arrive
     const audio = template.cloneNode(true) as HTMLAudioElement
-    audio.volume = 0.5
+    audio.volume = volume
     audio.currentTime = 0
     await audio.play()
   } catch {
     // Autoplay blocked or audio unavailable — fall back to Web Audio API tone
     try {
-      await playFallbackTone()
+      await playFallbackTone(type)
     } catch {
       // Silent fallback — audio not available in this environment
     }
   }
 }
 
-/** Fallback: Web Audio API two-tone chime if <audio> playback fails */
-async function playFallbackTone(): Promise<void> {
+// ---------------------------------------------------------------------------
+// Distinct Web Audio API fallback tones per notification type
+// ---------------------------------------------------------------------------
+
+/** Tone definitions: [frequency, startTime, duration, peakGain] */
+type ToneNote = { freq: number; start: number; dur: number; peak: number }
+
+const TONE_PROFILES: Record<NotificationSoundType, { waveform: OscillatorType; notes: ToneNote[] }> = {
+  // General message: gentle two-tone chime (C6 → E6)
+  message: {
+    waveform: "sine",
+    notes: [
+      { freq: 1047, start: 0, dur: 0.12, peak: 0.15 },
+      { freq: 1319, start: 0.08, dur: 0.17, peak: 0.12 },
+    ],
+  },
+  // DM: warm three-note ascending arpeggio (G5 → B5 → D6)
+  dm: {
+    waveform: "sine",
+    notes: [
+      { freq: 784, start: 0, dur: 0.1, peak: 0.14 },
+      { freq: 988, start: 0.07, dur: 0.1, peak: 0.13 },
+      { freq: 1175, start: 0.14, dur: 0.15, peak: 0.12 },
+    ],
+  },
+  // Mention: brighter attention-grabbing double-tap (E6 → E6 with gap)
+  mention: {
+    waveform: "triangle",
+    notes: [
+      { freq: 1319, start: 0, dur: 0.08, peak: 0.18 },
+      { freq: 1319, start: 0.12, dur: 0.08, peak: 0.18 },
+      { freq: 1568, start: 0.22, dur: 0.12, peak: 0.14 },
+    ],
+  },
+}
+
+async function playFallbackTone(type: NotificationSoundType = "message"): Promise<void> {
+  const volume = getNotificationVolume()
   const ctx = new AudioContext()
 
   try {
@@ -97,37 +142,30 @@ async function playFallbackTone(): Promise<void> {
     return
   }
 
-  const osc1 = ctx.createOscillator()
-  const gain1 = ctx.createGain()
-  osc1.connect(gain1)
-  gain1.connect(ctx.destination)
-  osc1.type = "sine"
-  osc1.frequency.setValueAtTime(1047, ctx.currentTime) // C6
-  gain1.gain.setValueAtTime(0.15, ctx.currentTime)
-  gain1.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.12)
-  osc1.start(ctx.currentTime)
-  osc1.stop(ctx.currentTime + 0.12)
+  const profile = TONE_PROFILES[type]
+  let lastEnd = 0
 
-  const osc2 = ctx.createOscillator()
-  const gain2 = ctx.createGain()
-  osc2.connect(gain2)
-  gain2.connect(ctx.destination)
-  osc2.type = "sine"
-  osc2.frequency.setValueAtTime(1319, ctx.currentTime + 0.08) // E6
-  gain2.gain.setValueAtTime(0, ctx.currentTime)
-  gain2.gain.setValueAtTime(0.12, ctx.currentTime + 0.08)
-  gain2.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.25)
-  osc2.start(ctx.currentTime + 0.08)
-  osc2.stop(ctx.currentTime + 0.25)
-
-  osc2.onended = () => {
-    ctx.close().catch(() => {})
+  for (const note of profile.notes) {
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    osc.connect(gain)
+    gain.connect(ctx.destination)
+    osc.type = profile.waveform
+    osc.frequency.setValueAtTime(note.freq, ctx.currentTime + note.start)
+    gain.gain.setValueAtTime(0, ctx.currentTime)
+    gain.gain.setValueAtTime(note.peak * volume, ctx.currentTime + note.start)
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + note.start + note.dur)
+    osc.start(ctx.currentTime + note.start)
+    osc.stop(ctx.currentTime + note.start + note.dur)
+    const end = note.start + note.dur
+    if (end > lastEnd) lastEnd = end
   }
+
   setTimeout(() => {
     if (ctx.state !== "closed") {
       ctx.close().catch(() => {})
     }
-  }, 1000)
+  }, (lastEnd + 0.5) * 1000)
 }
 
 // ---------------------------------------------------------------------------
@@ -135,14 +173,14 @@ async function playFallbackTone(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 export function useNotificationSound(): {
-  playNotification: () => void
+  playNotification: (type?: NotificationSoundType) => void
   notificationSoundEnabled: boolean
   setNotificationSoundEnabled: (enabled: boolean) => void
 } {
   const enabled = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
   const lastPlayedRef = useRef(0)
 
-  const playNotification = useCallback(() => {
+  const playNotification = useCallback((type: NotificationSoundType = "message") => {
     if (!getSnapshot()) return
 
     // Debounce rapid successive plays (500ms)
@@ -150,7 +188,7 @@ export function useNotificationSound(): {
     if (now - lastPlayedRef.current < 500) return
     lastPlayedRef.current = now
 
-    playNotificationSound()
+    playNotificationSound(type)
   }, [])
 
   return {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -75,6 +75,8 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/web-push": "^3.6.4",
+    "@typescript-eslint/eslint-plugin": "^8.58.0",
+    "@typescript-eslint/parser": "^8.58.0",
     "autoprefixer": "^10.0.1",
     "eslint": "^9.0.0",
     "eslint-config-next": "^16.2.0",

--- a/docs/mvp-core-features.md
+++ b/docs/mvp-core-features.md
@@ -161,6 +161,8 @@
 | Push notification sender avatar (#606) | Done | `lib/push.ts` — notification icon uses sender's `avatar_url`; system notifications (pins, invites) fall back to app icon |
 | Suppress @everyone / @role mention toggles (#607) | Done | `suppress_everyone` + `suppress_role_mentions` columns on `user_notification_preferences`; checked in `sendPushToChannel()`; UI toggles in Notification settings |
 | Test notification button (#609) | Done | `POST /api/notifications/test` — sends real push bypassing quiet hours; rate limited 1/30s; validates subscription exists; button in Notification settings |
+| Notification volume slider (#612) | Done | `notification_volume` REAL column (migration 00093); slider in Notification settings (0–100%); `getNotificationVolume()` utility; persisted per-user; 0% = silent but visible |
+| Distinct notification sounds (#615) | Done | `NotificationSoundType` enum (`message` \| `dm` \| `mention`); per-type audio files + Web Audio API fallback tones; DM notifications use warm arpeggio; mentions use attention double-tap |
 
 ## Direct Messages
 
@@ -296,7 +298,8 @@
 | CSS container queries for component responsiveness (#575) | Done | Added `container-type: inline-size` to channel sidebar, member list, message input, thread panel; responsive `@container` rules |
 | Named view transitions (#576) | Done | Added `view-transition-name` to server sidebar, channel sidebar, chat area, and chat header surfaces; respects `prefers-reduced-motion` |
 | Suspicious login detection enforcement (#545) | Done | `computeLoginRisk` now returns `action` field; score >= 60 requires MFA/email challenge; score >= 80 locks session and requires email verification |
-| TypeScript `any` type cleanup (#546) | Done | All 46 files cleaned; remaining `SupabaseClient<any>` consolidated in `lib/supabase/untyped-table.ts` utility (intentional for ungenerated tables) |
+| TypeScript `any` type cleanup (#546) | Done | All 46 files cleaned; remaining `SupabaseClient<any>` consolidated in `lib/supabase/untyped-table.ts` utility (intentional for ungenerated tables); ESLint `@typescript-eslint/no-explicit-any: error` rule added |
+| Message send state icons (#616) | Done | Clock (queued), animated spinner (sending), alert triangle (failed) Lucide icons in `message-item.tsx`; text labels preserved for screen reader accessibility |
 
 ## Search (#593)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,8 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@types/web-push": "^3.6.4",
+        "@typescript-eslint/eslint-plugin": "^8.58.0",
+        "@typescript-eslint/parser": "^8.58.0",
         "autoprefixer": "^10.0.1",
         "eslint": "^9.0.0",
         "eslint-config-next": "^16.2.0",
@@ -1070,6 +1072,360 @@
         "node": ">=18"
       }
     },
+    "apps/web/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
+      "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/type-utils": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
+      "integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
+      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.0",
+        "@typescript-eslint/tsconfig-utils": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
+      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.0",
+        "@typescript-eslint/types": "^8.58.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
+      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
+      "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
+      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.0",
+        "@typescript-eslint/tsconfig-utils": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
+      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.0",
+        "@typescript-eslint/types": "^8.58.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
+      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/parser": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
+      "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
+      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.0",
+        "@typescript-eslint/tsconfig-utils": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
+      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.0",
+        "@typescript-eslint/types": "^8.58.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
+      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
+      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/types": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
+      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "apps/web/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
+      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "apps/web/node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1205,6 +1561,19 @@
         "node": ">=6"
       }
     },
+    "apps/web/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "apps/web/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1221,6 +1590,16 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "apps/web/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "apps/web/node_modules/import-in-the-middle": {
@@ -1361,6 +1740,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "apps/web/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "apps/web/node_modules/strip-literal": {

--- a/supabase/migrations/00093_notification_volume.sql
+++ b/supabase/migrations/00093_notification_volume.sql
@@ -1,0 +1,5 @@
+-- Add notification_volume column to user_notification_preferences
+-- Stores a float 0.0–1.0 (maps to 0%–100% in the UI)
+ALTER TABLE user_notification_preferences
+  ADD COLUMN IF NOT EXISTS notification_volume REAL NOT NULL DEFAULT 0.5
+  CHECK (notification_volume >= 0 AND notification_volume <= 1);


### PR DESCRIPTION
## Summary

- **#616**: Add Clock/Loader2/AlertTriangle Lucide icons to queued/sending/failed message states, preserving text labels for accessibility
- **#612**: Add `notification_volume` DB column (migration 00093), volume slider (0–100%) in Notification settings, `getNotificationVolume()` utility used by all audio playback paths
- **#615**: Add `NotificationSoundType` (`message` | `dm` | `mention`) with distinct Web Audio API fallback tones and per-type audio file routing — DM uses warm arpeggio, mention uses attention double-tap
- **#546**: Add `@typescript-eslint/no-explicit-any: error` ESLint rule to prevent future `any` usage
- **#598**: Already fully implemented — confirmed and documented in mvp-core-features.md

## Test plan

- [ ] Verify queued/sending/failed message states show correct icons (Clock, animated spinner, red alert triangle) alongside text labels
- [ ] Confirm volume slider appears in Notification settings when sound is enabled, persists across page reloads
- [ ] Set volume to 0% and verify notifications are silent but still visible
- [ ] Trigger a DM notification and verify it plays a distinct sound from a channel message
- [ ] Trigger an @mention notification and verify it plays the attention double-tap tone
- [ ] Run `npx eslint .` and verify `no-explicit-any` rule is enforced (errors on new `any` usage)
- [ ] Run migration 00093 and verify `notification_volume` column exists with default 0.5

Closes #612, closes #615, closes #616

https://claude.ai/code/session_012HXvBAD6XaNckyHK3uMsxj