### PR TITLE
Add AI persona mentions and improve AI feature access control

### DIFF
--- a/apps/web/app/api/servers/[serverId]/ai-personas/route.ts
+++ b/apps/web/app/api/servers/[serverId]/ai-personas/route.ts
@@ -21,7 +21,7 @@ export async function GET(_req: NextRequest, { params }: Params): Promise<NextRe
 
     const { data: personas, error: queryError } = await supabase
       .from("ai_personas")
-      .select("id, name, avatar_url, description, is_active, allowed_channel_ids, created_at")
+      .select("id, name, avatar_url, description, system_prompt, is_active, allowed_channel_ids, created_at")
       .eq("server_id", serverId)
       .eq("is_active", true)
       .order("name", { ascending: true })

--- a/apps/web/app/api/servers/[serverId]/channels/[channelId]/summarize/route.ts
+++ b/apps/web/app/api/servers/[serverId]/channels/[channelId]/summarize/route.ts
@@ -105,11 +105,13 @@ export async function POST(req: NextRequest, { params }: Params) {
       )
     }
 
-    const result = await adapter.complete(
-      [
-        {
-          role: "system",
-          content: `You are a helpful assistant that summarizes chat channel conversations.
+    let result
+    try {
+      result = await adapter.complete(
+        [
+          {
+            role: "system",
+            content: `You are a helpful assistant that summarizes chat channel conversations.
 Return your response as JSON with this exact shape:
 {
   "summary": "2-4 sentence overview of what was discussed",
@@ -117,14 +119,22 @@ Return your response as JSON with this exact shape:
   "topics": ["topic1", "topic2"]
 }
 Be concise and factual. Only include information from the conversation.`,
-        },
-        {
-          role: "user",
-          content: `Summarize this conversation from the #${channel.name} channel (${chronological.length} messages):\n\n${transcript}`,
-        },
-      ],
-      { maxTokens: 512, jsonMode: true }
-    )
+          },
+          {
+            role: "user",
+            content: `Summarize this conversation from the #${channel.name} channel (${chronological.length} messages):\n\n${transcript}`,
+          },
+        ],
+        { maxTokens: 512, jsonMode: true }
+      )
+    } catch (aiErr: unknown) {
+      console.error("[summarize] AI provider error", {
+        serverId,
+        channelId,
+        error: aiErr instanceof Error ? aiErr.message : "Unknown AI error",
+      })
+      return NextResponse.json({ error: "AI summarization failed. Please try again later." }, { status: 502 })
+    }
 
     let parsed: { summary: string; highlights: string[]; topics: string[] }
     try {

--- a/apps/web/components/chat/chat-area.tsx
+++ b/apps/web/components/chat/chat-area.tsx
@@ -1390,6 +1390,21 @@ export function ChatArea({ channel, initialMessages, currentUserId, serverId, in
     setAndPersistOutbox((current) => removeOutboxEntry(current, messageId))
     upsertMessage(message)
 
+    // Fire-and-forget: trigger AI persona replies for any @bot mentions
+    const personaMentions = (content.match(/<@bot:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})>/gi) ?? [])
+      .map((m) => m.slice(6, -1))
+    if (personaMentions.length > 0) {
+      for (const personaId of personaMentions) {
+        fetch(`/api/servers/${serverId}/channels/${channel.id}/messages/${message.id}/persona-reply`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ personaId }),
+        }).catch((err) => {
+          console.error("[persona-reply] failed to trigger persona reply", { personaId, error: err })
+        })
+      }
+    }
+
     resetComposerState()
     onSent()
   }

--- a/apps/web/components/chat/markdown-renderer.tsx
+++ b/apps/web/components/chat/markdown-renderer.tsx
@@ -110,6 +110,12 @@ const remarkRoleMentions = splitTextByPattern(
   (m) => `<vortex-role-mention data-rid="${m[1]}"></vortex-role-mention>`,
 )
 
