### PR TITLE
fix: use virtualizer scrollToIndex for channel scroll

### DIFF
--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -899,7 +899,6 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     if (!shouldAutoScrollToLatestRef.current) return
     if (jumpToMessageId || openThreadId) return
     if (messages.length === 0) return
-    shouldAutoScrollToLatestRef.current = false
 
     // Scroll to bottom (newest messages) using the virtualizer's
     // scrollToIndex which correctly handles estimated row heights.
@@ -914,11 +913,15 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
 
     // Re-scroll after the virtualizer measures real element heights.
     // The first pass uses estimates; after paint the virtualizer measures
-    // actual DOM nodes which shifts positions.
+    // actual DOM nodes which shifts positions.  Clear the flag only after
+    // the correction pass so intervening message arrivals don't cancel
+    // the RAFs and leave the viewport above the newest message.
     const outerRaf = requestAnimationFrame(() => {
       const innerRaf = requestAnimationFrame(() => {
-        if (virtualizerRef.current && messages.length > 0) {
-          virtualizerRef.current.scrollToIndex(messages.length - 1, { align: "end" })
+        const latestCount = messagesRef.current.length
+        shouldAutoScrollToLatestRef.current = false
+        if (virtualizerRef.current && latestCount > 0) {
+          virtualizerRef.current.scrollToIndex(latestCount - 1, { align: "end" })
         } else {
           const el = messageScrollerRef.current
           if (el) el.scrollTop = el.scrollHeight


### PR DESCRIPTION
## Summary
- Replace `container.scrollTop = container.scrollHeight` with `virtualizerRef.scrollToIndex(lastIndex, { align: "end" })` for initial channel load and `scrollToLatest`
- `scrollHeight` is based on estimated row heights (68px) which don't match actual measured heights — so the "bottom" it scrolls to isn't the real bottom
- DMs work fine because they don't use virtualization

## Test plan
- [ ] Click on a channel — should show the most recent message at the bottom
- [ ] Switch between channels — each should land at the latest message
- [ ] Send a message — should auto-scroll to show it
- [ ] DMs should continue working as before

https://claude.ai/code/session_01EPvFGD3xAvsFfbgE9CFUeu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message auto-scrolling to more reliably display the latest message when switching between channels or opening conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->