### PR TITLE
fix: channel chat not scrolling to latest message on load

### DIFF
--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -504,12 +504,15 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     // Sync refs and derived state with the current messages.  The cache merge
     // already happened synchronously in the useState initializer, so on initial
     // mount this just aligns refs.  When initialMessages changes later (e.g.
-    // server re-render while the component is still mounted), re-merge and
-    // re-trigger scroll-to-bottom so the user sees the latest messages.
+    // server re-render while the component is still mounted), re-merge with
+    // the current messages and let the existing new-message effect handle
+    // scroll/unread decisions — don't force scroll-to-bottom here as the user
+    // may be reading older history.
     const currentMsgs = messagesRef.current
 
     // If initialMessages changed after mount (same channel, fresh server data),
-    // re-merge with the current messages and scroll to bottom.
+    // re-merge with the current messages.  The new-message useEffect will detect
+    // the changed newest ID and handle auto-scroll / pending-badge as normal.
     const initialNewest = initialMessages[initialMessages.length - 1]?.id ?? null
     const currentNewest = currentMsgs[currentMsgs.length - 1]?.id ?? null
     if (initialNewest && initialNewest !== currentNewest) {
@@ -519,14 +522,11 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
       const trimmed = merged.length > DISPLAY_LIMIT ? merged.slice(merged.length - DISPLAY_LIMIT) : merged
       messagesRef.current = trimmed
       setMessages(trimmed)
-      previousLastMessageIdRef.current = trimmed[trimmed.length - 1]?.id ?? null
-      shouldAutoScrollToLatestRef.current = true
     } else {
       messagesRef.current = currentMsgs
       previousLastMessageIdRef.current = currentMsgs[currentMsgs.length - 1]?.id ?? null
     }
 
-    setPendingNewMessageCount(0)
     setHasMoreHistory(messagesRef.current.length >= 50)
     for (const timer of animatedMessageTimersRef.current.values()) {
       clearTimeout(timer)


### PR DESCRIPTION
The channel chat had a race condition between message cache merging and
scroll-to-bottom logic. The scroll-to-bottom useLayoutEffect fired with
initialMessages (50), set its "already scrolled" flag to false, then a
post-paint useEffect replaced messages with the cache merge (up to 100
messages) — but the scroll flag was already consumed, leaving the user
stranded mid-scroll.

Fix: move the cache merge into the useState initializer so the first
render already has the correct merged message set. This matches DMs,
which work correctly because they don't have a cache merge effect.

https://claude.ai/code/session_01EPvFGD3xAvsFfbgE9CFUeu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized chat message initialization and caching logic to improve reliability of message display, ordering, and deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->