+/** Remark plugin: <@bot:personaId> → <vortex-persona-mention> elements. */
+const remarkPersonaMentions = splitTextByPattern(
+  /<@bot:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})>/gi,
+  (m) => `<vortex-persona-mention data-pid="${m[1]}"></vortex-persona-mention>`,
+)
+
 /** Remark plugin: ||spoiler|| → <vortex-spoiler> elements. */
 const remarkSpoiler = splitTextByPattern(
   /\|\|([\s\S]*?)\|\|/g,
@@ -486,6 +492,25 @@ function buildComponents(currentUserId: string, serverId: string | null, bigEmoj
       )
     },
 
+    "vortex-persona-mention": ({ node, ...props }: { node?: { properties?: Record<string, string> }; [key: string]: unknown }) => {
+      const pid = (props.dataPid ?? props["data-pid"] ?? node?.properties?.dataPid ?? "") as string
+      const personas = serverId ? useAppStore.getState().personas[serverId] ?? [] : []
+      const persona = personas.find((p) => p.id === pid)
+      return (
+        <span
+          className="inline-flex items-center gap-0.5 px-1 rounded cursor-pointer font-medium"
+          style={{
+            color: "var(--theme-ai-badge-text, #5865f2)",
+            background: "var(--theme-ai-badge-bg, rgba(88,101,242,0.15))",
+          }}
+          title={persona ? `AI Persona: ${persona.name}` : pid}
+        >
+          @{persona?.name ?? pid}
+          <span className="text-[9px] font-bold uppercase ml-0.5 opacity-70">BOT</span>
+        </span>
+      )
+    },
+
     "vortex-timestamp": ({ node, ...props }: { node?: { properties?: Record<string, string> }; [key: string]: unknown }) => {
       const epoch = parseInt((props.dataEpoch ?? props["data-epoch"] ?? node?.properties?.dataEpoch ?? "0") as string, 10)
       const format = (props.dataFormat ?? props["data-format"] ?? node?.properties?.dataFormat ?? "f") as string
@@ -524,6 +549,10 @@ function preProcessContent(content: string): string {
     tokens.push(match)
     return `__TOKEN_${tokens.length - 1}__`
   })
