### PR TITLE
fix: add urgency header and decouple badge fetch for iOS push notifications

### DIFF
--- a/apps/web/lib/push.ts
+++ b/apps/web/lib/push.ts
@@ -30,6 +30,12 @@ export interface PushPayload {
 // not be reachable immediately, so we use 24 hours to avoid silent drops.
 const PUSH_TTL_SECONDS = 86_400 // 24 hours
 
+// Urgency — Apple's APNs maps the Web Push Urgency header to apns-priority.
+// Without "high", iOS treats notifications as low/normal priority and may
+// delay, batch, or silently drop them — especially when the device is locked
+// or in low-power mode.  "high" maps to apns-priority 10 (immediate delivery).
+const PUSH_URGENCY = "high" as const
+
 /**
  * Send a push notification to all subscriptions for a given user.
  * Silently removes stale subscriptions (410 Gone).
@@ -92,7 +98,7 @@ export async function sendPushToUser(
         webpush.sendNotification(
           { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
           JSON.stringify(payload),
-          { TTL: PUSH_TTL_SECONDS }
+          { TTL: PUSH_TTL_SECONDS, urgency: PUSH_URGENCY }
         ).catch(async (err: unknown) => {
           const statusCode = (err as { statusCode?: number }).statusCode
           // 410 = subscription expired; clean it up

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -127,6 +127,12 @@ self.addEventListener("push", (event) => {
   // the same tag silently replaces earlier notifications without alerting.
   const isIOS = /iP(hone|ad|od)/.test(self.navigator?.userAgent ?? "")
 
+  // Show the notification FIRST and resolve waitUntil as soon as it's
+  // displayed.  The badge update is fire-and-forget — on iOS the SW has
+  // strict execution time limits, and chaining a network fetch after
+  // showNotification() risks the OS killing the SW before the promise
+  // chain resolves, which can cause iOS to silently revoke the push
+  // subscription entirely.
   event.waitUntil(
     self.clients.matchAll({ type: "window", includeUncontrolled: false }).then((clients) => {
       // If any tab is focused, the in-app handler will play the sound — make
@@ -147,7 +153,10 @@ self.addEventListener("push", (event) => {
         { action: "dismiss", title: "Dismiss" },
       ] : [])
 
-      return self.registration.showNotification(title, {
+      // Fire-and-forget badge update — do NOT chain this in the waitUntil
+      // promise.  On iOS, the SW has ~30s to finish; a slow/hanging fetch
+      // here can cause the OS to terminate the SW and revoke the push sub.
+      const badgeUpdate = self.registration.showNotification(title, {
         body,
         icon,
         badge: "/icon-192.png?v=2",
@@ -157,24 +166,22 @@ self.addEventListener("push", (event) => {
         requireInteraction: false,
         actions,
         silent: anyFocused,
-      }).then(() =>
-        // Update the PWA app badge after showing the notification.
-        // iOS does not support periodicSync, so this is the only
-        // opportunity to update the badge when the app is closed.
+      }).then(() => {
+        // Best-effort badge update after notification is shown.
+        // Intentionally not returned so it doesn't block waitUntil.
         fetch("/api/notifications/unread-count", { credentials: "same-origin" })
           .then((res) => {
-            if (!res.ok) {
-              console.debug("Badge update skipped: unread-count returned", res.status)
-              return null
-            }
+            if (!res.ok) return null
             return res.json()
           })
           .then((json) => {
             const count = json?.count
             if (typeof count === "number" && isFinite(count)) updateAppBadge(count)
           })
-          .catch(() => {}) // best-effort — don't break the notification
-      )
+          .catch(() => {})
+      })
+
+      return badgeUpdate
     })
   )
 })

--- a/apps/web/sw.src.js
+++ b/apps/web/sw.src.js
@@ -169,6 +169,12 @@ self.addEventListener("push", (event) => {
   // the same tag silently replaces earlier notifications without alerting.
   const isIOS = /iP(hone|ad|od)/.test(self.navigator?.userAgent ?? "")
 
+  // Show the notification FIRST and resolve waitUntil as soon as it's
+  // displayed.  The badge update is fire-and-forget — on iOS the SW has
+  // strict execution time limits, and chaining a network fetch after
+  // showNotification() risks the OS killing the SW before the promise
+  // chain resolves, which can cause iOS to silently revoke the push
+  // subscription entirely.
   event.waitUntil(
     self.clients.matchAll({ type: "window", includeUncontrolled: false }).then((clients) => {
       // If any tab is focused, the in-app handler will play the sound — make
@@ -189,7 +195,10 @@ self.addEventListener("push", (event) => {
         { action: "dismiss", title: "Dismiss" },
       ] : [])
 
-      return self.registration.showNotification(title, {
+      // Fire-and-forget badge update — do NOT chain this in the waitUntil
+      // promise.  On iOS, the SW has ~30s to finish; a slow/hanging fetch
+      // here can cause the OS to terminate the SW and revoke the push sub.
+      const badgeUpdate = self.registration.showNotification(title, {
         body,
         icon,
         badge: "/icon-192.png?v=2",
@@ -199,24 +208,22 @@ self.addEventListener("push", (event) => {
         requireInteraction: false,
         actions,
         silent: anyFocused,
-      }).then(() =>
-        // Update the PWA app badge after showing the notification.
-        // iOS does not support periodicSync, so this is the only
-        // opportunity to update the badge when the app is closed.
+      }).then(() => {
+        // Best-effort badge update after notification is shown.
+        // Intentionally not returned so it doesn't block waitUntil.
         fetch("/api/notifications/unread-count", { credentials: "same-origin" })
           .then((res) => {
-            if (!res.ok) {
-              console.debug("Badge update skipped: unread-count returned", res.status)
-              return null
-            }
+            if (!res.ok) return null
             return res.json()
           })
           .then((json) => {
             const count = json?.count
             if (typeof count === "number" && isFinite(count)) updateAppBadge(count)
           })
-          .catch(() => {}) // best-effort — don't break the notification
-      )
+          .catch(() => {})
+      })
+
+      return badgeUpdate
     })
   )
 })


### PR DESCRIPTION
iOS APNs maps the Web Push Urgency header to apns-priority. Without
explicitly setting urgency to "high", iOS treats notifications as
normal priority and can silently delay, batch, or drop them — especially
when the device is locked or in low-power mode.

Also decouples the badge count fetch from the showNotification() promise
chain in the service worker push handler. On iOS, the SW has strict
execution time limits (~30s); chaining a network fetch that may hang
(no auth cookies in SW context) after showNotification() risks the OS
terminating the SW before waitUntil resolves, which can cause iOS to
revoke the push subscription entirely.

https://claude.ai/code/session_01UPgx8VmhQrTUnZsmPZtHjJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Push notifications now configured with higher priority settings to accelerate delivery and improve visibility across devices, with enhanced support for iOS platforms.

* **Performance Improvements**
  * Optimized notification badge update mechanism to prevent display delays, enabling unread count refreshes to occur asynchronously in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->