### PR TITLE
fix: always scroll to bottom on channel/DM load

### DIFF
--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -126,6 +126,8 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
   const paginationRequestRef = useRef<Promise<unknown> | null>(null)
   const shouldAutoScrollToLatestRef = useRef(true)
   const prevChannelIdRef = useRef(channel.id)
+  const rafOuterRef = useRef(0)
+  const rafInnerRef = useRef(0)
   const messagesRef = useRef<MessageWithAuthor[]>(initialMessages)
   const reconnectCycleRef = useRef(0)
   const liveAnnouncementCounterRef = useRef(0)
@@ -469,8 +471,7 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     return () => {
       const msgs = messagesRef.current
       if (msgs.length > 0) {
-        const scrollTop = messageScrollerRef.current?.scrollTop ?? 0
-        cacheMessages(channel.id, msgs, scrollTop)
+        cacheMessages(channel.id, msgs)
       }
     }
   }, [channel.id, cacheMessages])
@@ -876,18 +877,23 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     const container = messageScrollerRef.current
     if (!container) return
 
-    // Check for cached scroll position from a previous visit to this channel
     // Scroll to bottom (newest messages).
     // With virtualized lists, estimated row heights mean scrollHeight may
     // change after the browser paints and the virtualizer measures real
     // elements.  Re-scroll after two animation frames to settle.
     container.scrollTop = container.scrollHeight
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
+    const outerRaf = requestAnimationFrame(() => {
+      const innerRaf = requestAnimationFrame(() => {
         const el = messageScrollerRef.current
         if (el) el.scrollTop = el.scrollHeight
       })
+      rafInnerRef.current = innerRaf
     })
+    rafOuterRef.current = outerRaf
+    return () => {
+      cancelAnimationFrame(rafOuterRef.current)
+      cancelAnimationFrame(rafInnerRef.current)
+    }
   }, [channel.id, jumpToMessageId, messages.length, openThreadId])
 
   useEffect(() => {

--- a/apps/web/components/dm/dm-channel-area.tsx
+++ b/apps/web/components/dm/dm-channel-area.tsx
@@ -631,12 +631,17 @@ export function DMChannelArea({ channelId, currentUserId }: Props) {
     scrollToBottom()
     // Re-scroll after layout settles — images, embeds, or lazy content may
     // change scrollHeight between useLayoutEffect and the first paint.
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
+    let rafInner = 0
+    const rafOuter = requestAnimationFrame(() => {
+      rafInner = requestAnimationFrame(() => {
         scrollToBottom()
       })
     })
     prevLastMsgIdRef.current = messages[messages.length - 1]?.id ?? null
+    return () => {
+      cancelAnimationFrame(rafOuter)
+      cancelAnimationFrame(rafInner)
+    }
   }, [channelId, messages.length, scrollToBottom])
 
   // Track active DM channel for notification suppression

--- a/apps/web/lib/stores/app-store.ts
+++ b/apps/web/lib/stores/app-store.ts
@@ -92,8 +92,8 @@ interface AppState {
   loadNotificationSettings: () => Promise<void>
 
   // Message cache (per-channel, most recent messages for instant channel switching)
-  messageCache: Record<string, { messages: MessageWithAuthor[]; scrollOffset: number; timestamp: number }>
-  cacheMessages: (channelId: string, messages: MessageWithAuthor[], scrollOffset?: number) => void
+  messageCache: Record<string, { messages: MessageWithAuthor[]; timestamp: number }>
+  cacheMessages: (channelId: string, messages: MessageWithAuthor[]) => void
   invalidateMessageCache: (channelId: string) => void
 
   // Mobile action dispatch (replaces fragile DOM CustomEvents between ServerMobileLayout → ChatArea)
@@ -259,13 +259,12 @@ export const useAppStore = create<AppState>((set) => ({
   },
 
   messageCache: {},
-  cacheMessages: (channelId, messages, scrollOffset = 0) =>
+  cacheMessages: (channelId, messages) =>
     set((state) => {
       const cache = { ...state.messageCache }
       // Keep only last 100 messages per channel and cap at 10 cached channels
       cache[channelId] = {
         messages: messages.slice(-100),
-        scrollOffset,
         timestamp: Date.now(),
       }
       // Evict oldest if over 10 channels cached


### PR DESCRIPTION
The virtualized message list uses estimated row heights (68px) for its
initial layout. When useLayoutEffect set scrollTop = scrollHeight, it
used the estimated total — then after the browser painted and the
virtualizer measured real elements, the total height changed, leaving
the user stranded in the middle of the conversation.

Fix: re-scroll after two animation frames so the virtualizer has
settled its measurements. Also removes the cached scroll offset restore
so channels and DMs always open at the newest message.

https://claude.ai/code/session_01QLk3DYBCX8hrfGvz2TXGt1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable auto-scroll to the latest message when switching channels, including after images/embeds load.
  * Ensures view consistently reaches the bottom on channel open/update.

* **Chores**
  * Channel message cache no longer restores prior scroll position when leaving/re-entering a channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->