+  processed = processed.replace(/<@bot:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})>/gi, (match) => {
+    tokens.push(match)
+    return `__TOKEN_${tokens.length - 1}__`
+  })
   processed = processed.replace(/<t:(\d+)(?::([tTdDfFR]))?>/g, (match) => {
     tokens.push(match)
     return `__TOKEN_${tokens.length - 1}__`
@@ -540,7 +569,7 @@ function preProcessContent(content: string): string {
 
 // ─── Stable plugin arrays ───────────────────────────────────────────────────
 
-const remarkPlugins = [remarkGfm, remarkBreaks, remarkCustomEmoji, remarkMentions, remarkRoleMentions, remarkSpoiler, remarkTimestamps, remarkUnicodeEmoji]
+const remarkPlugins = [remarkGfm, remarkBreaks, remarkCustomEmoji, remarkMentions, remarkRoleMentions, remarkPersonaMentions, remarkSpoiler, remarkTimestamps, remarkUnicodeEmoji]
 const sanitizeSchema = {
   ...defaultSchema,
   tagNames: [
@@ -549,6 +578,7 @@ const sanitizeSchema = {
     "vortex-emoji",
     "vortex-mention",
     "vortex-role-mention",
+    "vortex-persona-mention",
     "vortex-spoiler",
     "vortex-timestamp",
   ],
@@ -557,6 +587,7 @@ const sanitizeSchema = {
     "vortex-emoji": ["dataName"],
     "vortex-mention": ["dataUid"],
     "vortex-role-mention": ["dataRid"],
+    "vortex-persona-mention": ["dataPid"],
     "vortex-timestamp": ["dataEpoch", "dataFormat"],
     // Allow only src and alt on img — className/draggable/loading are hardcoded
     // in the component handler, not parsed from HTML attributes

--- a/apps/web/components/chat/mention-suggestions.tsx
+++ b/apps/web/components/chat/mention-suggestions.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import { useRef, useEffect } from "react"
+import { Bot } from "lucide-react"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
-import type { MemberForMention } from "@/lib/stores/app-store"
+import type { MemberForMention, PersonaForMention } from "@/lib/stores/app-store"
 import type { MentionSuggestion } from "@/hooks/use-mention-autocomplete"
 
 interface Props {
@@ -31,6 +32,15 @@ function getMemberMatchConfidence(member: MemberForMention, query: string): "Exa
 
   if (options.some((value) => value === normalized)) return "Exact"
   if (options.some((value) => value.startsWith(normalized))) return "Strong"
+  return "Weak"
+}
+
+function getPersonaMatchConfidence(persona: PersonaForMention, query: string): "Exact" | "Strong" | "Weak" {
+  const normalized = query.trim().toLowerCase()
+  if (!normalized) return "Strong"
+  const lower = persona.name.toLowerCase()
+  if (lower === normalized) return "Exact"
+  if (lower.startsWith(normalized)) return "Strong"
   return "Weak"
 }
 
@@ -97,6 +107,58 @@ export function MentionSuggestions({ suggestions, selectedIndex, query, onSelect
               <span
                 className="ml-auto text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded"
                 style={{ color: confidenceColor, background: `${confidenceColor}26` }}
+              >
+                {confidence}
+              </span>
+            </button>
+          )
+        }
+
+        if (suggestion.type === "persona") {
+          const persona = suggestion.data
+          const confidence = getPersonaMatchConfidence(persona, query)
+          const confidenceTone =
+            confidence === "Exact" ? "#3ba55d" : confidence === "Strong" ? "#5865f2" : "#faa81a"
+          const initials = persona.name.slice(0, 2).toUpperCase()
+
+          return (
+            <button
+              key={`persona-${persona.id}`}
+              role="option"
+              aria-selected={isSelected}
+              className="flex items-center gap-2 w-full px-3 py-1.5 text-left transition-colors"
+              style={{
+                background: isSelected ? "rgba(88,101,242,0.2)" : "transparent",
+                color: "var(--theme-text-normal)",
+              }}
+              onMouseDown={(e) => {
+                e.preventDefault()
+                onSelect(suggestion)
+              }}
+            >
+              <Avatar className="w-6 h-6">
+                {persona.avatar_url && <AvatarImage src={persona.avatar_url} />}
+                <AvatarFallback
+                  style={{ background: "var(--theme-ai-badge-bg, #5865f2)", color: "var(--theme-ai-badge-text, white)", fontSize: "10px" }}
+                >
+                  {initials}
+                </AvatarFallback>
+              </Avatar>
+              <span className="text-sm font-medium truncate">{persona.name}</span>
+              <span
+                className="inline-flex items-center gap-0.5 px-1 py-px rounded text-[9px] font-bold uppercase"
+                style={{ background: "var(--theme-ai-badge-bg, rgba(88,101,242,0.3))", color: "var(--theme-ai-badge-text, #5865f2)" }}
+              >
+                <Bot className="w-2.5 h-2.5" /> BOT
+              </span>
+              {persona.description && (
+                <span className="text-[10px] truncate max-w-[120px]" style={{ color: "var(--theme-text-muted)" }}>
+                  {persona.description}
+                </span>
+              )}
+              <span
+                className="ml-auto text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded"
+                style={{ color: confidenceTone, background: `${confidenceTone}26` }}
               >
                 {confidence}
               </span>

--- a/apps/web/components/chat/message-input.tsx
+++ b/apps/web/components/chat/message-input.tsx
@@ -144,12 +144,13 @@ export function MessageInput({ variant = "channel", channelName, draft, replyTo,
   }, [])
 
   // Mention autocomplete
-  const { activeServerId, activeChannelId, members: membersByServer, serverRoles: rolesByServer } = useAppStore(
-    useShallow((s) => ({ activeServerId: s.activeServerId, activeChannelId: s.activeChannelId, members: s.members, serverRoles: s.serverRoles }))
+  const { activeServerId, activeChannelId, members: membersByServer, serverRoles: rolesByServer, personas: personasByServer } = useAppStore(
+    useShallow((s) => ({ activeServerId: s.activeServerId, activeChannelId: s.activeChannelId, members: s.members, serverRoles: s.serverRoles, personas: s.personas }))
   )
   const members = activeServerId ? membersByServer[activeServerId] ?? [] : []
   const roles = serverId ? rolesByServer[serverId] ?? [] : []
-  const mention = useMentionAutocomplete({ content, cursorPosition, members, roles })
+  const personas = serverId ? personasByServer[serverId] ?? [] : []
+  const mention = useMentionAutocomplete({ content, cursorPosition, members, roles, personas })
 
   // Slash command state (needed by moderation hook below)
   const [appCommands, setAppCommands] = useState<SlashCommand[]>([])

--- a/apps/web/components/chat/smart-reply-tray.tsx
+++ b/apps/web/components/chat/smart-reply-tray.tsx
@@ -25,14 +25,12 @@ export function SmartReplyTray({ serverId, channelId, isTyping, hasContent, onSe
   const [loading, setLoading] = useState(false)
   const [dismissed, setDismissed] = useState(false)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const lastFetchRef = useRef<string>("")
+  const fetchCountRef = useRef(0)
 
   const fetchSuggestions = useCallback(async () => {
     if (!serverId || !channelId) return
-    const key = `${serverId}-${channelId}`
-    if (key === lastFetchRef.current) return // Don't re-fetch for same context
-    lastFetchRef.current = key
     setLoading(true)
+    fetchCountRef.current += 1
     try {
       const res = await fetch(`/api/servers/${serverId}/channels/${channelId}/smart-replies`, {
         method: "POST",
@@ -40,8 +38,11 @@ export function SmartReplyTray({ serverId, channelId, isTyping, hasContent, onSe
       })
       if (!res.ok) { setSuggestions([]); return }
       const data = await res.json()
-      setSuggestions(data.suggestions ?? [])
-      setDismissed(false)
+      const newSuggestions = data.suggestions ?? []
+      if (newSuggestions.length > 0) {
+        setSuggestions(newSuggestions)
+        setDismissed(false)
+      }
     } catch {
       setSuggestions([])
     } finally {
@@ -49,9 +50,11 @@ export function SmartReplyTray({ serverId, channelId, isTyping, hasContent, onSe
     }
   }, [serverId, channelId])
 
-  // Debounced fetch: trigger after 2s of idle
+  // Debounced fetch: trigger after 2s of idle (not typing, no content)
   useEffect(() => {
     if (isTyping || hasContent || !serverId || !channelId) return
+    // Only auto-fetch once per channel visit to avoid spamming
+    if (fetchCountRef.current > 0) return
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(fetchSuggestions, 2000)
     return () => { if (debounceRef.current) clearTimeout(debounceRef.current) }
@@ -61,10 +64,10 @@ export function SmartReplyTray({ serverId, channelId, isTyping, hasContent, onSe
   useEffect(() => {
     setSuggestions([])
     setDismissed(false)
-    lastFetchRef.current = ""
+    fetchCountRef.current = 0
   }, [channelId])
 
-  // Hide when typing
+  // Hide when typing or has content
   if (isTyping || hasContent || dismissed || suggestions.length === 0) {
     if (loading && !isTyping && !hasContent && !dismissed) {
       return (

--- a/apps/web/components/layout/member-list.tsx
+++ b/apps/web/components/layout/member-list.tsx
@@ -122,6 +122,16 @@ export function MemberList({ serverId, initialMembers }: Props) {
       .catch((err) => { console.error("Failed to fetch roles for server", { serverId, error: err }) })
   }, [serverId])
 
+  // Fetch AI personas for @persona mention autocomplete
+  useEffect(() => {
+    fetch(`/api/servers/${encodeURIComponent(serverId)}/ai-personas`, { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : { personas: [] }))
+      .then((data: { personas: Array<{ id: string; name: string; avatar_url: string | null; description: string | null }> }) => {
+        useAppStore.getState().setPersonas(serverId, data.personas ?? [])
+      })
+      .catch((err) => { console.error("Failed to fetch AI personas for server", { serverId, error: err }) })
+  }, [serverId])
+
   useEffect(() => {
     setSelectedMemberId(null)
   }, [serverId])

--- a/apps/web/components/settings/ai-personas-section.tsx
+++ b/apps/web/components/settings/ai-personas-section.tsx
@@ -8,6 +8,7 @@ interface Persona {
   name: string
   avatar_url: string | null
   description: string | null
+  system_prompt: string | null
   is_active: boolean
   allowed_channel_ids: string[]
   created_at: string
@@ -268,6 +269,11 @@ export function AiPersonasSection({ serverId }: AiPersonasSectionProps) {
                     {p.description && (
                       <div className="text-xs" style={{ color: "var(--theme-text-muted)" }}>{p.description}</div>
                     )}
+                    {p.system_prompt && !isEditing && (
+                      <div className="text-[11px] mt-1 line-clamp-2 italic" style={{ color: "var(--theme-text-muted)", opacity: 0.7 }}>
+                        {p.system_prompt}
+                      </div>
+                    )}
                   </div>
                 </div>
                 <div className="flex items-center gap-1">
@@ -277,7 +283,7 @@ export function AiPersonasSection({ serverId }: AiPersonasSectionProps) {
                         setEditingId(p.id)
                         setEditName(p.name)
                         setEditDescription(p.description ?? "")
-                        setEditPrompt("")
+                        setEditPrompt(p.system_prompt ?? "")
                       }
                     }}
                     className="p-1.5 rounded transition-colors hover:bg-white/5"
@@ -325,12 +331,15 @@ export function AiPersonasSection({ serverId }: AiPersonasSectionProps) {
                     <textarea
                       value={editPrompt}
                       onChange={(e) => setEditPrompt(e.target.value)}
-                      placeholder="Enter new system prompt to replace current..."
-                      rows={3}
+                      placeholder="Define the persona's personality and knowledge..."
+                      rows={4}
                       maxLength={4000}
                       className="w-full rounded-md border py-1.5 px-2 text-xs text-white placeholder:text-gray-500 resize-none"
                       style={{ background: "var(--theme-bg-secondary)", borderColor: "var(--theme-border)" }}
                     />
+                    <div className="text-right text-[10px]" style={{ color: "var(--theme-text-muted)" }}>
+                      {editPrompt.length}/4000
+                    </div>
                   </div>
                   <div className="flex justify-end gap-2">
                     <button

--- a/apps/web/hooks/use-mention-autocomplete.ts
+++ b/apps/web/hooks/use-mention-autocomplete.ts
@@ -1,16 +1,18 @@
 import { useCallback } from "react"
-import type { MemberForMention, RoleForMention } from "@/lib/stores/app-store"
+import type { MemberForMention, RoleForMention, PersonaForMention } from "@/lib/stores/app-store"
 import { useAutocomplete } from "./use-autocomplete"
 
 export type MentionSuggestion =
   | { type: "member"; data: MemberForMention }
   | { type: "role"; data: RoleForMention }
+  | { type: "persona"; data: PersonaForMention }
 
 interface Options {
   content: string
   cursorPosition: number
   members: MemberForMention[]
   roles?: RoleForMention[]
+  personas?: PersonaForMention[]
 }
 
 interface Result {
@@ -43,7 +45,7 @@ function findMentionQuery(text: string, cursor: number): string | null {
   return null
 }
 
-export function useMentionAutocomplete({ content, cursorPosition, members, roles = [] }: Options): Result {
+export function useMentionAutocomplete({ content, cursorPosition, members, roles = [], personas = [] }: Options): Result {
   const filter = useCallback(
     (query: string): MentionSuggestion[] => {
       const lower = query.toLowerCase()
@@ -63,9 +65,14 @@ export function useMentionAutocomplete({ content, cursorPosition, members, roles
         .slice(0, 4)
         .map((r) => ({ type: "role", data: r }))
 
-      return [...roleResults, ...memberResults].slice(0, 10)
+      const personaResults: MentionSuggestion[] = personas
+        .filter((p) => p.name.toLowerCase().includes(lower))
+        .slice(0, 4)
+        .map((p) => ({ type: "persona", data: p }))
+
+      return [...personaResults, ...roleResults, ...memberResults].slice(0, 10)
     },
-    [members, roles]
+    [members, roles, personas]
   )
 
   const { isOpen, query, matches, selectedIndex, handleKeyDown, close } = useAutocomplete({
@@ -83,6 +90,8 @@ export function useMentionAutocomplete({ content, cursorPosition, members, roles
     let mention: string
     if (suggestion.type === "role") {
       mention = `<@&${suggestion.data.id}> `
+    } else if (suggestion.type === "persona") {
+      mention = `<@bot:${suggestion.data.id}> `
     } else {
       mention = `<@${suggestion.data.username}> `
     }

--- a/apps/web/lib/ai/ai-router.ts
+++ b/apps/web/lib/ai/ai-router.ts
@@ -14,6 +14,7 @@ import type { SupabaseClient } from "@supabase/supabase-js"
 import type { AiFunction, AiProvider, ResolvedAiProvider } from "@vortex/shared"
 import { AI_PROVIDER_META } from "@vortex/shared"
 import { createAdapter, type AiProviderAdapter } from "./providers"
+import { createServiceRoleClient } from "@/lib/supabase/server"
 
 interface ProviderConfigRow {
   id: string
@@ -31,15 +32,22 @@ interface FunctionRoutingRow {
 /**
  * Resolve which AI provider to use for a given server + function.
  * Returns null when no provider is configured.
+ *
+ * Uses service-role client to bypass RLS on ai_provider_configs,
+ * ai_function_routing, and server_secrets tables, which are owner-only.
+ * This allows any server member to use AI features configured by the owner.
  */
 export async function resolveProviderConfig(
-  supabase: SupabaseClient,
+  _supabase: SupabaseClient,
   serverId: string,
   aiFunction: AiFunction
 ): Promise<ResolvedAiProvider | null> {
   try {
+    // Use service-role client to bypass owner-only RLS on AI config tables
+    const serviceClient = await createServiceRoleClient()
+
     // 1. Check per-function routing
-    const { data: routing } = await supabase
+    const { data: routing } = await serviceClient
       .from("ai_function_routing")
       .select("provider_config_id")
       .eq("server_id", serverId)
@@ -47,12 +55,12 @@ export async function resolveProviderConfig(
       .maybeSingle<FunctionRoutingRow>()
 
     if (routing?.provider_config_id) {
-      const config = await fetchProviderConfig(supabase, routing.provider_config_id)
+      const config = await fetchProviderConfig(serviceClient, routing.provider_config_id)
       if (config) return config
     }
 
     // 2. Check server default provider
-    const { data: defaultConfig } = await supabase
+    const { data: defaultConfig } = await serviceClient
       .from("ai_provider_configs")
       .select("id, provider, api_key, base_url, model, is_default")
       .eq("server_id", serverId)
@@ -64,7 +72,7 @@ export async function resolveProviderConfig(
     }
 
     // 3. Legacy fallback: server_secrets.gemini_api_key
-    const { data: secrets } = await supabase
+    const { data: secrets } = await serviceClient
       .from("server_secrets")
       .select("gemini_api_key")
       .eq("server_id", serverId)
@@ -109,10 +117,10 @@ export async function resolveAdapter(
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
 async function fetchProviderConfig(
-  supabase: SupabaseClient,
+  serviceClient: SupabaseClient,
   configId: string
 ): Promise<ResolvedAiProvider | null> {
-  const { data } = await supabase
+  const { data } = await serviceClient
     .from("ai_provider_configs")
     .select("id, provider, api_key, base_url, model, is_default")
     .eq("id", configId)

--- a/apps/web/lib/stores/app-store.ts
+++ b/apps/web/lib/stores/app-store.ts
@@ -24,6 +24,13 @@ export interface RoleForMention {
   mentionable: boolean
 }
 
+export interface PersonaForMention {
+  id: string
+  name: string
+  avatar_url: string | null
+  description: string | null
+}
+
 interface AppState {
   // Current user
   currentUser: UserRow | null
@@ -52,6 +59,10 @@ interface AppState {
   // Roles (for @role mention autocomplete + rendering)
   serverRoles: Record<string, RoleForMention[]> // serverId -> roles
   setServerRoles: (serverId: string, roles: RoleForMention[]) => void
+
+  // AI Personas (for @persona mention autocomplete)
+  personas: Record<string, PersonaForMention[]> // serverId -> personas
+  setPersonas: (serverId: string, personas: PersonaForMention[]) => void
 
   // Active state
   activeServerId: string | null
@@ -195,6 +206,10 @@ export const useAppStore = create<AppState>((set) => ({
   serverRoles: {},
   setServerRoles: (serverId, roles) =>
     set((state) => ({ serverRoles: { ...state.serverRoles, [serverId]: roles } })),
+
+  personas: {},
+  setPersonas: (serverId, personas) =>
+    set((state) => ({ personas: { ...state.personas, [serverId]: personas } })),
 
   activeServerId: null,
   activeChannelId: null,


### PR DESCRIPTION
## Summary
This PR adds support for mentioning AI personas in chat messages (via `<@bot:personaId>` syntax) and improves access control for AI features by using service-role clients to bypass RLS restrictions on AI configuration tables.

## Key Changes

- **AI Persona Mentions**: Added full support for mentioning AI personas in messages
  - New `PersonaForMention` type in app store for persona data
  - Persona mention autocomplete in message input with confidence scoring
  - Markdown renderer support for `<@bot:personaId>` syntax with styled persona badges
  - Fire-and-forget persona reply triggering when personas are mentioned in messages
  - Persona list fetching in member list component

- **Improved AI Access Control**: 
  - Modified `resolveProviderConfig()` to use service-role Supabase client instead of user client
  - Allows any server member to access AI features configured by the server owner
  - Bypasses RLS on `ai_provider_configs`, `ai_function_routing`, and `server_secrets` tables

- **Enhanced Error Handling**:
  - Added try-catch around AI summarization requests with proper error logging
  - Returns 502 status with user-friendly message on AI provider failures

- **Smart Reply Improvements**:
  - Changed from context-based deduplication to fetch-count tracking
  - Only auto-fetches suggestions once per channel visit to reduce API spam
  - Better handling of empty suggestion responses

- **AI Personas Settings**:
  - Display system prompt preview in persona list (when not editing)
  - Pre-populate system prompt field when editing existing personas
  - Added character counter for system prompt field (max 4000 chars)
  - Improved placeholder text for better UX

## Implementation Details

- Persona mentions use UUID format: `<@bot:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx>`
- Persona suggestions appear first in mention autocomplete, followed by roles, then members
- Persona badges styled with AI-specific colors (configurable via CSS variables)
- Service-role client creation is async and cached for performance

https://claude.ai/code/session_01K5zYCj7j2QmYe4AAQ1Rs5a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now mention AI personas in chat with autocomplete suggestions
  * Added system prompt configuration for AI personas in settings
  * Automatic persona replies trigger when personas are mentioned in messages

* **Bug Fixes**
  * Improved error handling for AI chat summarization with user-friendly error responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->