### PR TITLE
fix(presence): restore online status after gateway migration

### DIFF
--- a/apps/signal/src/gateway.ts
+++ b/apps/signal/src/gateway.ts
@@ -293,12 +293,15 @@ export function initGateway(options: GatewayOptions): void {
         if (supabase) {
           try {
             const now = new Date().toISOString()
-            await supabase
+            const { error: dbErr } = await supabase
               .from("users")
               .update({ status: userStatus, last_heartbeat_at: now, updated_at: now })
               .eq("id", state.userId)
+            if (dbErr) {
+              log.error({ err: dbErr, userId: state.userId }, "gateway:presence DB status update failed")
+            }
           } catch (err) {
-            log.error({ err, userId: state.userId }, "gateway:presence DB status update failed")
+            log.error({ err, userId: state.userId }, "gateway:presence DB status update threw")
           }
         }
 
@@ -443,12 +446,15 @@ export function initGateway(options: GatewayOptions): void {
         if (supabase) {
           try {
             const now = new Date().toISOString()
-            await supabase
+            const { error: dbErr } = await supabase
               .from("users")
               .update({ status, last_heartbeat_at: now, updated_at: now })
               .eq("id", userId)
+            if (dbErr) {
+              log.error({ err: dbErr, userId }, "gateway:init DB status update failed")
+            }
           } catch (err) {
-            log.error({ err, userId }, "gateway:init DB status update failed")
+            log.error({ err, userId }, "gateway:init DB status update threw")
           }
         }
 
@@ -503,12 +509,15 @@ export function initGateway(options: GatewayOptions): void {
         if (supabase) {
           try {
             const now = new Date().toISOString()
-            await supabase
+            const { error: dbErr } = await supabase
               .from("users")
               .update({ status: "offline", last_online_at: now, updated_at: now })
               .eq("id", state.userId)
+            if (dbErr) {
+              log.error({ err: dbErr, userId: state.userId }, "disconnect DB status update failed")
+            }
           } catch (err) {
-            log.error({ err, userId: state.userId }, "disconnect DB status update failed")
+            log.error({ err, userId: state.userId }, "disconnect DB status update threw")
           }
         }
 

--- a/apps/signal/src/gateway.ts
+++ b/apps/signal/src/gateway.ts
@@ -288,6 +288,20 @@ export function initGateway(options: GatewayOptions): void {
         const userStatus = status as UserStatus
         await presence.updateStatus(state.userId, userStatus)
 
+        // Persist status change to DB so Supabase Realtime presence
+        // and subsequent page loads reflect the correct status (#presence-fix)
+        if (supabase) {
+          try {
+            const now = new Date().toISOString()
+            await supabase
+              .from("users")
+              .update({ status: userStatus, last_heartbeat_at: now, updated_at: now })
+              .eq("id", state.userId)
+          } catch (err) {
+            log.error({ err, userId: state.userId }, "gateway:presence DB status update failed")
+          }
+        }
+
         // Broadcast to all servers the user belongs to.
         // Uses socket.to() which is cluster-aware via the Redis adapter,
         // ensuring recipients on other replicas also receive the update.
@@ -424,6 +438,20 @@ export function initGateway(options: GatewayOptions): void {
         // Set presence
         await presence.setOnline(userId, socket.id, status, serverIds)
 
+        // Persist status to DB so Supabase Realtime presence and page
+        // loads reflect the correct status (#presence-fix)
+        if (supabase) {
+          try {
+            const now = new Date().toISOString()
+            await supabase
+              .from("users")
+              .update({ status, last_heartbeat_at: now, updated_at: now })
+              .eq("id", userId)
+          } catch (err) {
+            log.error({ err, userId }, "gateway:init DB status update failed")
+          }
+        }
+
         // Join presence rooms
         for (const serverId of serverIds) {
           socket.join(`presence:${serverId}`)
@@ -470,6 +498,20 @@ export function initGateway(options: GatewayOptions): void {
 
         // Set offline and broadcast
         const serverIds = await presence.setOffline(state.userId)
+
+        // Persist offline status to DB (#presence-fix)
+        if (supabase) {
+          try {
+            const now = new Date().toISOString()
+            await supabase
+              .from("users")
+              .update({ status: "offline", last_online_at: now, updated_at: now })
+              .eq("id", state.userId)
+          } catch (err) {
+            log.error({ err, userId: state.userId }, "disconnect DB status update failed")
+          }
+        }
+
         for (const serverId of serverIds) {
           io.to(`presence:${serverId}`).emit("gateway:presence", {
             userId: state.userId,

--- a/apps/web/components/layout/member-list.tsx
+++ b/apps/web/components/layout/member-list.tsx
@@ -18,6 +18,7 @@ import { useToast } from "@/components/ui/use-toast"
 import type { RoleRow } from "@/types/database"
 import { PERMISSIONS } from "@vortex/shared"
 import type { RealtimeChannel } from "@supabase/supabase-js"
+import { useGatewayContext } from "@/hooks/use-gateway-context"
 import { Skeleton } from "@/components/ui/skeleton"
 import { openDmChannel, sendFriendRequest } from "@/lib/social-actions"
 const ReportModal = lazy(() => import("@/components/modals/report-modal").then((m) => ({ default: m.ReportModal })))
@@ -87,6 +88,7 @@ export function MemberList({ serverId, initialMembers }: Props) {
   const channelRef = useRef<RealtimeChannel | null>(null)
   const memberFetchControllerRef = useRef<AbortController | null>(null)
   const supabase = useMemo(() => createClientSupabaseClient(), [])
+  const gateway = useGatewayContext()
 
   // Perf: log mount time relative to navigation start
   useEffect(() => {
@@ -256,15 +258,16 @@ export function MemberList({ serverId, initialMembers }: Props) {
           try {
             const { data: { user } } = await supabase.auth.getUser()
             if (user) {
-              // Read user's actual status from the database
-              const { data: profile } = await supabase
-                .from("users")
-                .select("status")
-                .eq("id", user.id)
-                .single()
+              // Use the current user status from the app store (kept in sync
+              // by useGatewayPresence) rather than reading from the DB, which
+              // may be stale if the gateway:init DB write hasn't landed yet.
+              const storeStatus = useAppStore.getState().currentUser?.status
+              const trackStatus = storeStatus && storeStatus !== "offline"
+                ? storeStatus
+                : "online"
               await channel.track({
                 user_id: user.id,
-                status: profile?.status ?? "online",
+                status: trackStatus,
               })
             }
           } catch (err) {
@@ -294,6 +297,27 @@ export function MemberList({ serverId, initialMembers }: Props) {
       })
     }
   }, [currentUser?.status, currentUser?.id])
+
+  // Listen for gateway:presence Socket.IO events for real-time presence updates
+  // from other users. This is the primary presence path now that usePresenceSync
+  // has been replaced by useGatewayPresence (#presence-fix).
+  useEffect(() => {
+    const unsubscribe = gateway.addPresenceListener((data) => {
+      setPresence((prev) => {
+        const current = prev[data.userId]
+        // Skip update if status hasn't changed
+        if (current?.status === data.status) return prev
+        return {
+          ...prev,
+          [data.userId]: {
+            ...current,
+            status: data.status,
+          },
+        }
+      })
+    })
+    return unsubscribe
+  }, [gateway])
 
   const onlineMembers = useMemo(
     () => members.filter((m) => {


### PR DESCRIPTION
When usePresenceSync was replaced by useGatewayPresence, the DB users.status column stopped being updated and member-list never received Socket.IO presence events from other users, causing everyone to appear offline.

- Signal server now syncs status to DB on gateway:init, presence change, and disconnect so the DB stays consistent for page loads and cron
- Member list subscribes to gateway:presence events via addPresenceListener for real-time status updates from other users
- Initial presence tracking reads from app store (live) instead of DB (stale) to avoid race with gateway:init write

https://claude.ai/code/session_01SELhB6iPbSAfSV9VtSWjHz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced user presence tracking with persistent status storage at key lifecycle events for improved reliability.
  * Implemented real-time presence synchronization via gateway listener, ensuring member lists display accurate user availability.

* **Improvements**
  * Optimized member list refresh efficiency by leveraging real-time presence updates instead of repeated database queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->